### PR TITLE
Remove "const" from publicly exported enums

### DIFF
--- a/packages/shiki/src/stackElementMetadata.ts
+++ b/packages/shiki/src/stackElementMetadata.ts
@@ -40,7 +40,7 @@ export const enum TemporaryStandardTokenType {
   MetaEmbedded = 8
 }
 
-export const enum FontStyle {
+export enum FontStyle {
   NotSet = -1,
   None = 0,
   Italic = 1,


### PR DESCRIPTION
This makes it possible to use Shiki with projects that set the "isolatedModules" flag for improved compiler performance.

Closes #172