### PR TITLE
feat: support web workers

### DIFF
--- a/packages/shiki/src/loader.ts
+++ b/packages/shiki/src/loader.ts
@@ -5,7 +5,7 @@ import type { IOnigLib, IRawGrammar, IRawTheme } from 'vscode-textmate'
 import type { IShikiTheme } from './types'
 
 export const isWebWorker =
-  typeof self !== 'undefined'&&
+  typeof self !== 'undefined' &&
   typeof self.WorkerGlobalScope !== 'undefined'
 
 export const isBrowser =

--- a/packages/shiki/src/loader.ts
+++ b/packages/shiki/src/loader.ts
@@ -4,10 +4,16 @@ import { join, dirname } from './utils'
 import type { IOnigLib, IRawGrammar, IRawTheme } from 'vscode-textmate'
 import type { IShikiTheme } from './types'
 
+export const isWebWorker =
+  typeof self !== 'undefined'&&
+  typeof self.WorkerGlobalScope !== 'undefined'
+
 export const isBrowser =
-  typeof window !== 'undefined' &&
-  typeof window.document !== 'undefined' &&
-  typeof fetch !== 'undefined'
+  isWebWorker || (
+    typeof window !== 'undefined' &&
+    typeof window.document !== 'undefined' &&
+    typeof fetch !== 'undefined'
+  )
 
 // to be replaced by rollup
 let CDN_ROOT = '__CDN_ROOT__'

--- a/packages/shiki/tsconfig.json
+++ b/packages/shiki/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2017",
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "lib": ["esnext", "DOM"],
+    "lib": ["esnext", "DOM", "WebWorker"],
     "sourceMap": true
   },
   "exclude": ["samples"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "lib": ["es2015", "es2016.array.include", "DOM"],
+    "lib": ["es2015", "es2016.array.include", "DOM", "WebWorker"],
     "sourceMap": true
   },
   "references": [{ "path": "packages/shiki" }, { "path": "packages/renderer-svg" }]


### PR DESCRIPTION
Resolves #188 

These changes aim to make `shiki` working in web workers :)

Side note : `WebWorker` is needed in `tsconfig.json` to make `WorkerGlobalScope` available on `self`.