### PR TITLE
Adds a deploy  workflow

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy Daily Builds
+
+# For testing
+# on: push
+
+# For production
+on:
+  schedule:
+    - cron: '0 4 * * *'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: 'yarn install'
+      - run: 'yarn test'
+      - run: 'yarn build'
+
+      - uses: orta/monorepo-deploy-nightly@master
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This sets up GitHub to deploy packages when they change on a nightly basis. Sharing the infra with https://github.com/sveltejs/language-tools/ 

So for example, because I merged #51 today - then that package is the only one which would be deployed tomorrow morning

I don't have access to deploy the module, so I'm afraid adding the NPM access token in [the security section](https://github.com/shikijs/shiki/settings/secrets) - my recommendation is to make a shiki-only bot account to deploy so that your credentials don't go in there