### PR TITLE
Allow dropping the theme option in the highlighter's getTheme interface

### DIFF
--- a/packages/shiki/src/highlighter.ts
+++ b/packages/shiki/src/highlighter.ts
@@ -56,7 +56,7 @@ export async function getHighlighter(options: HighlighterOptions): Promise<Highl
   let _currentTheme: IShikiTheme | undefined
   await _registry.loadLanguages(_languages)
 
-  function getTheme(theme: IThemeRegistration) {
+  function getTheme(theme?: IThemeRegistration) {
     const _theme = theme ? _registry.getTheme(theme) : _defaultTheme
     if (!_theme) {
       throw Error(`No theme registration for ${theme}`)

--- a/packages/shiki/src/types.ts
+++ b/packages/shiki/src/types.ts
@@ -56,7 +56,7 @@ export interface Highlighter {
   /**
    * Get the loaded theme
    */
-  getTheme(theme: IThemeRegistration): IShikiTheme
+  getTheme(theme?: IThemeRegistration): IShikiTheme
 
   /**
    * Load a theme


### PR DESCRIPTION
`getTheme` supports passing an `undefined` to grab the default but the types doesn't cover that case, this makes the param optional to account for that.