### PR TITLE
feat: add fish shell language

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -49,6 +49,7 @@ export type Lang =
   | 'elm'
   | 'erb'
   | 'erlang'
+  | 'fish'
   | 'fsharp' | 'f#'
   | 'gherkin'
   | 'git-commit'

--- a/packages/shiki/languages/fish.tmLanguage.json
+++ b/packages/shiki/languages/fish.tmLanguage.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "fileTypes": ["fish"],
+  "firstLineMatch": "^#!.*\\bfish\\b",
+  "foldingStartMarker": "^\\s*(function|while|if|switch|for|begin)\\s.*$",
+  "foldingStopMarker": "^\\s*end\\s*$",
+  "keyEquivalent": "^~F",
+  "name": "fish",
+  "patterns": [
+    {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.fish"
+        }
+      },
+      "comment": "Double quoted string",
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.fish"
+        }
+      },
+      "name": "string.quoted.double.fish",
+      "patterns": [
+        {
+          "include": "#variable"
+        },
+        {
+          "comment": "https://fishshell.com/docs/current/#quotes",
+          "match": "\\\\(\\\"|\\$|$|\\\\)",
+          "name": "constant.character.escape.fish"
+        }
+      ]
+    },
+    {
+      "begin": "'",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.fish"
+        }
+      },
+      "comment": "Single quoted string",
+      "end": "'",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.fish"
+        }
+      },
+      "name": "string.quoted.single.fish",
+      "patterns": [
+        {
+          "comment": "https://fishshell.com/docs/current/#quotes",
+          "match": "\\\\('|`|\\\\)",
+          "name": "constant.character.escape.fish"
+        }
+      ]
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.comment.fish"
+        }
+      },
+      "comment": "line comment",
+      "match": "(?<!\\$)(#)(?!\\{).*$\\n?",
+      "name": "comment.line.number-sign.fish"
+    },
+    {
+      "comment": "name of command, either a function or a binary",
+      "match": "(^\\s*|&&\\s*|\\|\\s*|\\(\\s*|[;]\\s*|\\b(if|while)\\b\\s+)(?!(?<!\\.)\\b(function|while|if|else|switch|case|for|in|begin|end|continue|break|return|source|exit|wait)\\b(?![?!]))([a-zA-Z_\\-0-9\\[\\].]+)",
+      "captures": {
+        "2": {
+          "name": "keyword.control.fish"
+        },
+        "4": {
+          "name": "support.function.command.fish"
+        }
+      }
+    },
+    {
+      "comment": "keywords that affect control flow",
+      "match": "(?<!\\.)\\b(function|while|if|else|switch|case|for|in|begin|end|continue|break|return|source|exit|wait)\\b(?![?!])",
+      "name": "keyword.control.fish"
+    },
+    {
+      "match": "(?<!\\.)\\bfunction\\b(?![?!])",
+      "name": "storage.type.fish"
+    },
+    {
+      "match": "\\|",
+      "name": "keyword.operator.pipe.fish"
+    },
+    {
+      "comment": "IO Redirection",
+      "match": "(?x:\n<|# Standard Input\n(>|\\^|>>|\\^\\^)(&[012\\-])?| # Redirection of stderr\n[012](<|>|>>)(&[012\\-])? # Redirect input/output of file descriptors\n)",
+      "name": "keyword.operator.redirect.fish"
+    },
+    {
+      "match": "&",
+      "name": "keyword.operator.background.fish"
+    },
+    {
+      "match": "\\*\\*|\\*|\\?",
+      "name": "keyword.operator.glob.fish"
+    },
+    {
+      "comment": "command short/long options",
+      "match": "\\s(-{1,2}[a-zA-Z_\\-0-9]+|-\\w)\\b",
+      "captures": {
+        "1": {
+          "name": "source.option.fish"
+        }
+      }
+    },
+    {
+      "include": "#variable"
+    },
+    {
+      "include": "#escape"
+    }
+  ],
+  "repository": {
+    "escape": {
+      "patterns": [
+        {
+          "comment": "single character character escape sequences",
+          "match": "\\\\[abefnrtv $*?~#(){}\\[\\]<>^&|;\"']",
+          "name": "constant.character.escape.single.fish"
+        },
+        {
+          "comment": "escapes the ascii character with the specified value (hexadecimal)",
+          "match": "\\\\x[0-9a-fA-F]{1,2}",
+          "name": "constant.character.escape.hex-ascii.fish"
+        },
+        {
+          "comment": "escapes a byte of data with the specified value (hexadecimal). If you are using mutibyte encoding, this can be used to enter invalid strings. Only use this if you know what are doing.",
+          "match": "\\\\X[0-9a-fA-F]{1,2}",
+          "name": "constant.character.escape.hex-byte.fish"
+        },
+        {
+          "comment": "escapes the ascii character with the specified value (octal)",
+          "match": "\\\\[0-7]{1,3}",
+          "name": "constant.character.escape.octal.fish"
+        },
+        {
+          "comment": "escapes the 16-bit unicode character with the specified value (hexadecimal)",
+          "match": "\\\\u[0-9a-fA-F]{1,4}",
+          "name": "constant.character.escape.unicode-16-bit.fish"
+        },
+        {
+          "comment": "escapes the 32-bit unicode character with the specified value (hexadecimal)",
+          "match": "\\\\U[0-9a-fA-F]{1,8}",
+          "name": "constant.character.escape.unicode-32-bit.fish"
+        },
+        {
+          "comment": "escapes the control sequence generated by pressing the control key and the specified letter",
+          "match": "\\\\c[a-zA-Z]",
+          "name": "constant.character.escape.control.fish"
+        }
+      ]
+    },
+    "variable": {
+      "patterns": [
+        {
+          "comment": "Built-in variables visible by pressing $ TAB TAB in a new shell",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.variable.fish"
+            }
+          },
+          "match": "(\\$)(argv|CMD_DURATION|COLUMNS|fish_bind_mode|fish_color_autosuggestion|fish_color_cancel|fish_color_command|fish_color_comment|fish_color_cwd|fish_color_cwd_root|fish_color_end|fish_color_error|fish_color_escape|fish_color_hg_added|fish_color_hg_clean|fish_color_hg_copied|fish_color_hg_deleted|fish_color_hg_dirty|fish_color_hg_modified|fish_color_hg_renamed|fish_color_hg_unmerged|fish_color_hg_untracked|fish_color_history_current|fish_color_host|fish_color_host_remote|fish_color_match|fish_color_normal|fish_color_operator|fish_color_param|fish_color_quote|fish_color_redirection|fish_color_search_match|fish_color_selection|fish_color_status|fish_color_user|fish_color_valid_path|fish_complete_path|fish_function_path|fish_greeting|fish_key_bindings|fish_pager_color_completion|fish_pager_color_description|fish_pager_color_prefix|fish_pager_color_progress|fish_pid|fish_prompt_hg_status_added|fish_prompt_hg_status_copied|fish_prompt_hg_status_deleted|fish_prompt_hg_status_modified|fish_prompt_hg_status_order|fish_prompt_hg_status_unmerged|fish_prompt_hg_status_untracked|FISH_VERSION|history|hostname|IFS|LINES|pipestatus|status|umask|version)\\b",
+          "name": "variable.language.fish"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.variable.fish"
+            }
+          },
+          "match": "(\\$)[a-zA-Z_][a-zA-Z0-9_]*",
+          "name": "variable.other.normal.fish"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.fish",
+  "uuid": "9CA6DB6F-A16F-4836-A058-617C7378775D"
+}

--- a/packages/shiki/samples/fish.sample
+++ b/packages/shiki/samples/fish.sample
@@ -1,0 +1,13 @@
+function fish_prompt
+    # A simple prompt. Displays the current directory
+    # (which fish stores in the $PWD variable)
+    # and then a user symbol - a '►' for a normal user and a '#' for root.
+    set -l user_char '►'
+    if fish_is_root_user
+        set user_char '#'
+    end
+
+    echo (set_color yellow)$PWD (set_color purple)$user_char
+end
+
+# From https://fishshell.com/docs/current/language.html#functions

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -28,6 +28,7 @@ export type Lang =
   | 'elm'
   | 'erb'
   | 'erlang'
+  | 'fish'
   | 'fsharp' | 'f#'
   | 'gherkin'
   | 'git-commit'
@@ -270,6 +271,11 @@ export const languages: ILanguageRegistration[] = [
     id: 'erlang',
     scopeName: 'source.erlang',
     path: 'erlang.tmLanguage.json'
+  },
+  {
+    id: 'fish',
+    scopeName: 'source.fish',
+    path: 'fish.tmLanguage.json'
   },
   {
     id: 'fsharp',

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -152,7 +152,8 @@ export const githubGrammarSources: (string | [string, string])[] = [
   'https://github.com/stardog-union/stardog-vsc/blob/master/stardog-rdf-grammars/syntaxes/sparql.tmLanguage.json',
   'https://github.com/prisma/language-tools/blob/master/packages/vscode/syntaxes/prisma.tmLanguage.json',
   'https://github.com/StoneCypher/sublime-jssm/blob/master/jssm.tmLanguage',
-  'https://github.com/gbasood/vscode-atomic-dreams/blob/master/syntaxes/dm.tmLanguage.json'
+  'https://github.com/gbasood/vscode-atomic-dreams/blob/master/syntaxes/dm.tmLanguage.json',
+  'https://github.com/bmalehorn/vscode-fish/blob/master/syntaxes/fish.tmLanguage.json'
 ]
 
 /**


### PR DESCRIPTION
This PR adds support for [fish shell](https://fishshell.com/) language.
```fish
function fish_prompt
    # A simple prompt. Displays the current directory
    # (which fish stores in the $PWD variable)
    # and then a user symbol - a '►' for a normal user and a '#' for root.
    set -l user_char '►'
    if fish_is_root_user
        set user_char '#'
    end

    echo (set_color yellow)$PWD (set_color purple)$user_char
end
```