### PR TITLE
docs: update astro grammar url

### DIFF
--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -154,7 +154,7 @@ export const githubGrammarSources: (string | [string, string])[] = [
   'https://github.com/StoneCypher/sublime-jssm/blob/master/jssm.tmLanguage',
   'https://github.com/gbasood/vscode-atomic-dreams/blob/master/syntaxes/dm.tmLanguage.json',
   'https://github.com/bmalehorn/vscode-fish/blob/master/syntaxes/fish.tmLanguage.json',
-  'https://github.com/snowpackjs/astro/blob/main/tools/vscode/syntaxes/astro.tmLanguage.json',
+  'https://github.com/withastro/astro/blob/main/tools/vscode/syntaxes/astro.tmLanguage.json',
   ['csharp', 'https://github.com/dotnet/csharp-tmLanguage/blob/main/grammars/csharp.tmLanguage'],
   [
     'ballerina',


### PR DESCRIPTION
- [X] I have read docs for [adding a language](/docs/languages.md#adding-grammar).
- [X] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [X] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](/docs/languages.md#adding-grammar) for requirement.

We updated the Astro org name which means we now have a new URL. I ran ` yarn update:grammars ` and confirmed no other changes were needed!