### PR TITLE
fix: updated astro grammar source

### DIFF
--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -157,7 +157,7 @@ export const githubGrammarSources: (string | [string, string])[] = [
   'https://github.com/StoneCypher/sublime-jssm/blob/master/jssm.tmLanguage',
   'https://github.com/gbasood/vscode-atomic-dreams/blob/master/syntaxes/dm.tmLanguage.json',
   'https://github.com/bmalehorn/vscode-fish/blob/master/syntaxes/fish.tmLanguage.json',
-  'https://github.com/withastro/astro/blob/main/tools/vscode/syntaxes/astro.tmLanguage.json',
+  'https://github.com/withastro/language-tools/blob/main/packages/vscode/syntaxes/astro.tmLanguage.json',
   ['csharp', 'https://github.com/dotnet/csharp-tmLanguage/blob/main/grammars/csharp.tmLanguage'],
   [
     'ballerina',


### PR DESCRIPTION
- [ ] Add a test if possible
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

<!-- If adding a language -->

- [x] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.