### PR TITLE
Fix default color highlighting in VS Code Dark

### DIFF
--- a/packages/themes/data/dark-plus.json
+++ b/packages/themes/data/dark-plus.json
@@ -3,6 +3,12 @@
   "name": "dark-plus",
   "tokenColors": [
     {
+			"scope": "source",
+			"settings": {
+				"foreground": "#CCCCCC",
+			}
+		},
+    {
       "scope": [
         "meta.embedded",
         "source.groovy.embedded"


### PR DESCRIPTION
Hi @octref, thanks for this library, really cool!

It seems like the VS Code Dark default color highlighting is broken again, which was previously reported and fixed here:

Original Issue: https://github.com/shikijs/shiki/issues/45
Original PR: https://github.com/shikijs/shiki/pull/64

Potentially broken by something around: https://github.com/shikijs/shiki/commit/9fc790e7a0b72cac7bad454f84cb65546087afd2#diff-3934a4a9ee6eb5b09946d87cdb31e5f4

I guess there should be an automated way of adding this one back, to prevent future breakages.

See the problem in the example CodeSandbox here: https://codesandbox.io/s/kind-wildflower-mrx10?file=/pages/index.js

![Screen Shot 2020-08-26 at 12 08 44](https://user-images.githubusercontent.com/1935696/91291287-1e236180-e795-11ea-992b-b15f7afe7d0b.png)
