### PR TITLE
Highlighting lines

### DIFF
--- a/packages/shiki/src/__tests__/simple.test.ts
+++ b/packages/shiki/src/__tests__/simple.test.ts
@@ -7,3 +7,60 @@ test('Nord highlighter highlights simple JavaScript', async () => {
   const out = highlighter.codeToHtml(`console.log('shiki');`, 'js')
   expect(out).toMatchSnapshot()
 })
+
+test('Individual lines are highlighted', async () => {
+  const highlighter = await getHighlighter({
+    theme: 'nord'
+  })
+  const code = `
+let a = 1;
+let b = 2;
+console.log(a+b);
+console.log('shiki');
+`
+
+  const out = highlighter.codeToHtml(code, 'js', { highlightLines: [2, 4] })
+  expect(out).toBe(
+    `<pre class=\"shiki highlighted\" style=\"background-color: #2e3440\"><code>
+<span class=\"hl\"><span style=\"color: #81A1C1\">let</span><span style=\"color: #D8DEE9FF\"> </span><span style=\"color: #D8DEE9\">a</span><span style=\"color: #D8DEE9FF\"> </span><span style=\"color: #81A1C1\">=</span><span style=\"color: #D8DEE9FF\"> </span><span style=\"color: #B48EAD\">1</span><span style=\"color: #81A1C1\">;</span></span>
+<span style=\"color: #81A1C1\">let</span><span style=\"color: #D8DEE9FF\"> </span><span style=\"color: #D8DEE9\">b</span><span style=\"color: #D8DEE9FF\"> </span><span style=\"color: #81A1C1\">=</span><span style=\"color: #D8DEE9FF\"> </span><span style=\"color: #B48EAD\">2</span><span style=\"color: #81A1C1\">;</span>
+<span class=\"hl\"><span style=\"color: #8FBCBB\">console</span><span style=\"color: #ECEFF4\">.</span><span style=\"color: #88C0D0\">log</span><span style=\"color: #D8DEE9FF\">(</span><span style=\"color: #D8DEE9\">a</span><span style=\"color: #81A1C1\">+</span><span style=\"color: #D8DEE9\">b</span><span style=\"color: #D8DEE9FF\">)</span><span style=\"color: #81A1C1\">;</span></span>
+<span style=\"color: #8FBCBB\">console</span><span style=\"color: #ECEFF4\">.</span><span style=\"color: #88C0D0\">log</span><span style=\"color: #D8DEE9FF\">(</span><span style=\"color: #ECEFF4\">&apos;</span><span style=\"color: #A3BE8C\">shiki</span><span style=\"color: #ECEFF4\">&apos;</span><span style=\"color: #D8DEE9FF\">)</span><span style=\"color: #81A1C1\">;</span></code></pre>`
+  )
+})
+
+test('Line ranges are highlighted', async () => {
+  const highlighter = await getHighlighter({
+    theme: 'nord'
+  })
+  const code = `let a = 1;
+let b = 2;
+console.log(a+b);
+console.log('shiki');
+`
+  const out = highlighter.codeToHtml(code, 'js', { highlightLines: ['1-3'] })
+  expect(out).toBe(
+    `<pre class="shiki highlighted" style="background-color: #2e3440"><code><span class="hl"><span style="color: #81A1C1">let</span><span style="color: #D8DEE9FF"> </span><span style="color: #D8DEE9">a</span><span style="color: #D8DEE9FF"> </span><span style="color: #81A1C1">=</span><span style="color: #D8DEE9FF"> </span><span style="color: #B48EAD">1</span><span style="color: #81A1C1">;</span></span>
+<span class="hl"><span style="color: #81A1C1">let</span><span style="color: #D8DEE9FF"> </span><span style="color: #D8DEE9">b</span><span style="color: #D8DEE9FF"> </span><span style="color: #81A1C1">=</span><span style="color: #D8DEE9FF"> </span><span style="color: #B48EAD">2</span><span style="color: #81A1C1">;</span></span>
+<span class="hl"><span style="color: #8FBCBB">console</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #D8DEE9">a</span><span style="color: #81A1C1">+</span><span style="color: #D8DEE9">b</span><span style="color: #D8DEE9FF">)</span><span style="color: #81A1C1">;</span></span>
+<span style="color: #8FBCBB">console</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #ECEFF4">&apos;</span><span style="color: #A3BE8C">shiki</span><span style="color: #ECEFF4">&apos;</span><span style="color: #D8DEE9FF">)</span><span style="color: #81A1C1">;</span></code></pre>`
+  )
+})
+
+test('Combinations of lines are highlighted', async () => {
+  const highlighter = await getHighlighter({
+    theme: 'nord'
+  })
+  const code = `let a = 1;
+let b = 2;
+console.log(a+b);
+console.log('shiki');
+`
+  const out = highlighter.codeToHtml(code, 'js', { highlightLines: [1, '3-4'] })
+  expect(out).toBe(
+    `<pre class="shiki highlighted" style="background-color: #2e3440"><code><span class="hl"><span style="color: #81A1C1">let</span><span style="color: #D8DEE9FF"> </span><span style="color: #D8DEE9">a</span><span style="color: #D8DEE9FF"> </span><span style="color: #81A1C1">=</span><span style="color: #D8DEE9FF"> </span><span style="color: #B48EAD">1</span><span style="color: #81A1C1">;</span></span>
+<span style="color: #81A1C1">let</span><span style="color: #D8DEE9FF"> </span><span style="color: #D8DEE9">b</span><span style="color: #D8DEE9FF"> </span><span style="color: #81A1C1">=</span><span style="color: #D8DEE9FF"> </span><span style="color: #B48EAD">2</span><span style="color: #81A1C1">;</span>
+<span class="hl"><span style="color: #8FBCBB">console</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #D8DEE9">a</span><span style="color: #81A1C1">+</span><span style="color: #D8DEE9">b</span><span style="color: #D8DEE9FF">)</span><span style="color: #81A1C1">;</span></span>
+<span class="hl"><span style="color: #8FBCBB">console</span><span style="color: #ECEFF4">.</span><span style="color: #88C0D0">log</span><span style="color: #D8DEE9FF">(</span><span style="color: #ECEFF4">&apos;</span><span style="color: #A3BE8C">shiki</span><span style="color: #ECEFF4">&apos;</span><span style="color: #D8DEE9FF">)</span><span style="color: #81A1C1">;</span></span></code></pre>`
+  )
+})

--- a/packages/shiki/src/highlighter.ts
+++ b/packages/shiki/src/highlighter.ts
@@ -14,6 +14,11 @@ export interface HighlighterOptions {
   langs?: ILanguageRegistration[]
 }
 
+export interface HtmlOptions {
+  // Pass an array of lines and line ranges (strikes like "4-18")
+  highlightLines?: (string | number)[]
+}
+
 export async function getHighlighter(options: HighlighterOptions) {
   let t: IShikiTheme
   if (typeof options.theme === 'string') {
@@ -87,7 +92,7 @@ class Shiki {
         }
         return tokenizeWithTheme(this._theme, this._colorMap, code, ltog[lang], options)
       },
-      codeToHtml: (code, lang) => {
+      codeToHtml: (code, lang, options) => {
         if (isPlaintext(lang)) {
           return renderToHtml([[{ content: code }]], {
             fg: this._theme.fg,
@@ -101,7 +106,8 @@ class Shiki {
           includeExplanation: false
         })
         return renderToHtml(tokens, {
-          bg: this._theme.bg
+          bg: this._theme.bg,
+          highlightLines: options?.highlightLines
         })
       }
     }
@@ -123,7 +129,7 @@ export interface Highlighter {
     lang: StringLiteralUnion<Lang>,
     options?: ThemedTokenizerOptions
   ): IThemedToken[][]
-  codeToHtml?(code: string, lang: StringLiteralUnion<Lang>): string
+  codeToHtml?(code: string, lang: StringLiteralUnion<Lang>, options?: HtmlOptions): string
 
   // codeToRawHtml?(code: string): string
   // getRawCSS?(): string

--- a/packages/shiki/src/renderer.ts
+++ b/packages/shiki/src/renderer.ts
@@ -39,7 +39,8 @@ export function renderToHtml(lines: IThemedToken[][], options: HtmlRendererOptio
     }
 
     if (highlightedLines.has(lineNo)) {
-      html += `</span>\n`
+      // Newline goes before the close, so that display:block on the line will work
+      html += `\n</span>`
     } else {
       html += `\n`
     }

--- a/packages/shiki/src/renderer.ts
+++ b/packages/shiki/src/renderer.ts
@@ -1,31 +1,46 @@
 import { IThemedToken } from './themedTokenizer'
+import { isNumber } from 'util'
 
 export interface HtmlRendererOptions {
   langId?: string
   fg?: string
   bg?: string
+  highlightLines?: (string | number)[]
 }
 
 export function renderToHtml(lines: IThemedToken[][], options: HtmlRendererOptions = {}) {
   const bg = options.bg || '#fff'
+  const highlightedLines = makeHighlightSet(options.highlightLines)
 
   let html = ''
+  let className = 'shiki'
+  if (highlightedLines.size) {
+    className += ' highlighted'
+  }
 
-  html += `<pre class="shiki" style="background-color: ${bg}">`
+  html += `<pre class="${className}" style="background-color: ${bg}">`
   if (options.langId) {
     html += `<div class="language-id">${options.langId}</div>`
   }
   html += `<code>`
 
-  lines.forEach((l: IThemedToken[]) => {
-    if (l.length === 0) {
-      html += `\n`
-    } else {
+  lines.forEach((l: IThemedToken[], index: number) => {
+    const lineNo = index + 1
+    if (highlightedLines.has(lineNo)) {
+      html += `<span class="hl">`
+    }
+
+    if (l.length > 0) {
       l.forEach(token => {
         html += `<span style="color: ${token.color || options.fg}">${escapeHtml(
           token.content
         )}</span>`
       })
+    }
+
+    if (highlightedLines.has(lineNo)) {
+      html += `</span>\n`
+    } else {
       html += `\n`
     }
   })
@@ -45,4 +60,34 @@ const htmlEscapes = {
 
 function escapeHtml(html: string) {
   return html.replace(/[&<>"']/g, chr => htmlEscapes[chr])
+}
+
+function commaSeparatedLinesToArray(lineList: string) {
+  return lineList.split(',').map(segment => {
+    if (Number(segment) > 0) {
+      return Number(segment)
+    }
+    return segment
+  })
+}
+
+function makeHighlightSet(highlightLines?: (string | number)[]) {
+  const lines = new Set()
+
+  if (!highlightLines) {
+    return lines
+  }
+
+  for (let lineSpec of highlightLines) {
+    if (typeof lineSpec === 'number') {
+      lines.add(lineSpec)
+    } else if (lineSpec.includes('-')) {
+      const [begin, end] = lineSpec.split('-').map(lineNo => Number(lineNo))
+      for (let line = begin; line <= end; line++) {
+        lines.add(line)
+      }
+    }
+  }
+
+  return lines
 }

--- a/packages/shiki/src/renderer.ts
+++ b/packages/shiki/src/renderer.ts
@@ -6,16 +6,32 @@ export interface HtmlRendererOptions {
   fg?: string
   bg?: string
   highlightLines?: (string | number)[]
+  addLines?: (string | number)[]
+  deleteLines?: (string | number)[]
+  focusLines?: (string | number)[]
+  debugColors?: boolean
 }
 
 export function renderToHtml(lines: IThemedToken[][], options: HtmlRendererOptions = {}) {
   const bg = options.bg || '#fff'
   const highlightedLines = makeHighlightSet(options.highlightLines)
+  const addLines = makeHighlightSet(options.addLines)
+  const deleteLines = makeHighlightSet(options.deleteLines)
+  const focusLines = makeHighlightSet(options.focusLines)
 
   let html = ''
   let className = 'shiki'
   if (highlightedLines.size) {
     className += ' highlighted'
+  }
+  if (addLines.size) {
+    className += ' added'
+  }
+  if (deleteLines.size) {
+    className += ' deleted'
+  }
+  if (focusLines.size) {
+    className += ' has-focus'
   }
 
   html += `<pre class="${className}" style="background-color: ${bg}">`
@@ -26,8 +42,21 @@ export function renderToHtml(lines: IThemedToken[][], options: HtmlRendererOptio
 
   lines.forEach((l: IThemedToken[], index: number) => {
     const lineNo = index + 1
+    let highlightClasses = ''
     if (highlightedLines.has(lineNo)) {
-      html += `<span class="hl">`
+      highlightClasses += ' hl'
+    }
+    if (addLines.has(lineNo)) {
+      highlightClasses += ' add'
+    }
+    if (deleteLines.has(lineNo)) {
+      highlightClasses += ' del'
+    }
+    if (focusLines.has(lineNo)) {
+      highlightClasses += ' foc'
+    }
+    if (highlightClasses) {
+      html += `<span class="${highlightClasses.trim()}">`
     }
 
     if (l.length > 0) {
@@ -38,7 +67,7 @@ export function renderToHtml(lines: IThemedToken[][], options: HtmlRendererOptio
       })
     }
 
-    if (highlightedLines.has(lineNo)) {
+    if (highlightClasses) {
       // Newline goes before the close, so that display:block on the line will work
       html += `\n</span>`
     } else {
@@ -72,8 +101,8 @@ function commaSeparatedLinesToArray(lineList: string) {
   })
 }
 
-function makeHighlightSet(highlightLines?: (string | number)[]) {
-  const lines = new Set()
+export function makeHighlightSet(highlightLines?: (string | number)[]): Set<number> {
+  const lines = new Set<number>()
 
   if (!highlightLines) {
     return lines

--- a/packages/shiki/src/themedTokenizer.ts
+++ b/packages/shiki/src/themedTokenizer.ts
@@ -92,7 +92,8 @@ export function tokenizeWithTheme(
   colorMap: string[],
   fileContents: string,
   grammar: IGrammar,
-  options: { includeExplanation?: boolean }
+  options: { includeExplanation?: boolean },
+  ignoreLines: Set<number> = new Set()
 ): IThemedToken[][] {
   let lines = fileContents.split(/\r\n|\r|\n/)
 
@@ -105,6 +106,20 @@ export function tokenizeWithTheme(
     if (line === '') {
       actual = []
       final.push([])
+      continue
+    }
+
+    // If this line should be ignored (e.g. it's a removed line in a diff),
+    // don't tokenize it, but do include it in the result.
+    // Also - ignoreLines is 1-based
+    if (ignoreLines.has(i + 1)) {
+      final.push([
+        {
+          content: line,
+          color: '',
+          explanation: []
+        }
+      ])
       continue
     }
 


### PR DESCRIPTION
I'm not sure this is ready to merge, but I wanted to put it up to help the discussion in #74.

The broad idea here is to pass an array of line numbers and ranges into Shiki when calling `codeToHtml`, and it will then add appropriate classes to the highlighted/added/deleted/focused lines.