### PR TITLE
Fix Vue template highlighting

### DIFF
--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -116,6 +116,7 @@ export type Lang =
   | 'vhdl'
   | 'viml'
   | 'vue'
+  | 'vue-html'
   | 'wasm'
   | 'wenyan' | '文言'
   | 'xml'
@@ -768,6 +769,11 @@ export const languages: ILanguageRegistration[] = [
     scopeName: 'source.vue',
     path: 'vue.tmLanguage.json',
     embeddedLangs: ['json', 'markdown', 'pug', 'haml', 'sass', 'scss', 'less', 'stylus', 'postcss', 'css', 'typescript', 'coffee', 'javascript']
+  },
+  {
+    id: 'vue-html',
+    scopeName: 'text.html.vue-html',
+    path: 'vue-html.tmLanguage.json'
   },
   {
     id: 'wasm',


### PR DESCRIPTION
For some reason `vue-html` isn't registered in languages, which causes `<template>` blocks in Vue files not being properly highlighted.

Adding this also enables highlighting a piece of Vue template directly (without having to nest it inside `<template>` as in SFCs).