### PR TITLE
Expand browser check to include 'fetch'

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*"],
-  "version": "0.9.0",
+  "version": "0.9.1",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/shiki/package.json
+++ b/packages/shiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shiki",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "shiki",
   "author": "Pine Wu <octref@gmail.com>",
   "homepage": "https://github.com/octref/shiki/tree/master/packages/shiki",

--- a/packages/shiki/src/loader.ts
+++ b/packages/shiki/src/loader.ts
@@ -3,7 +3,10 @@ import type { IOnigLib, IRawGrammar, IRawTheme } from 'vscode-textmate'
 import type { IShikiTheme } from './types'
 import { dirname, join } from 'path'
 
-export const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined'
+export const isBrowser =
+  typeof window !== 'undefined' &&
+  typeof window.document !== 'undefined' &&
+  typeof fetch !== 'undefined'
 
 // to be replaced by rollup
 let CDN_ROOT = '__CDN_ROOT__'


### PR DESCRIPTION
By default jest include jsdom, which adds both document and window - but does not include fetch. By adding fetch to the check we can run in Jest without additional config on end users setting `"testEnvironment": "node"`.