### PR TITLE
fix: small typo in mono.md (readfileSync should be readFileSync)

### DIFF
--- a/packages/site/mono.md
+++ b/packages/site/mono.md
@@ -2,6 +2,6 @@
 const shiki = require('shiki')
 
 shiki.getHighlighter({
-  theme: JSON.parse(fs.readfileSync('./monochrome-dark-subtle.json', 'utf-8'))
+  theme: JSON.parse(fs.readFileSync('./monochrome-dark-subtle.json', 'utf-8'))
 })
 ```


### PR DESCRIPTION
Per the title. Thanks for all your amazing work on this library @octref, it's really a wonderful project 🙂 🙌 