### PR TITLE
Add `wrapperClasses` param to `codeToHtml`

### DIFF
--- a/packages/shiki/src/__tests__/__snapshots__/wrapper-classes.test.ts.snap
+++ b/packages/shiki/src/__tests__/__snapshots__/wrapper-classes.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`empty wrapperClasses omits <pre> class attribute 1`] = `"<pre style=\\"background-color: #2e3440ff\\"><code><span class=\\"line\\"><span style=\\"color: #D8DEE9\\">console</span><span style=\\"color: #ECEFF4\\">.</span><span style=\\"color: #88C0D0\\">log</span><span style=\\"color: #D8DEE9FF\\">(</span><span style=\\"color: #ECEFF4\\">&#39;</span><span style=\\"color: #A3BE8C\\">test</span><span style=\\"color: #ECEFF4\\">&#39;</span><span style=\\"color: #D8DEE9FF\\">)</span><span style=\\"color: #81A1C1\\">;</span></span></code></pre>"`;
+
+exports[`wrapperClasses parameter adds classes 1`] = `"<pre class=\\"foo bar\\" style=\\"background-color: #2e3440ff\\"><code><span class=\\"line\\"><span style=\\"color: #D8DEE9\\">console</span><span style=\\"color: #ECEFF4\\">.</span><span style=\\"color: #88C0D0\\">log</span><span style=\\"color: #D8DEE9FF\\">(</span><span style=\\"color: #ECEFF4\\">&#39;</span><span style=\\"color: #A3BE8C\\">test</span><span style=\\"color: #ECEFF4\\">&#39;</span><span style=\\"color: #D8DEE9FF\\">)</span><span style=\\"color: #81A1C1\\">;</span></span></code></pre>"`;

--- a/packages/shiki/src/__tests__/wrapper-classes.test.ts
+++ b/packages/shiki/src/__tests__/wrapper-classes.test.ts
@@ -1,0 +1,20 @@
+import { getHighlighter } from '../index'
+
+test('wrapperClasses parameter adds classes', async () => {
+  const highlighter = await getHighlighter({
+    theme: 'nord'
+  })
+
+  const out = highlighter.codeToHtml(`console.log('test');`, 'js', 'nord', ['foo', 'bar'])
+  expect(out).toMatchSnapshot()
+  expect(out).not.toContain('shiki')
+})
+
+test('empty wrapperClasses omits <pre> class attribute', async () => {
+  const highlighter = await getHighlighter({
+    theme: 'nord'
+  })
+  const out = highlighter.codeToHtml(`console.log('test');`, 'js', 'nord', [])
+  expect(out).toMatchSnapshot()
+  expect(out).not.toContain('<pre class=')
+})

--- a/packages/shiki/src/highlighter.ts
+++ b/packages/shiki/src/highlighter.ts
@@ -123,14 +123,20 @@ export async function getHighlighter(options: HighlighterOptions): Promise<Highl
     return tokenizeWithTheme(_theme, _colorMap, code, _grammer, options)
   }
 
-  function codeToHtml(code: string, lang = 'text', theme?: StringLiteralUnion<Theme>) {
+  function codeToHtml(
+    code: string,
+    lang = 'text',
+    theme?: StringLiteralUnion<Theme>,
+    wrapperClasses?: string[]
+  ) {
     const tokens = codeToThemedTokens(code, lang, theme, {
       includeExplanation: false
     })
     const { _theme } = getTheme(theme)
     return renderToHtml(tokens, {
       fg: _theme.fg,
-      bg: _theme.bg
+      bg: _theme.bg,
+      wrapperClasses
     })
   }
 

--- a/packages/shiki/src/renderer.ts
+++ b/packages/shiki/src/renderer.ts
@@ -5,6 +5,7 @@ export interface HtmlRendererOptions {
   langId?: string
   fg?: string
   bg?: string
+  wrapperClasses?: string[]
 }
 
 const FONT_STYLE_TO_CSS = {
@@ -15,10 +16,15 @@ const FONT_STYLE_TO_CSS = {
 
 export function renderToHtml(lines: IThemedToken[][], options: HtmlRendererOptions = {}) {
   const bg = options.bg || '#fff'
+  const classes = options.wrapperClasses || ['shiki']
 
   let html = ''
 
-  html += `<pre class="shiki" style="background-color: ${bg}">`
+  html += '<pre '
+  if (classes.length) {
+    html += `class="${classes.join(' ')}" `
+  }
+  html += `style="background-color: ${bg}">`
   if (options.langId) {
     html += `<div class="language-id">${options.langId}</div>`
   }

--- a/packages/shiki/src/types.ts
+++ b/packages/shiki/src/types.ts
@@ -33,11 +33,13 @@ export interface Highlighter {
   /**
    * Convert code to HTML tokens.
    * `lang` and `theme` must have been loaded.
+   * `wrapperClasses` defaults to ['shiki].
    */
   codeToHtml(
     code: string,
     lang?: StringLiteralUnion<Lang>,
-    theme?: StringLiteralUnion<Theme>
+    theme?: StringLiteralUnion<Theme>,
+    wrapperClasses?: string[]
   ): string
 
   /**


### PR DESCRIPTION
Related: #206 

### Motivation

Sometimes I'd like to add classes to Shiki's `<pre>` tag because my site uses utility classes (ala Tailwind). Additionally, it might be nice to opt-out of the `shiki` class in generated HTML.

### Implementation

I based this implementation on the suggestion in #206 and added an optional 4th param to `codeToHtml`: `wrapperClasses`.
Usage:
```js
const html = highlighter.codeToHtml(`console.log('test');`, 'js', 'nord', ['rounded-full', 'mx-auto'])
// <pre class="rounded-full mx-auto" style=...
```
And to remove all classes:
```js
const html = highlighter.codeToHtml(`console.log('test');`, 'js', 'nord', [])
// <pre style=...
```

### Drawbacks and Notes

1. The 3rd param for `codeToHtml` becomes required if the user wants to set classes with the 4th param 😐 
  i. passing an options object as the third param that could contain `theme` and `wrapperClasses` would be better, but that would be a breaking change to the API
1. If the user wants to keep the `shiki` class and add custom classes, they need to include "shiki"
  i. this seems fine to me and keeps the code simpler
1. I didn't include "extra win" from the original issue to add the theme name as a class
  i. this could be really helpful to target specific theme styles with CSS
  ii. Shiki could use a custom token in the array of classes: `['rounded-full', '$theme']`

Let me know what you think! Happy to make changes.