### PR TITLE
refactor: Make tests take less than half as long to run

### DIFF
--- a/packages/shiki/src/__tests__/background.test.ts
+++ b/packages/shiki/src/__tests__/background.test.ts
@@ -2,7 +2,8 @@ import { getHighlighter } from '../index'
 
 test(`Token with no color shouldn't generate color: undefined`, async () => {
   const highlighter = await getHighlighter({
-    theme: 'monokai'
+    theme: 'monokai',
+    langs: ['js']
   })
   const out = highlighter.codeToHtml(`whatever`, 'txt')
   expect(out).not.toContain('undefined')

--- a/packages/shiki/src/__tests__/comprehensive.test.ts
+++ b/packages/shiki/src/__tests__/comprehensive.test.ts
@@ -3,19 +3,24 @@ import { getHighlighter } from '../index'
 import { languages } from '../languages'
 
 describe('validates all themes run some JS', () => {
+  const highlighter = getHighlighter({ langs: ['js'] })
+
   themes.forEach(theme => {
     it(theme, async () => {
-      const highlighter = await getHighlighter({ theme })
-      highlighter.codeToHtml(`console.log('shiki');`, 'js')
+      const hl = await highlighter
+      await hl.loadTheme(theme)
+      hl.codeToHtml(`console.log('shiki');`, 'js')
     })
   })
 })
 
 describe('validates all languages can show a hello-world', () => {
+  const highlighter = getHighlighter({ theme: 'nord' })
+
   languages.forEach(language => {
     it(language.id, async () => {
-      const highlighter = await getHighlighter({ theme: 'nord' })
-      highlighter.codeToHtml(`console.log('shiki');`, language.id)
+      const hl = await highlighter
+      hl.codeToHtml(`console.log('shiki');`, language.id)
     })
   })
 })

--- a/packages/shiki/src/__tests__/cssVars.test.ts
+++ b/packages/shiki/src/__tests__/cssVars.test.ts
@@ -2,7 +2,8 @@ import { getHighlighter } from '../index'
 
 test('The theme with css-variables renders correctly', async () => {
   const highlighter = await getHighlighter({
-    theme: 'css-variables'
+    theme: 'css-variables',
+    langs: ['js']
   })
 
   const kindOfAQuine = `

--- a/packages/shiki/src/__tests__/multiFontStyle.test.ts
+++ b/packages/shiki/src/__tests__/multiFontStyle.test.ts
@@ -2,7 +2,8 @@ import { getHighlighter } from '../index'
 
 test('Handle multiple font styles', async () => {
   const highlighter = await getHighlighter({
-    theme: 'material-default'
+    theme: 'material-default',
+    langs: ['md']
   })
   const out = highlighter.codeToHtml(`***bold italic***`, 'md')
   expect(out).toMatchSnapshot()

--- a/packages/shiki/src/__tests__/simple.test.ts
+++ b/packages/shiki/src/__tests__/simple.test.ts
@@ -2,7 +2,8 @@ import { getHighlighter } from '../index'
 
 test('Nord highlighter highlights simple JavaScript', async () => {
   const highlighter = await getHighlighter({
-    theme: 'nord'
+    theme: 'nord',
+    langs: ['js']
   })
   const out = highlighter.codeToHtml(`console.log('shiki');`, 'js')
   expect(out).toMatchSnapshot()


### PR DESCRIPTION
There's no need for the tests to load things that they don't need, or repeatedly load the same grammars and themes again and again...

- [x] Add a test if possible
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

```
Tests:       160 passed, 160 total
Snapshots:   7 passed, 7 total
Time:        10.297 s, estimated 28 s
```
