### PR TITLE
feat: add prisma language

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -93,6 +93,7 @@ export type Lang =
   | 'plsql'
   | 'postcss'
   | 'powershell' | 'ps' | 'ps1'
+  | 'prisma'
   | 'prolog'
   | 'pug' | 'jade'
   | 'puppet'

--- a/packages/shiki/languages/prisma.tmLanguage.json
+++ b/packages/shiki/languages/prisma.tmLanguage.json
@@ -1,0 +1,439 @@
+{
+  "name": "prisma",
+  "scopeName": "source.prisma",
+  "patterns": [
+    {
+      "include": "#triple_comment"
+    },
+    {
+      "include": "#double_comment"
+    },
+    {
+      "include": "#model_block_definition"
+    },
+    {
+      "include": "#config_block_definition"
+    },
+    {
+      "include": "#enum_block_definition"
+    },
+    {
+      "include": "#type_definition"
+    }
+  ],
+  "repository": {
+    "model_block_definition": {
+      "begin": "^\\s*(model|type)\\s+([A-Za-z][\\w]*)\\s*({)",
+      "name": "source.prisma.embedded.source",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.model.prisma"
+        },
+        "2": {
+          "name": "entity.name.type.model.prisma"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#triple_comment"
+        },
+        {
+          "include": "#double_comment"
+        },
+        {
+          "include": "#field_definition"
+        }
+      ],
+      "end": "\\s*\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "enum_block_definition": {
+      "begin": "^\\s*(enum)\\s+([A-Za-z][\\w]*)\\s+({)",
+      "name": "source.prisma.embedded.source",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.enum.prisma"
+        },
+        "2": {
+          "name": "entity.name.type.enum.prisma"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#triple_comment"
+        },
+        {
+          "include": "#double_comment"
+        },
+        {
+          "include": "#enum_value_definition"
+        }
+      ],
+      "end": "\\s*\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "config_block_definition": {
+      "begin": "^\\s*(generator|datasource)\\s+([A-Za-z][\\w]*)\\s+({)",
+      "name": "source.prisma.embedded.source",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.config.prisma"
+        },
+        "2": {
+          "name": "entity.name.type.config.prisma"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#triple_comment"
+        },
+        {
+          "include": "#double_comment"
+        },
+        {
+          "include": "#assignment"
+        }
+      ],
+      "end": "\\s*\\}",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "assignment": {
+      "patterns": [
+        {
+          "begin": "^\\s*(\\w+)\\s*(=)\\s*",
+          "beginCaptures": {
+            "1": {
+              "name": "variable.other.assignment.prisma"
+            },
+            "2": {
+              "name": "keyword.operator.terraform"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#value"
+            },
+            {
+              "include": "#double_comment_inline"
+            }
+          ],
+          "end": "\\n"
+        }
+      ]
+    },
+    "field_definition": {
+      "name": "scalar.field",
+      "patterns": [
+        {
+          "match": "^\\s*(\\w+)(\\s*:)?\\s+((?!(?:Int|String|DateTime|Bytes|Decimal|Float|Json|Boolean)\\b)\\b\\w+)?(Int|String|DateTime|Bytes|Decimal|Float|Json|Boolean)?(\\[\\])?(\\?)?(\\!)?",
+          "captures": {
+            "1": {
+              "name": "variable.other.assignment.prisma"
+            },
+            "2": {
+              "name": "invalid.illegal.colon.prisma"
+            },
+            "3": {
+              "name": "variable.language.relations.prisma"
+            },
+            "4": {
+              "name": "support.type.primitive.prisma"
+            },
+            "5": {
+              "name": "keyword.operator.list_type.prisma"
+            },
+            "6": {
+              "name": "keyword.operator.optional_type.prisma"
+            },
+            "7": {
+              "name": "invalid.illegal.required_type.prisma"
+            }
+          }
+        },
+        {
+          "include": "#attribute_with_arguments"
+        },
+        {
+          "include": "#attribute"
+        }
+      ]
+    },
+    "type_definition": {
+      "patterns": [
+        {
+          "match": "^\\s*(type)\\s+(\\w+)\\s*=\\s*(\\w+)",
+          "captures": {
+            "1": {
+              "name": "storage.type.type.prisma"
+            },
+            "2": {
+              "name": "entity.name.type.type.prisma"
+            },
+            "3": {
+              "name": "support.type.primitive.prisma"
+            }
+          }
+        },
+        {
+          "include": "#attribute_with_arguments"
+        },
+        {
+          "include": "#attribute"
+        }
+      ]
+    },
+    "enum_value_definition": {
+      "patterns": [
+        {
+          "match": "^\\s*(\\w+)\\s*",
+          "captures": {
+            "1": {
+              "name": "variable.other.assignment.prisma"
+            }
+          }
+        },
+        {
+          "include": "#attribute_with_arguments"
+        },
+        {
+          "include": "#attribute"
+        }
+      ]
+    },
+    "attribute_with_arguments": {
+      "name": "source.prisma.attribute.with_arguments",
+      "begin": "(@@?[\\w\\.]+)(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.attribute.prisma"
+        },
+        "2": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#named_argument"
+        },
+        {
+          "include": "#value"
+        }
+      ],
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "attribute": {
+      "name": "source.prisma.attribute",
+      "match": "(@@?[\\w\\.]+)",
+      "captures": {
+        "1": {
+          "name": "entity.name.function.attribute.prisma"
+        }
+      }
+    },
+    "array": {
+      "name": "source.prisma.array",
+      "begin": "\\[",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value"
+        }
+      ],
+      "end": "\\]",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "value": {
+      "name": "source.prisma.value",
+      "patterns": [
+        {
+          "include": "#array"
+        },
+        {
+          "include": "#functional"
+        },
+        {
+          "include": "#literal"
+        }
+      ]
+    },
+    "functional": {
+      "name": "source.prisma.functional",
+      "begin": "(\\w+)(\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.functional.prisma"
+        },
+        "2": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value"
+        }
+      ],
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "literal": {
+      "name": "source.prisma.literal",
+      "patterns": [
+        {
+          "include": "#boolean"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#double_quoted_string"
+        },
+        {
+          "include": "#identifier"
+        }
+      ]
+    },
+    "identifier": {
+      "patterns": [
+        {
+          "match": "\\b(\\w)+\\b",
+          "name": "support.constant.constant.prisma"
+        }
+      ]
+    },
+    "map_key": {
+      "name": "source.prisma.key",
+      "patterns": [
+        {
+          "match": "(\\w+)\\s*(:)\\s*",
+          "captures": {
+            "1": {
+              "name": "variable.parameter.key.prisma"
+            },
+            "2": {
+              "name": "punctuation.definition.separator.key-value.prisma"
+            }
+          }
+        }
+      ]
+    },
+    "named_argument": {
+      "name": "source.prisma.named_argument",
+      "patterns": [
+        {
+          "include": "#map_key"
+        },
+        {
+          "include": "#value"
+        }
+      ]
+    },
+    "triple_comment": {
+      "begin": "///",
+      "end": "$\\n?",
+      "name": "comment.prisma"
+    },
+    "double_comment": {
+      "begin": "//",
+      "end": "$\\n?",
+      "name": "comment.prisma"
+    },
+    "double_comment_inline": {
+      "match": "//[^\\n]*",
+      "name": "comment.prisma"
+    },
+    "boolean": {
+      "match": "\\b(true|false)\\b",
+      "name": "constant.language.boolean.prisma"
+    },
+    "number": {
+      "match": "((0(x|X)[0-9a-fA-F]*)|(\\+|-)?\\b(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)([LlFfUuDdg]|UL|ul)?\\b",
+      "name": "constant.numeric.prisma"
+    },
+    "double_quoted_string": {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "string.quoted.double.start.prisma"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "string.quoted.double.end.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#string_interpolation"
+        },
+        {
+          "match": "([\\w\\-\\/\\._\\\\%@:\\?=]+)",
+          "name": "string.quoted.double.prisma"
+        }
+      ],
+      "name": "unnamed"
+    },
+    "string_interpolation": {
+      "patterns": [
+        {
+          "begin": "\\$\\{",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.control.interpolation.start.prisma"
+            }
+          },
+          "end": "\\s*\\}",
+          "endCaptures": {
+            "0": {
+              "name": "keyword.control.interpolation.end.prisma"
+            }
+          },
+          "name": "source.tag.embedded.source.prisma",
+          "patterns": [
+            {
+              "include": "#value"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/shiki/samples/prisma.sample
+++ b/packages/shiki/samples/prisma.sample
@@ -1,0 +1,41 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+/// Post including an author and content.
+model Post {
+  id        Int         @default(autoincrement()) @id
+  content   String?
+  published Boolean     @default(false)
+  author    User?       @relation(fields: [authorId], references: [id])
+  authorId  Int?
+}
+
+// Documentation for this model.
+model User {
+  id    Int     @default(autoincrement()) @id
+  email String  @unique
+  name  String?
+  posts Post[]
+  specialName UserName
+  test Test
+}
+
+/// This is an enum specifying the UserName.
+enum UserName {
+    Fred
+    Eric
+}
+
+// This is a test enum.
+enum Test {
+  TestUno
+  TestDue
+}
+
+// taken from https://github.com/prisma/language-tools/blob/master/packages/vscode/testFixture/hover.prisma

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -73,6 +73,7 @@ export type Lang =
   | 'plsql'
   | 'postcss'
   | 'powershell' | 'ps' | 'ps1'
+  | 'prisma'
   | 'prolog'
   | 'pug' | 'jade'
   | 'puppet'
@@ -519,6 +520,12 @@ export const languages: ILanguageRegistration[] = [
     scopeName: 'source.powershell',
     path: 'powershell.tmLanguage.json',
     aliases: ['ps', 'ps1']
+  },
+  {
+    id: 'prisma',
+    scopeName: 'source.prisma',
+    path: 'prisma.tmLanguage.json',
+    samplePath: 'prisma.sample'
   },
   {
     id: 'prolog',

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -149,7 +149,8 @@ export const githubGrammarSources: (string | [string, string])[] = [
     'https://github.com/nalabdou/Symfony-code-snippets/blob/master/syntaxes/twig.tmLanguage'
   ],
   'https://github.com/stardog-union/stardog-vsc/blob/master/stardog-rdf-grammars/syntaxes/turtle.tmLanguage.json',
-  'https://github.com/stardog-union/stardog-vsc/blob/master/stardog-rdf-grammars/syntaxes/sparql.tmLanguage.json'
+  'https://github.com/stardog-union/stardog-vsc/blob/master/stardog-rdf-grammars/syntaxes/sparql.tmLanguage.json',
+  'https://github.com/prisma/language-tools/blob/master/packages/vscode/syntaxes/prisma.tmLanguage.json'
 ]
 
 /**


### PR DESCRIPTION
Add support for [Prisma's](https://github.com/prisma/prisma) datamodel syntax.

e.g.

```prisma
datasource db {
  provider = "postgresql"
  url      = env("DATABASE_URL")
}

generator client {
  provider = "prisma-client-js"
}

model Post {
  id        Int         @default(autoincrement()) @id
  content   String?
  published Boolean     @default(false)
  author    User?       @relation(fields: [authorId], references: [id])
  authorId  Int?
}

model User {
  id    Int     @default(autoincrement()) @id
  email String  @unique
  name  String?
  role  Role    @default(USER)
  posts Post[]
}

enum Role {
    USER
    ADMIN
}
```