### PR TITLE
Add optional preserveFontStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ const shiki = require('shiki')
 
 shiki
   .getHighlighter({
-    theme: 'nord'
+    theme: 'nord',
+    preserveFontStyle: false //Optional. Defaults to true
   })
   .then(highlighter => {
     console.log(highlighter.codeToHtml(`console.log('shiki');`, 'js'))

--- a/packages/shiki/src/highlighter.ts
+++ b/packages/shiki/src/highlighter.ts
@@ -8,11 +8,11 @@ import { tokenizeWithTheme, IThemedToken } from './themedTokenizer'
 import { renderToHtml } from './renderer'
 
 import { getTheme, TTheme, IShikiTheme } from 'shiki-themes'
+import { FontStyle } from './stackElementMetadata'
 
 export interface HighlighterOptions {
   theme: TTheme | IShikiTheme
   langs?: ILanguageRegistration[]
-  preserveFontStyle?: boolean
 }
 
 export async function getHighlighter(options: HighlighterOptions) {
@@ -31,14 +31,7 @@ export async function getHighlighter(options: HighlighterOptions) {
     languages = [...bundledLanguages, ...options.langs]
   }
 
-  let preserveFontStyle: boolean
-  if (typeof options.preserveFontStyle  === 'boolean') {
-    preserveFontStyle = options.preserveFontStyle  ? true : false
-  } else {
-    preserveFontStyle = true
-  }
-
-  const s = new Shiki(t, languages, preserveFontStyle)
+  const s = new Shiki(t, languages)
   return await s.getHighlighter()
 }
 
@@ -53,21 +46,20 @@ interface ThemedTokenizerOptions {
 class Shiki {
   private _resolver: Resolver
   private _registry: Registry
-  private _preserveFontStyle: boolean
+
   private _theme: IShikiTheme
   private _colorMap: string[]
-  private _styleMap: object
   private _langs: ILanguageRegistration[]
 
-  constructor(theme: IShikiTheme, langs: ILanguageRegistration[], preserveFontStyle: boolean) {
+  constructor(theme: IShikiTheme, langs: ILanguageRegistration[]) {
     this._resolver = new Resolver(langs, getOnigasm(), 'onigasm')
     this._registry = new Registry(this._resolver)
-    this._preserveFontStyle = preserveFontStyle
+
     this._registry.setTheme(theme)
 
     this._theme = theme
     this._colorMap = this._registry.getColorMap()
-    this._styleMap = {1: `font-style: italic;`, 2: `font-weight: bold`, 4: `text-decoration: underline`}
+
     this._langs = langs
   }
 
@@ -94,11 +86,11 @@ class Shiki {
         if (!ltog[lang]) {
           throw Error(`No language registration for ${lang}`)
         }
-        return tokenizeWithTheme(this._theme, this._preserveFontStyle, this._colorMap, this._styleMap, code, ltog[lang], options)
+        return tokenizeWithTheme(this._theme, this._colorMap, code, ltog[lang], options)
       },
       codeToHtml: (code, lang) => {
         if (isPlaintext(lang)) {
-          return renderToHtml([[{ content: code }]], {
+          return renderToHtml([[{ content: code, fontStyle: FontStyle.None }]], {
             fg: this._theme.fg,
             bg: this._theme.bg
           })
@@ -106,12 +98,12 @@ class Shiki {
         if (!ltog[lang]) {
           throw Error(`No language registration for ${lang}`)
         }
-        const tokens = tokenizeWithTheme(this._theme, this._preserveFontStyle, this._colorMap, this._styleMap, code, ltog[lang], {
+        const tokens = tokenizeWithTheme(this._theme, this._colorMap, code, ltog[lang], {
           includeExplanation: false
         })
-
         return renderToHtml(tokens, {
-          bg: this._theme.bg
+          bg: this._theme.bg,
+          preserveFontStyle: false
         })
       }
     }

--- a/packages/shiki/src/renderer.ts
+++ b/packages/shiki/src/renderer.ts
@@ -1,13 +1,25 @@
 import { IThemedToken } from './themedTokenizer'
+import { FontStyle } from './stackElementMetadata'
 
 export interface HtmlRendererOptions {
   langId?: string
   fg?: string
   bg?: string
+  /**
+   * Whether to show italics/bold/underline
+   */
+  preserveFontStyle?: boolean
+}
+
+const FONT_STYLE_TO_CSS = {
+  [FontStyle.Italic]: 'font-style: italic',
+  [FontStyle.Bold]: 'font-weight: bold',
+  [FontStyle.Underline]: 'text-decoration: underline'
 }
 
 export function renderToHtml(lines: IThemedToken[][], options: HtmlRendererOptions = {}) {
   const bg = options.bg || '#fff'
+  const preserveFontStyle = !!options.preserveFontStyle
 
   let html = ''
 
@@ -22,11 +34,11 @@ export function renderToHtml(lines: IThemedToken[][], options: HtmlRendererOptio
       html += `\n`
     } else {
       l.forEach(token => {
-        const styleValue = token.preserveFontStyle
-          ? `color: ${token.color || options.fg}; ${token.fontStyle}`
-          : `color: ${token.color || options.fg}`
-
-        html += `<span style="${styleValue}">${escapeHtml(token.content)}</span>`
+        const cssDeclarations = [`color: ${token.color || options.fg}`]
+        if (preserveFontStyle && token.fontStyle > FontStyle.None) {
+          cssDeclarations.push(FONT_STYLE_TO_CSS[token.fontStyle])
+        }
+        html += `<span style="${cssDeclarations.join('; ')}">${escapeHtml(token.content)}</span>`
       })
       html += `\n`
     }

--- a/packages/shiki/src/renderer.ts
+++ b/packages/shiki/src/renderer.ts
@@ -22,9 +22,11 @@ export function renderToHtml(lines: IThemedToken[][], options: HtmlRendererOptio
       html += `\n`
     } else {
       l.forEach(token => {
-        html += `<span style="color: ${token.color || options.fg}">${escapeHtml(
-          token.content
-        )}</span>`
+        const styleValue = token.preserveFontStyle
+          ? `color: ${token.color || options.fg}; ${token.fontStyle}`
+          : `color: ${token.color || options.fg}`
+
+        html += `<span style="${styleValue}">${escapeHtml(token.content)}</span>`
       })
       html += `\n`
     }

--- a/packages/shiki/src/themedTokenizer.ts
+++ b/packages/shiki/src/themedTokenizer.ts
@@ -4,7 +4,7 @@
 'use strict'
 
 import { IGrammar, StackElement, IRawTheme, IRawThemeSetting } from 'vscode-textmate'
-import { StackElementMetadata } from './stackElementMetadata'
+import { StackElementMetadata, FontStyle } from './stackElementMetadata'
 
 export interface IThemedTokenScopeExplanation {
   scopeName: string
@@ -85,15 +85,15 @@ export interface IThemedToken {
    * - reason that token text is given a color (one matching scope matches a rule (scope -> color) in the theme)
    */
   explanation?: IThemedTokenExplanation[]
-
-  preserveFontStyle?: boolean
+  /**
+   * Font style of token. Can be None/Italic/Bold/Underline
+   */
+  fontStyle?: FontStyle
 }
 
 export function tokenizeWithTheme(
   theme: IRawTheme,
-  preserveFontStyle: boolean,
   colorMap: string[],
-  styleMap: object,
   fileContents: string,
   grammar: IGrammar,
   options: { includeExplanation?: boolean }
@@ -128,11 +128,7 @@ export function tokenizeWithTheme(
       let metadata = result.tokens[2 * j + 1]
       let foreground = StackElementMetadata.getForeground(metadata)
       let foregroundColor = colorMap[foreground]
-      let font = StackElementMetadata.getFontStyle(metadata);
-      let fontStyle = null;
-      if (preserveFontStyle) {
-        fontStyle = font > 0 ? styleMap[font.toString()] : null
-      } 
+      let fontStyle: FontStyle = StackElementMetadata.getFontStyle(metadata)
       let explanation: IThemedTokenExplanation[] = []
       if (options.includeExplanation) {
         let offset = 0
@@ -159,7 +155,6 @@ export function tokenizeWithTheme(
         explanation: explanation,
         fontStyle
       })
-
     }
     final.push(actual)
     actual = []

--- a/packages/shiki/src/themedTokenizer.ts
+++ b/packages/shiki/src/themedTokenizer.ts
@@ -85,11 +85,15 @@ export interface IThemedToken {
    * - reason that token text is given a color (one matching scope matches a rule (scope -> color) in the theme)
    */
   explanation?: IThemedTokenExplanation[]
+
+  preserveFontStyle?: boolean
 }
 
 export function tokenizeWithTheme(
   theme: IRawTheme,
+  preserveFontStyle: boolean,
   colorMap: string[],
+  styleMap: object,
   fileContents: string,
   grammar: IGrammar,
   options: { includeExplanation?: boolean }
@@ -124,7 +128,11 @@ export function tokenizeWithTheme(
       let metadata = result.tokens[2 * j + 1]
       let foreground = StackElementMetadata.getForeground(metadata)
       let foregroundColor = colorMap[foreground]
-
+      let font = StackElementMetadata.getFontStyle(metadata);
+      let fontStyle = null;
+      if (preserveFontStyle) {
+        fontStyle = font > 0 ? styleMap[font.toString()] : null
+      } 
       let explanation: IThemedTokenExplanation[] = []
       if (options.includeExplanation) {
         let offset = 0
@@ -148,8 +156,10 @@ export function tokenizeWithTheme(
       actual.push({
         content: line.substring(startIndex, nextStartIndex),
         color: foregroundColor,
-        explanation: explanation
+        explanation: explanation,
+        fontStyle
       })
+
     }
     final.push(actual)
     actual = []

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -40,7 +40,8 @@ const shiki  = require('shiki')
 const t = shiki.loadTheme('./my-theme.json')
 
 shiki.getHighlighter({
-  theme: t
+  theme: t,
+  preserveFontStyle: false //Optional. Defaults to true
 })
 ```
 


### PR DESCRIPTION
In response to this feature requesst: https://github.com/octref/shiki/issues/15
Optional preserveFontStyle passed as a prop in 

```(js)
shiki
  .getHighlighter({
     theme: 'nord',
     preserveFontStyle: false
   })
```
I found the style maps from vscode-textmate but I didn't see a mapping function like colorMap. 
```(js)
 this._styleMap = {
    1: `font-style: italic;`, 
    2: `font-weight: bold`,
    4: `text-decoration: underline`
}
```