### PR TITLE
[css-variables] fix theme fg & bg

### DIFF
--- a/packages/shiki/src/__tests__/__snapshots__/cssVars.test.ts.snap
+++ b/packages/shiki/src/__tests__/__snapshots__/cssVars.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The theme with css-variables renders correctly 1`] = `
-"<pre class=\\"shiki\\" style=\\"background-color: #000002\\"><code><span class=\\"line\\"></span>
+"<pre class=\\"shiki\\" style=\\"background-color: var(--shiki-color-background)\\"><code><span class=\\"line\\"></span>
 <span class=\\"line\\"><span style=\\"color: var(--shiki-token-keyword)\\">import</span><span style=\\"color: var(--shiki-color-text)\\"> { getHighlighter } </span><span style=\\"color: var(--shiki-token-keyword)\\">from</span><span style=\\"color: var(--shiki-color-text)\\"> </span><span style=\\"color: var(--shiki-token-string-expression)\\">&#39;../index&#39;</span></span>
 <span class=\\"line\\"></span>
 <span class=\\"line\\"><span style=\\"color: var(--shiki-token-function)\\">test</span><span style=\\"color: var(--shiki-color-text)\\">(</span><span style=\\"color: var(--shiki-token-string-expression)\\">&#39;The theme with css-variables renders correctly&#39;</span><span style=\\"color: var(--shiki-token-punctuation)\\">,</span><span style=\\"color: var(--shiki-color-text)\\"> </span><span style=\\"color: var(--shiki-token-keyword)\\">async</span><span style=\\"color: var(--shiki-color-text)\\"> () </span><span style=\\"color: var(--shiki-token-keyword)\\">=&gt;</span><span style=\\"color: var(--shiki-color-text)\\"> {</span></span>

--- a/packages/shiki/src/highlighter.ts
+++ b/packages/shiki/src/highlighter.ts
@@ -77,7 +77,9 @@ export async function getHighlighter(options: HighlighterOptions): Promise<Highl
     '#000012': 'var(--shiki-token-link)'
   }
 
-  function fixCssVariablesColorMap(colorMap: string[]) {
+  function fixCssVariablesTheme(theme: IShikiTheme, colorMap: string[]) {
+    theme.bg = COLOR_REPLACEMENTS[theme.bg] || theme.bg
+    theme.fg = COLOR_REPLACEMENTS[theme.fg] || theme.fg
     colorMap.forEach((val, i) => {
       colorMap[i] = COLOR_REPLACEMENTS[val] || val
     })
@@ -94,7 +96,7 @@ export async function getHighlighter(options: HighlighterOptions): Promise<Highl
     }
     const _colorMap = _registry.getColorMap()
     if (_theme.name === 'css-variables') {
-      fixCssVariablesColorMap(_colorMap)
+      fixCssVariablesTheme(_theme, _colorMap)
     }
     return { _theme, _colorMap }
   }


### PR DESCRIPTION
Resolves #214 

While testing the latest changes in the Astro repo I uncovered a small bug in #212 where the `foreground` and `background` styles were not being applied. @tbeseda ran into the same in #214.

The fix is that foreground and background are managed separately, outside of the color map. This PR adds these two properties to the "fix" step. Tests also updated.