### PR TITLE
chore: Bump Shiki version to 0.9.13

### DIFF
--- a/packages/shiki/package.json
+++ b/packages/shiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shiki",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "shiki",
   "author": "Pine Wu <octref@gmail.com>",
   "homepage": "https://github.com/octref/shiki/tree/main/packages/shiki",


### PR DESCRIPTION
Release includes:

- Updated grammars / themes
- fix: Update oniguruma to version used by VSCode 
- fix typo: grammer -> grammar (technically a breaking change, but it doesn't look like anyone uses it, so I left this as a patch release)