### PR TITLE
fix(readme): add destructure import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ npm i shiki
 
 ```js
 const shiki = require('shiki')
+// import { getHighlighter } from 'shiki'
 
 shiki
   .getHighlighter({


### PR DESCRIPTION
Since in `index.ts` we don't export any default module,

https://github.com/shikijs/shiki/blob/58cb92cd9427a97d5b4f89e3cec8e12290fcb793/packages/shiki/src/index.ts#L1-L6

it would raise an error like this, if we use `import shiki from 'shiki'` syntax.

```
The requested module 'file:///<some-path>/node_modules/shiki/dist/index.js' does not provide an export named 'default'
```

I think it's better to add destructure way to import `shiki`.