### PR TITLE
chore: bump shiki version number

### DIFF
--- a/packages/shiki/package.json
+++ b/packages/shiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shiki",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "shiki",
   "author": "Pine Wu <octref@gmail.com>",
   "homepage": "https://github.com/octref/shiki/tree/main/packages/shiki",


### PR DESCRIPTION
So that the fix to gh-219 gets released. @Gerrit0 recommended I do this.

- [ N/A ] Add a test if possible
- [ X ] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
