### PR TITLE
Bump Shiki version

### DIFF
--- a/packages/shiki/package.json
+++ b/packages/shiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shiki",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "shiki",
   "author": "Pine Wu <octref@gmail.com>",
   "homepage": "https://github.com/octref/shiki/tree/main/packages/shiki",


### PR DESCRIPTION
TypeDoc 0.22.3:

```
Debug: Loading Shiki took 1956ms
Debug: HTML rendering took 2243ms
```

Shiki makes up 87% of the time TypeDoc takes to render, I'm hoping #222 has helped the situation.