### PR TITLE
Handle token colors with multiple font styles

### DIFF
--- a/packages/shiki/src/__tests__/__snapshots__/multiFontStyle.test.ts.snap
+++ b/packages/shiki/src/__tests__/__snapshots__/multiFontStyle.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Handle multiple font styles 1`] = `"<pre class=\\"shiki\\" style=\\"background-color: #263238\\"><code><span class=\\"line\\"><span style=\\"color: #89DDFF; font-weight: bold\\">**</span><span style=\\"color: #89DDFF; font-style: italic; font-weight: bold\\">*</span><span style=\\"color: #F07178; font-style: italic; font-weight: bold\\">bold italic</span><span style=\\"color: #89DDFF; font-style: italic; font-weight: bold\\">*</span><span style=\\"color: #89DDFF; font-weight: bold\\">**</span></span></code></pre>"`;

--- a/packages/shiki/src/__tests__/multiFontStyle.test.ts
+++ b/packages/shiki/src/__tests__/multiFontStyle.test.ts
@@ -1,0 +1,9 @@
+import { getHighlighter } from '../index'
+
+test('Handle multiple font styles', async () => {
+  const highlighter = await getHighlighter({
+    theme: 'material-default'
+  })
+  const out = highlighter.codeToHtml(`***bold italic***`, 'md')
+  expect(out).toMatchSnapshot()
+})

--- a/packages/shiki/src/renderer.ts
+++ b/packages/shiki/src/renderer.ts
@@ -7,12 +7,6 @@ export interface HtmlRendererOptions {
   bg?: string
 }
 
-const FONT_STYLE_TO_CSS = {
-  [FontStyle.Italic]: 'font-style: italic',
-  [FontStyle.Bold]: 'font-weight: bold',
-  [FontStyle.Underline]: 'text-decoration: underline'
-}
-
 export function renderToHtml(lines: IThemedToken[][], options: HtmlRendererOptions = {}) {
   const bg = options.bg || '#fff'
 
@@ -29,8 +23,14 @@ export function renderToHtml(lines: IThemedToken[][], options: HtmlRendererOptio
 
     l.forEach(token => {
       const cssDeclarations = [`color: ${token.color || options.fg}`]
-      if (token.fontStyle > FontStyle.None) {
-        cssDeclarations.push(FONT_STYLE_TO_CSS[token.fontStyle])
+      if (token.fontStyle & FontStyle.Italic) {
+        cssDeclarations.push('font-style: italic')
+      }
+      if (token.fontStyle & FontStyle.Bold) {
+        cssDeclarations.push('font-weight: bold')
+      }
+      if (token.fontStyle & FontStyle.Underline) {
+        cssDeclarations.push('text-decoration: underline')
       }
       html += `<span style="${cssDeclarations.join('; ')}">${escapeHtml(token.content)}</span>`
     })


### PR DESCRIPTION
`FontStyle` is bitwise and themes can set multiple font styles simultaneously (e.g. https://github.com/theacodes/witchhazel/blob/5dc744fb0fb7210be1ccacc5863a5768644a8380/witchhazelhypercolor.tmTheme#L139-L151).

Tested locally with a converted version of Witch Hazel Hypercolor (as linked above).