### PR TITLE
Split plaintext code into lines

### DIFF
--- a/packages/shiki/src/__tests__/__snapshots__/lineOptions.test.ts.snap
+++ b/packages/shiki/src/__tests__/__snapshots__/lineOptions.test.ts.snap
@@ -23,3 +23,8 @@ exports[`ignores line numbers out of range 1`] = `
 <span class=\\"line highlighted\\"><span style=\\"color: var(--shiki-token-constant)\\">console</span><span style=\\"color: var(--shiki-token-function)\\">.log</span><span style=\\"color: var(--shiki-color-text)\\">(</span><span style=\\"color: var(--shiki-token-string-expression)\\">&#39;line 2&#39;</span><span style=\\"color: var(--shiki-color-text)\\">);</span></span>
 <span class=\\"line\\"><span style=\\"color: var(--shiki-token-constant)\\">console</span><span style=\\"color: var(--shiki-token-function)\\">.log</span><span style=\\"color: var(--shiki-color-text)\\">(</span><span style=\\"color: var(--shiki-token-string-expression)\\">&#39;line 3&#39;</span><span style=\\"color: var(--shiki-color-text)\\">);</span></span></code></pre>"
 `;
+
+exports[`splits plaintext into lines 1`] = `
+"<pre class=\\"shiki\\" style=\\"background-color: var(--shiki-color-background)\\"><code><span class=\\"line highlighted\\"><span style=\\"color: var(--shiki-color-text)\\">lorem ipsum</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-text)\\">dolor sit amet</span></span></code></pre>"
+`;

--- a/packages/shiki/src/__tests__/lineOptions.test.ts
+++ b/packages/shiki/src/__tests__/lineOptions.test.ts
@@ -18,6 +18,23 @@ console.log('line 2');
   expect(html).toMatchSnapshot()
 })
 
+test('splits plaintext into lines', async () => {
+  const highlighter = await getHighlighter({
+    theme: 'css-variables'
+  })
+
+  const code = `
+lorem ipsum
+dolor sit amet
+`.trim()
+
+  const html = highlighter.codeToHtml(code, {
+    lang: 'txt',
+    lineOptions: [{ line: 1, classes: ['highlighted'] }]
+  })
+  expect(html).toMatchSnapshot()
+})
+
 test('applies different classes to different lines', async () => {
   const highlighter = await getHighlighter({
     theme: 'css-variables',

--- a/packages/shiki/src/highlighter.ts
+++ b/packages/shiki/src/highlighter.ts
@@ -117,7 +117,8 @@ export async function getHighlighter(options: HighlighterOptions): Promise<Highl
     options = { includeExplanation: true }
   ) {
     if (isPlaintext(lang)) {
-      return [[{ content: code }]]
+      const lines = code.split(/\r\n|\r|\n/)
+      return [...lines.map(line => [{ content: line }])]
     }
     const { _grammar } = getGrammar(lang)
     const { _theme, _colorMap } = getTheme(theme)


### PR DESCRIPTION
- [x] Add a test if possible
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

Currently it isn't possible to highlight lines in `txt` code blocks because the entire code is being treated as a single line. This changes makes the highlighter respect line breaks.
