### PR TITLE
[Vuepress plugin] Support additional language registration

### DIFF
--- a/packages/vuepress-plugin/index.js
+++ b/packages/vuepress-plugin/index.js
@@ -1,14 +1,21 @@
 const shiki = require('shiki')
 
-let h
+let hl
 
 module.exports = (options, ctx) => {
   return {
     async ready() {
-      h = await shiki.getHighlighter({
+      hl = await shiki.getHighlighter({
         theme: options.theme ? options.theme : 'nord',
         langs: options.langs ? options.langs : []
       })
+
+      // load additional languages
+      if (options.additionalLangs) {
+        for (langRegist in additionalLangs) {
+          await hl.loadLanguage(langRegist)
+        }
+      }
     },
 
     chainMarkdown(config) {
@@ -16,7 +23,7 @@ module.exports = (options, ctx) => {
         if (!lang) {
           return `<pre><code>${escapeHtml(code)}</code></pre>`
         }
-        return h.codeToHtml(code, { lang })
+        return hl.codeToHtml(code, { lang })
       })
     }
   }

--- a/packages/vuepress-plugin/index.js
+++ b/packages/vuepress-plugin/index.js
@@ -12,7 +12,7 @@ module.exports = (options, ctx) => {
 
       // load additional languages
       if (options.additionalLangs) {
-        for (langRegist in additionalLangs) {
+        for (langRegist of options.additionalLangs) {
           await hl.loadLanguage(langRegist)
         }
       }


### PR DESCRIPTION
Allow additional language registration through `option.additionalLangs`, which is an array of [`ILanguageRegistration`](https://github.com/shikijs/shiki/blob/ebb3f1f5da4bbc130b48d0a15ff60973b5d0ce82/packages/shiki/src/types.ts#L117) objects.