### PR TITLE
Deprecate the codeToHtml(code, lang?, theme?) overload in favor of codeToHtml(code, options?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ shiki
     theme: 'nord'
   })
   .then(highlighter => {
-    console.log(highlighter.codeToHtml(`console.log('shiki');`, 'js'))
+    console.log(highlighter.codeToHtml(`console.log('shiki');`, { lang: 'js' }))
   })
 
 // <pre class="shiki" style="background-color: #2e3440"><code>
@@ -36,7 +36,7 @@ shiki
       theme: 'nord'
     })
     .then(highlighter => {
-      const code = highlighter.codeToHtml(`console.log('shiki');`, 'js')
+      const code = highlighter.codeToHtml(`console.log('shiki');`, { lang: 'js' })
       document.getElementById('output').innerHTML = code
     })
 </script>

--- a/packages/shiki/README.md
+++ b/packages/shiki/README.md
@@ -20,7 +20,7 @@ shiki
     theme: 'nord'
   })
   .then(highlighter => {
-    console.log(highlighter.codeToHtml(`console.log('shiki');`, 'js'))
+    console.log(highlighter.codeToHtml(`console.log('shiki');`, { lang: 'js' }))
   })
 
 // <pre class="shiki" style="background-color: #2e3440"><code>
@@ -36,7 +36,7 @@ shiki
       theme: 'nord'
     })
     .then(highlighter => {
-      const code = highlighter.codeToHtml(`console.log('shiki');`, 'js')
+      const code = highlighter.codeToHtml(`console.log('shiki');`, { lang: 'js' })
       document.getElementById('output').innerHTML = code
     })
 </script>

--- a/packages/shiki/src/__tests__/__snapshots__/deprecatedOverloads.test.ts.snap
+++ b/packages/shiki/src/__tests__/__snapshots__/deprecatedOverloads.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Nord highlighter highlights simple JavaScript using deprecated codeToHtml(code, lang?, theme?) overload 1`] = `"<pre class=\\"shiki\\" style=\\"background-color: #2e3440ff\\"><code><span class=\\"line\\"><span style=\\"color: #D8DEE9\\">console</span><span style=\\"color: #ECEFF4\\">.</span><span style=\\"color: #88C0D0\\">log</span><span style=\\"color: #D8DEE9FF\\">(</span><span style=\\"color: #ECEFF4\\">&#39;</span><span style=\\"color: #A3BE8C\\">shiki</span><span style=\\"color: #ECEFF4\\">&#39;</span><span style=\\"color: #D8DEE9FF\\">)</span><span style=\\"color: #81A1C1\\">;</span></span></code></pre>"`;

--- a/packages/shiki/src/__tests__/background.test.ts
+++ b/packages/shiki/src/__tests__/background.test.ts
@@ -5,6 +5,6 @@ test(`Token with no color shouldn't generate color: undefined`, async () => {
     theme: 'monokai',
     langs: ['js']
   })
-  const out = highlighter.codeToHtml(`whatever`, 'txt')
+  const out = highlighter.codeToHtml(`whatever`, { lang: 'txt' })
   expect(out).not.toContain('undefined')
 })

--- a/packages/shiki/src/__tests__/comprehensive.test.ts
+++ b/packages/shiki/src/__tests__/comprehensive.test.ts
@@ -9,7 +9,7 @@ describe('validates all themes run some JS', () => {
     it(theme, async () => {
       const hl = await highlighter
       await hl.loadTheme(theme)
-      hl.codeToHtml(`console.log('shiki');`, 'js')
+      hl.codeToHtml(`console.log('shiki');`, { lang: 'js' })
     })
   })
 })
@@ -20,7 +20,7 @@ describe('validates all languages can show a hello-world', () => {
   languages.forEach(language => {
     it(language.id, async () => {
       const hl = await highlighter
-      hl.codeToHtml(`console.log('shiki');`, language.id)
+      hl.codeToHtml(`console.log('shiki');`, { lang: language.id })
     })
   })
 })

--- a/packages/shiki/src/__tests__/cssVars.test.ts
+++ b/packages/shiki/src/__tests__/cssVars.test.ts
@@ -18,6 +18,6 @@ test('The theme with css-variables renders correctly', async () => {
 })
 `
 
-  const out = highlighter.codeToHtml(kindOfAQuine, 'js')
+  const out = highlighter.codeToHtml(kindOfAQuine, { lang: 'js' })
   expect(out).toMatchSnapshot()
 })

--- a/packages/shiki/src/__tests__/custom-language/customLanguage.test.ts
+++ b/packages/shiki/src/__tests__/custom-language/customLanguage.test.ts
@@ -20,7 +20,7 @@ test('Highlights custom language - Rockstar', async () => {
   })
 
   const code = readFileSync(currentDirPath('rockstar.rock'), 'utf-8')
-  const out = highlighter.codeToHtml(code, 'rockstar')
+  const out = highlighter.codeToHtml(code, { lang: 'rockstar' })
   expect(out).toMatchSnapshot()
 })
 
@@ -44,7 +44,7 @@ test('Multiple custom language registrations should use last one', async () => {
   })
 
   const code = readFileSync(currentDirPath('rockstar.rock'), 'utf-8')
-  const out = highlighter.codeToHtml(code, 'rockstar')
+  const out = highlighter.codeToHtml(code, { lang: 'rockstar' })
   expect(out).toMatchSnapshot()
 })
 
@@ -62,6 +62,6 @@ test('Custom language registration can override builtin language', async () => {
   })
 
   const code = readFileSync(currentDirPath('rockstar.rock'), 'utf-8')
-  const out = highlighter.codeToHtml(code, 'html')
+  const out = highlighter.codeToHtml(code, { lang: 'html' })
   expect(out).toMatchSnapshot('rockstar')
 })

--- a/packages/shiki/src/__tests__/deprecatedOverloads.test.ts
+++ b/packages/shiki/src/__tests__/deprecatedOverloads.test.ts
@@ -1,0 +1,10 @@
+import { getHighlighter } from '../index'
+
+test('Nord highlighter highlights simple JavaScript using deprecated codeToHtml(code, lang?, theme?) overload', async () => {
+  const highlighter = await getHighlighter({
+    theme: 'nord',
+    langs: ['js']
+  })
+  const out = highlighter.codeToHtml(`console.log('shiki');`, 'js')
+  expect(out).toMatchSnapshot()
+})

--- a/packages/shiki/src/__tests__/multiFontStyle.test.ts
+++ b/packages/shiki/src/__tests__/multiFontStyle.test.ts
@@ -5,6 +5,6 @@ test('Handle multiple font styles', async () => {
     theme: 'material-default',
     langs: ['md']
   })
-  const out = highlighter.codeToHtml(`***bold italic***`, 'md')
+  const out = highlighter.codeToHtml(`***bold italic***`, { lang: 'md' })
   expect(out).toMatchSnapshot()
 })

--- a/packages/shiki/src/__tests__/simple.test.ts
+++ b/packages/shiki/src/__tests__/simple.test.ts
@@ -5,6 +5,6 @@ test('Nord highlighter highlights simple JavaScript', async () => {
     theme: 'nord',
     langs: ['js']
   })
-  const out = highlighter.codeToHtml(`console.log('shiki');`, 'js')
+  const out = highlighter.codeToHtml(`console.log('shiki');`, { lang: 'js' })
   expect(out).toMatchSnapshot()
 })

--- a/packages/shiki/src/highlighter.ts
+++ b/packages/shiki/src/highlighter.ts
@@ -1,6 +1,7 @@
 import type {
   Highlighter,
   HighlighterOptions,
+  HtmlOptions,
   ILanguageRegistration,
   IShikiTheme,
   IThemeRegistration,
@@ -123,11 +124,35 @@ export async function getHighlighter(options: HighlighterOptions): Promise<Highl
     return tokenizeWithTheme(_theme, _colorMap, code, _grammar, options)
   }
 
-  function codeToHtml(code: string, lang = 'text', theme?: IThemeRegistration) {
-    const tokens = codeToThemedTokens(code, lang, theme, {
+  function codeToHtml(code: string, options?: HtmlOptions): string
+  function codeToHtml(
+    code: string,
+    lang?: StringLiteralUnion<Lang>,
+    theme?: StringLiteralUnion<Theme>
+  ): string
+  function codeToHtml(
+    code: string,
+    arg1: StringLiteralUnion<Lang> | HtmlOptions = 'text',
+    arg2?: StringLiteralUnion<Theme>
+  ) {
+    let options: HtmlOptions
+
+    // codeToHtml(code, options?) overload
+    if (typeof arg1 === 'object') {
+      options = arg1
+    }
+    // codeToHtml(code, lang?, theme?) overload
+    else {
+      options = {
+        lang: arg1,
+        theme: arg2
+      }
+    }
+
+    const tokens = codeToThemedTokens(code, options.lang, options.theme, {
       includeExplanation: false
     })
-    const { _theme } = getTheme(theme)
+    const { _theme } = getTheme(options.theme)
     return renderToHtml(tokens, {
       fg: _theme.fg,
       bg: _theme.bg

--- a/packages/shiki/src/types.ts
+++ b/packages/shiki/src/types.ts
@@ -33,12 +33,19 @@ export interface Highlighter {
   /**
    * Convert code to HTML tokens.
    * `lang` and `theme` must have been loaded.
+   * @deprecated Please use the `codeToHtml(code, options?)` overload instead.
    */
   codeToHtml(
     code: string,
     lang?: StringLiteralUnion<Lang>,
     theme?: StringLiteralUnion<Theme>
   ): string
+
+  /**
+   * Convert code to HTML tokens.
+   * `lang` and `theme` must have been loaded.
+   */
+  codeToHtml(code: string, options?: HtmlOptions): string
 
   /**
    * Convert code to themed tokens for custom processing.
@@ -174,6 +181,11 @@ export interface IShikiTheme extends IRawTheme {
  * Adapted from https://github.com/microsoft/TypeScript/issues/29729
  */
 export type StringLiteralUnion<T extends U, U = string> = T | (U & {})
+
+export interface HtmlOptions {
+  lang?: StringLiteralUnion<Lang>
+  theme?: StringLiteralUnion<Theme>
+}
 
 export interface ThemedTokenizerOptions {
   /**

--- a/packages/site/gen-custom-theme.js
+++ b/packages/site/gen-custom-theme.js
@@ -18,7 +18,7 @@ shiki
   .then(highlighter => {
     const md = markdown({
       highlight: (code, lang) => {
-        return highlighter.codeToHtml(code, lang)
+        return highlighter.codeToHtml(code, { lang })
       }
     })
 

--- a/packages/site/gen-index.js
+++ b/packages/site/gen-index.js
@@ -10,7 +10,7 @@ shiki
     const md = markdown({
       html: true,
       highlight: (code, lang) => {
-        return highlighter.codeToHtml(code, lang)
+        return highlighter.codeToHtml(code, { lang })
       }
     })
 

--- a/packages/site/gen-mono.js
+++ b/packages/site/gen-mono.js
@@ -9,7 +9,7 @@ shiki
   .then(highlighter => {
     const md = markdown({
       highlight: (code, lang) => {
-        return highlighter.codeToHtml(code, lang)
+        return highlighter.codeToHtml(code, { lang })
       }
     })
 

--- a/packages/site/gen-palenight.js
+++ b/packages/site/gen-palenight.js
@@ -9,7 +9,7 @@ shiki
   .then(highlighter => {
     const md = markdown({
       highlight: (code, lang) => {
-        return highlighter.codeToHtml(code, lang)
+        return highlighter.codeToHtml(code, { lang })
       }
     })
 

--- a/packages/site/gen-wenyan.js
+++ b/packages/site/gen-wenyan.js
@@ -8,7 +8,7 @@ const shiki = require('shiki')
 
   const code = fs.readFileSync('beer.wy', 'utf-8')
 
-  const html = highlighter.codeToHtml(code, '文言')
+  const html = highlighter.codeToHtml(code, { lang: '文言' })
 
   fs.writeFileSync('文言.html', html)
 

--- a/packages/site/index.md
+++ b/packages/site/index.md
@@ -12,7 +12,7 @@ const shiki = require('shiki')
 shiki.getHighlighter({
   theme: 'nord'
 }).then(highlighter => {
-  console.log(highlighter.codeToHtml(`console.log('shiki');`, 'js'))
+  console.log(highlighter.codeToHtml(`console.log('shiki');`, { lang: 'js' }))
 })
 
 // <pre class="shiki" style="background-color: #2e3440"><code>
@@ -33,7 +33,7 @@ shiki.getHighlighter({
   const md = markdown({
     html: true,
     highlight: (code, lang) => {
-      return highlighter.codeToHtml(code, lang)
+      return highlighter.codeToHtml(code, { lang })
     }
   })
 
@@ -92,7 +92,7 @@ shiki.getHighlighter({
     }
   ]
 }).then(highlighter => {
-  highlighter.codeToHtml('Shout Rockstar', 'rockstar')
+  highlighter.codeToHtml('Shout Rockstar', { lang: 'rockstar' })
 })
 ```
 

--- a/packages/vuepress-plugin/index.js
+++ b/packages/vuepress-plugin/index.js
@@ -16,7 +16,7 @@ module.exports = (options, ctx) => {
         if (!lang) {
           return `<pre><code>${escapeHtml(code)}</code></pre>`
         }
-        return h.codeToHtml(code, lang)
+        return h.codeToHtml(code, { lang })
       })
     }
   }


### PR DESCRIPTION
Deprecate the `codeToHtml(code, lang?, theme?)` overload in favor of `codeToHtml(code, options?)`. For the discussion about this PR, please see #260.