### PR TITLE
perf: Avoid some unnecessary string copies

### DIFF
--- a/packages/shiki/src/themedTokenizer.ts
+++ b/packages/shiki/src/themedTokenizer.ts
@@ -52,8 +52,7 @@ export function tokenizeWithTheme(
     for (let j = 0; j < tokensLength; j++) {
       let startIndex = result.tokens[2 * j]
       let nextStartIndex = j + 1 < tokensLength ? result.tokens[2 * j + 2] : line.length
-      let tokenText = line.substring(startIndex, nextStartIndex)
-      if (tokenText === '') {
+      if (startIndex === nextStartIndex) {
         continue
       }
       let metadata = result.tokens[2 * j + 1]
@@ -61,15 +60,15 @@ export function tokenizeWithTheme(
       let foregroundColor = colorMap[foreground]
 
       let explanation: IThemedTokenExplanation[] = []
-      let tmpTokenText = tokenText
-      while (tmpTokenText.length > 0) {
+      let offset = 0
+      while (startIndex + offset < nextStartIndex) {
         let tokenWithScopes = tokensWithScopes[tokensWithScopesIndex]
 
         let tokenWithScopesText = line.substring(
           tokenWithScopes.startIndex,
           tokenWithScopes.endIndex
         )
-        tmpTokenText = tmpTokenText.substring(tokenWithScopesText.length)
+        offset += tokenWithScopesText.length
         explanation.push({
           content: tokenWithScopesText,
           scopes: explainThemeScopes(theme, tokenWithScopes.scopes)
@@ -78,7 +77,7 @@ export function tokenizeWithTheme(
         tokensWithScopesIndex++
       }
       actual.push({
-        content: tokenText,
+        content: line.substring(startIndex, nextStartIndex),
         color: foregroundColor,
         explanation: explanation
       })


### PR DESCRIPTION
TypeDoc@future is using Shiki now for highlighting, and while profiling I noticed that >50% of the runtime in a moderately sized project was spent highlighting code comments. ~60% of this time was spent in node internals, which I deduced was the `substring` calls here.

Unfortunately, due to the existing API contract requiring that the same string be included several times, it isn't possible to completely eliminate this overhead... but I was able to reduce the runtime by ~20% by making these changes. There is still lots of room for improvement. I think the runtime can be cut in half if less information is returned (I don't need all that this gives... maybe I should just be using vscode-textmate directly)