### PR TITLE
feat: add 'tex' as an alias of latex

### DIFF
--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -358,7 +358,8 @@ export const languages: ILanguageRegistration[] = [
   {
     id: 'latex',
     scopeName: 'text.tex.latex',
-    path: 'latex.tmLanguage.json'
+    path: 'latex.tmLanguage.json',
+    aliases: ['tex']
   },
   {
     id: 'less',

--- a/scripts/updateLangSrc.js
+++ b/scripts/updateLangSrc.js
@@ -15,6 +15,7 @@ const aliases = {
   fsharp: ['f#'],
   handlebars: ['hbs'],
   javascript: ['js'],
+  latex: ['tex'],
   markdown: ['md'],
   'objective-c': ['objc'],
   powershell: ['ps', 'ps1'],


### PR DESCRIPTION
Many LaTeX source code have the extenstion `.tex`, so I make `tex` an alias to `latex`.