### PR TITLE
Add CodeSandbox interactive demo (with Next.js)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h2 align="center">Shiki</h2>
 </p>
 <p align="center">
-  Shiki is a beautiful Syntax Highlighter. <a href="http://shiki.matsu.io">Demo</a>.
+  Shiki is a beautiful Syntax Highlighter. <a href="http://shiki.matsu.io">Docs</a>. <a href="https://codesandbox.io/s/shiki-next-js-cir0y">CodeSandbox</a>.
 </p>
 
 ## Usage
@@ -35,7 +35,8 @@ shiki
 
 ## Seen
 
-- https://shiki.matsu.io
+- Shiki Docs: https://shiki.matsu.io
+- Interactive Demo on CodeSandbox (with Next.js): https://codesandbox.io/s/shiki-next-js-cir0y
 - [VS Code website](https://code.visualstudio.com), such as in the [Notebook API page](https://code.visualstudio.com/api/extension-guides/notebook).
 - [TypeScript website](https://www.typescriptlang.org), such as in the [Basic Types documentation page](https://www.typescriptlang.org/docs/handbook/basic-types.html#tuple).
 - [Markdown Preview Shiki Highlighting](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-Shiki), a VS Code plugin to use Shiki's highlighting in Markdown preview.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h2 align="center">Shiki</h2>
 </p>
 <p align="center">
-  Shiki is a beautiful Syntax Highlighter. <a href="http://shiki.matsu.io">Docs</a>. <a href="https://codesandbox.io/s/shiki-next-js-cir0y">CodeSandbox</a>.
+  Shiki is a beautiful Syntax Highlighter. <a href="http://shiki.matsu.io">Demo</a>.
 </p>
 
 ## Usage
@@ -32,6 +32,8 @@ shiki
 - [Languages](./packages/languages/README.md#literal-values)
 - [SVG Renderer](./packages/renderer-svg/README.md)
 - [vuepress-plugin-shiki](./packages/vuepress-plugin/README.md)
+
+Clone [shikijs/shiki-starter](https://github.com/shikijs/shiki-starter) to play with Shiki, or try it out on [CodeSandbox](https://codesandbox.io/s/shiki-starter-gphup).
 
 ## Seen
 


### PR DESCRIPTION
Hi @octref ! 👋

I have been considering different highlighting options (also Prism.js with `react-syntax-highlighter`), and stumbled upon your project through Orta (who used it for the [`shiki-twoslash`](https://www.npmjs.com/package/shiki-twoslash) package for the TypeScript website)

One thing that I was looking for when going through this repo and also the docs website was an interactive demo.

I've set one up on CodeSandbox (with Next.js). It is currently a frozen sandbox (so that I remember to not accidentally make changes to it), but of course happy to have you fork it so that you control the sandbox.

What are your thoughts?