### PR TITLE
Expose the HtmlRendererOptions

### DIFF
--- a/packages/shiki/src/index.ts
+++ b/packages/shiki/src/index.ts
@@ -2,7 +2,7 @@ export { themes as BUNDLED_THEMES, Theme } from './themes'
 export { languages as BUNDLED_LANGUAGES, Lang } from './languages'
 
 export { getHighlighter } from './highlighter'
-export { renderToHtml } from './renderer'
+export { renderToHtml, HtmlRendererOptions } from './renderer'
 export { IThemedToken } from './themedTokenizer'
 export { setCDN, setOnigasmWASM, fetchTheme as loadTheme } from './loader'
 export {


### PR DESCRIPTION
Been moving the TypeScript website over, while this isn't essential, I have been using it a lot in my custom shiki renderers to be consistent with the default renderer