### PR TITLE
fix minimus theme name

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -99,6 +99,7 @@ export type Theme =
   | 'material-palenight'
   | 'min-dark'
   | 'min-light'
+  | 'minimus'
   | 'monokai'
   | 'nord'
   | 'one-dark-pro'
@@ -107,7 +108,6 @@ export type Theme =
   | 'slack-ochin'
   | 'solarized-dark'
   | 'solarized-light'
-  | 'spaceinvadev'
   | 'vitesse-dark'
   | 'vitesse-light'
 ```

--- a/packages/shiki/src/themes.ts
+++ b/packages/shiki/src/themes.ts
@@ -15,6 +15,7 @@ export type Theme =
   | 'material-palenight'
   | 'min-dark'
   | 'min-light'
+  | 'minimus'
   | 'monokai'
   | 'nord'
   | 'one-dark-pro'
@@ -23,7 +24,6 @@ export type Theme =
   | 'slack-ochin'
   | 'solarized-dark'
   | 'solarized-light'
-  | 'spaceinvadev'
   | 'vitesse-dark'
   | 'vitesse-light'
 
@@ -44,6 +44,7 @@ export const themes: Theme[] = [
   'material-palenight',
   'min-dark',
   'min-light',
+  'minimus',
   'monokai',
   'nord',
   'one-dark-pro',
@@ -52,7 +53,6 @@ export const themes: Theme[] = [
   'slack-ochin',
   'solarized-dark',
   'solarized-light',
-  'spaceinvadev',
   'vitesse-dark',
   'vitesse-light'
 ]

--- a/packages/shiki/themes/minimus.json
+++ b/packages/shiki/themes/minimus.json
@@ -1,5 +1,5 @@
 {
-  "name": "spaceinvadev",
+  "name": "minimus",
   "type": "light",
   "tokenColors": [
     {

--- a/scripts/themeSources.ts
+++ b/scripts/themeSources.ts
@@ -62,7 +62,7 @@ export const githubThemeSources: (string | [string, string])[] = [
     'https://github.com/drcmda/poimandres-theme/blob/main/themes/poimandres-color-theme.json'
   ],
   [
-    'spaceinvadev',
+    'minimus',
     'https://github.com/spaceinvadev/minimus-vscode-theme/blob/main/themes/minimus-color-theme.json'
   ],
   [


### PR DESCRIPTION
Updating the name of the "minimus" theme. It was previously added with the wrong name ("spaceinvadev").