### PR TITLE
Don't call `setTheme` if `_theme` hasn't changed

### DIFF
--- a/packages/shiki/src/highlighter.ts
+++ b/packages/shiki/src/highlighter.ts
@@ -53,6 +53,7 @@ export async function getHighlighter(options: HighlighterOptions): Promise<Highl
 
   const themes = await _registry.loadThemes(_themes)
   const _defaultTheme = themes[0]
+  let _currentTheme: IShikiTheme | undefined
   await _registry.loadLanguages(_languages)
 
   function getTheme(theme: IThemeRegistration) {
@@ -60,7 +61,10 @@ export async function getHighlighter(options: HighlighterOptions): Promise<Highl
     if (!_theme) {
       throw Error(`No theme registration for ${theme}`)
     }
-    _registry.setTheme(_theme)
+    if (_currentTheme !== _theme) {
+      _registry.setTheme(_theme)
+      _currentTheme = _theme
+    }
     const _colorMap = _registry.getColorMap()
     return { _theme, _colorMap }
   }


### PR DESCRIPTION
`setTheme` can be an expensive operation because it parses the raw theme
every time it's called:
https://github.com/microsoft/vscode-textmate/blob/9e3c5941668cbfcee5095eaec0e58090fda8f316/src/main.ts#L93-L95

In https://github.com/banga/git-split-diffs/, I invoke
`codeToThemedTokens` many times, one line at a time, so the cost of
`setTheme` adds up. In my local profiling, this was taking about 25% of
the time spent in `codeToThemedTokens`. I realize this is probably not
the intended way to use this function, but there isn't an easy
alternative for syntax highlighting individual lines in a diff.

Before
![image](https://user-images.githubusercontent.com/541603/115807228-15734180-a39d-11eb-9030-3fe473a2a373.png)

After
![image](https://user-images.githubusercontent.com/541603/115807268-2c199880-a39d-11eb-806d-2036e3899de1.png)
