### PR TITLE
Add CodeChalk to `Seen` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Clone [shikijs/shiki-starter](https://github.com/shikijs/shiki-starter) to play 
 - [Blockstack Documentation](https://docs.blockstack.org/)
 - [VPC Shiki](https://github.com/Vap0r1ze/vpc-shiki), Shiki codeblocks on Discord. Powered by [Powercord](http://powercord.dev/)
 - [Torchlight](https://torchlight.dev/), a syntax highlighting API powered by the Shiki tokenizer.
+- [CodeChalk](https://github.com/a20185/codechalk), A neat terminal code highlighting tool powered by Shiki tokenizer and Chalk.
 
 ## Contributing
 


### PR DESCRIPTION
Hi @octref . We've implement a util based on shiki. It converts shiki tokenizer result to chalk calls, which enables syntax highlighting for outputing instruction codes in terminals.

I'm wondering if it's possible to add the tool to `Seen` part, thanks~