### PR TITLE
Add ZenScript support

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -183,4 +183,5 @@ export type Lang =
   | 'xml'
   | 'xsl'
   | 'yaml'
+  | 'zenscript'
 ```

--- a/packages/shiki/languages/zenscript.tmLanguage.json
+++ b/packages/shiki/languages/zenscript.tmLanguage.json
@@ -1,0 +1,254 @@
+{
+  "fileTypes": ["zs"],
+  "name": "zenscript",
+  "patterns": [
+    {
+      "comment": "numbers",
+      "name": "constant.numeric.zenscript",
+      "match": "\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\\b"
+    },
+    {
+      "comment": "prefixedNumbers",
+      "name": "constant.numeric.zenscript",
+      "match": "\\b\\-?(0b|0x|0o|0B|0X|0O)(0|[1-9a-fA-F][0-9a-fA-F_]*)[a-zA-Z_]*\\b"
+    },
+    {
+      "include": "#code"
+    },
+    {
+      "comment": "arrays",
+      "name": "storage.type.object.array.zenscript",
+      "match": "\\b((?:[a-z]\\w*\\.)*[A-Z]+\\w*)(?=\\[)"
+    }
+  ],
+  "repository": {
+    "code": {
+      "patterns": [
+        {
+          "include": "#class"
+        },
+        {
+          "include": "#functions"
+        },
+        {
+          "include": "#dots"
+        },
+        {
+          "include": "#quotes"
+        },
+        {
+          "include": "#brackets"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#var"
+        },
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#operators"
+        }
+      ]
+    },
+    "class": {
+      "comment": "class",
+      "name": "meta.class.zenscript",
+      "match": "(zenClass)\\s+(\\w+)",
+      "captures": {
+        "1": {
+          "name": "storage.type.zenscript"
+        },
+        "2": {
+          "name": "entity.name.type.class.zenscript"
+        }
+      }
+    },
+    "functions": {
+      "comment": "functions",
+      "name": "meta.function.zenscript",
+      "match": "function\\s+([A-Za-z_$][\\w$]*)\\s*(?=\\()",
+      "captures": {
+        "0": {
+          "name": "storage.type.function.zenscript"
+        },
+        "1": {
+          "name": "entity.name.function.zenscript"
+        }
+      }
+    },
+    "dots": {
+      "comment": "dots",
+      "name": "plain.text.zenscript",
+      "match": "\\b(\\w+)(\\.)(\\w+)((\\.)(\\w+))*",
+      "captures": {
+        "1": {
+          "name": "storage.type.zenscript"
+        },
+        "2": {
+          "name": "keyword.control.zenscript"
+        },
+        "5": {
+          "name": "keyword.control.zenscript"
+        }
+      }
+    },
+    "quotes": {
+      "patterns": [
+        {
+          "begin": "\"",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.zenscript"
+            }
+          },
+          "end": "\"",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.zenscript"
+            }
+          },
+          "name": "string.quoted.double.zenscript",
+          "patterns": [
+            {
+              "match": "\\\\.",
+              "name": "constant.character.escape.zenscript"
+            }
+          ]
+        },
+        {
+          "begin": "'",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.zenscript"
+            }
+          },
+          "end": "'",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.zenscript"
+            }
+          },
+          "name": "string.quoted.single.zenscript",
+          "patterns": [
+            {
+              "match": "\\\\.",
+              "name": "constant.character.escape.zenscript"
+            }
+          ]
+        }
+      ]
+    },
+    "brackets": {
+      "patterns": [
+        {
+          "comment": "items and blocks",
+          "name": "keyword.other.zenscript",
+          "match": "(<)\\b(.*?)(:(.*?(:(\\*|\\d+)?)?)?)(>)",
+          "captures": {
+            "1": {
+              "name": "keyword.control.zenscript"
+            },
+            "2": {
+              "name": "keyword.other.zenscript"
+            },
+            "3": {
+              "name": "keyword.control.zenscript"
+            },
+            "4": {
+              "name": "variable.other.zenscript"
+            },
+            "5": {
+              "name": "keyword.control.zenscript"
+            },
+            "6": {
+              "name": "constant.numeric.zenscript"
+            },
+            "7": {
+              "name": "keyword.control.zenscript"
+            }
+          }
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "comment": "inline comments",
+          "name": "comment.line.double=slash",
+          "match": "//[^\n]*"
+        },
+        {
+          "comment": "block comments",
+          "name": "comment.block",
+          "begin": "\\/\\*",
+          "beginCaptures": {
+            "0": {
+              "name": "comment.block"
+            }
+          },
+          "end": "\\*\\/",
+          "endCaptures": {
+            "0": {
+              "name": "comment.block"
+            }
+          }
+        }
+      ]
+    },
+    "var": {
+      "comment": "var",
+      "match": "\\b(val|var)\\b",
+      "name": "storage.type"
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "comment": "statement keywords",
+          "name": "keyword.control.zenscript",
+          "match": "\\b(instanceof|get|implements|set|import|function|override|const|if|else|do|while|for|throw|panic|lock|try|catch|finally|return|break|continue|switch|case|default|in|is|as|match|throws|super|new)\\b"
+        },
+        {
+          "comment": "storage keywords",
+          "name": "storage.type.zenscript",
+          "match": "\\b(zenClass|zenConstructor|alias|class|interface|enum|struct|expand|variant|set|void|bool|byte|sbyte|short|ushort|int|uint|long|ulong|usize|float|double|char|string)\\b"
+        },
+        {
+          "comment": "modifier keywords",
+          "name": "storage.modifier.zenscript",
+          "match": "\\b(variant|abstract|final|private|public|export|internal|static|protected|implicit|virtual|extern|immutable)\\b"
+        },
+        {
+          "comment": "annotation keywords",
+          "name": "entity.other.attribute-name",
+          "match": "\\b(Native|Precondition)\\b"
+        },
+        {
+          "comment": "language keywords",
+          "name": "constant.language",
+          "match": "\\b(null|true|false)\\b"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "comment": "math operators",
+          "name": "keyword.control",
+          "match": "\\b(\\.|\\.\\.|\\.\\.\\.|,|\\+|\\+=|\\+\\+|-|-=|--|~|~=|\\*|\\*=|/|/=|%|%=|\\||\\|=|\\|\\||&|&=|&&|\\^|\\^=|\\?|\\?\\.|\\?\\?|<|<=|<<|<<=|>|>=|>>|>>=|>>>|>>>=|=>|=|==|===|!|!=|!==|\\$|`)\\b"
+        },
+        {
+          "comment": "colons",
+          "name": "keyword.control",
+          "match": "\\b(;|:)\\b"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.zenscript"
+}

--- a/packages/shiki/samples/zenscript.sample
+++ b/packages/shiki/samples/zenscript.sample
@@ -1,0 +1,44 @@
+import crafttweaker.api.BracketHandlers;
+
+val air = <item:minecraft:air>;
+val diamond = <item:minecraft:diamond>;
+var woodTypes = ["oak","spruce","birch","jungle","acacia","dark_oak"];
+
+for name in woodTypes {
+    val thing = BracketHandlers.getItem("minecraft:" + name + "_planks");
+    craftingTable.addShaped(name + "_diamond", diamond, [[air, thing], [thing, air]]);
+}
+
+function checkLeapYear(year as int) as bool {
+    if(year % 4 == 0) {
+        if(year % 100 == 0) {
+            if(year % 400 == 0) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return true;
+        }
+    } else {
+        return false;
+    }
+}
+
+print("Is 2000 a leap year: " ~ checkLeapYear(2000));
+print("Is 2004 a leap year: " ~ checkLeapYear(2004));
+print("Is 2100 a leap year: " ~ checkLeapYear(2100));
+print("Is 2012 a leap year: " ~ checkLeapYear(2012));
+
+
+//Note: this is a cleaner way
+function checkLeapYear2(year as int) as bool {
+    return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+}
+
+print("Is 2000 a leap year (2nd function): " ~ checkLeapYear2(2000));
+print("Is 2004 a leap year (2nd function): " ~ checkLeapYear2(2004));
+print("Is 2100 a leap year (2nd function): " ~ checkLeapYear2(2100));
+print("Is 2012 a leap year (2nd function): " ~ checkLeapYear2(2012));
+
+# From https://github.com/CraftTweaker/CraftTweaker-Examples

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -133,6 +133,7 @@ export type Lang =
   | 'xml'
   | 'xsl'
   | 'yaml'
+  | 'zenscript'
 
 export const languages: ILanguageRegistration[] = [
   {
@@ -909,5 +910,11 @@ export const languages: ILanguageRegistration[] = [
     id: 'yaml',
     scopeName: 'source.yaml',
     path: 'yaml.tmLanguage.json'
+  },
+  {
+    id: 'zenscript',
+    scopeName: 'source.zenscript',
+    path: 'zenscript.tmLanguage.json',
+    samplePath: 'zenscript.sample'
   }
 ]

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -171,7 +171,11 @@ export const githubGrammarSources: (string | [string, string])[] = [
     'https://github.com/berry-lang/berry/blob/master/tools/plugins/vscode/skiars.berry-0.1.0/syntaxes/berry.json'
   ],
   'https://github.com/kylebarron/language-stata/blob/vscode/grammars/stata.json',
-  'https://github.com/relationalai-oss/rel_vscode/blob/master/syntaxes/rel.tmLanguage.json'
+  'https://github.com/relationalai-oss/rel_vscode/blob/master/syntaxes/rel.tmLanguage.json',
+  [
+    'zenscript',
+    'https://github.com/CraftTweaker/ZenScript-tmLanguage/blob/master/zenscript.tmLanguage.json'
+  ]
 ]
 
 /**


### PR DESCRIPTION
ZenScript is a scripting language for Java. It is primarily used by [CraftTweaker](https://github.com/CraftTweaker/CraftTweaker), which is a Minecraft mod that allows users to change many aspects of the game using scripts.

- [x] Add a test if possible
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

- [x] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [x] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [x] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.