### PR TITLE
feat: add liquid lang

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -115,6 +115,7 @@ export type Lang =
   | 'kotlin'
   | 'latex'
   | 'less'
+  | 'liquid'
   | 'lisp'
   | 'logo'
   | 'lua'

--- a/packages/shiki/languages/liquid.tmLanguage.json
+++ b/packages/shiki/languages/liquid.tmLanguage.json
@@ -1,0 +1,929 @@
+{
+  "name": "liquid",
+  "scopeName": "text.html.liquid",
+  "fileTypes": ["liquid"],
+  "foldingStartMarker": "(?x)\n{%\n  -?\n  \\s*\n  (capture|case|comment|for|form|if|javascript|paginate|schema|style)\n  [^(%})]+\n%}\n",
+  "foldingStopMarker": "(?x)\n{%\n  \\s*\n  (endcapture|endcase|endcomment|endfor|endform|endif|endjavascript|endpaginate|endschema|endstyle)\n  [^(%})]+\n%}\n",
+  "injections": {
+    "L:meta.embedded.block.js, L:meta.embedded.block.css, L:meta.embedded.block.html, L:string.quoted": {
+      "patterns": [
+        {
+          "include": "#injection"
+        }
+      ]
+    }
+  },
+  "patterns": [
+    {
+      "include": "#core"
+    }
+  ],
+  "repository": {
+    "core": {
+      "patterns": [
+        {
+          "include": "#raw_tag"
+        },
+        {
+          "include": "#comment_block"
+        },
+        {
+          "include": "#comment_inline"
+        },
+        {
+          "include": "#style_codefence"
+        },
+        {
+          "include": "#json_codefence"
+        },
+        {
+          "include": "#javascript_codefence"
+        },
+        {
+          "include": "#object"
+        },
+        {
+          "include": "#tag"
+        },
+        {
+          "include": "text.html.basic"
+        }
+      ]
+    },
+    "injection": {
+      "patterns": [
+        {
+          "include": "#raw_tag"
+        },
+        {
+          "include": "#comment_block"
+        },
+        {
+          "include": "#comment_inline"
+        },
+        {
+          "include": "#object"
+        },
+        {
+          "include": "#tag_injection"
+        }
+      ]
+    },
+    "raw_tag": {
+      "begin": "{%-?\\s*(raw)\\s*-?%}",
+      "end": "{%-?\\s*(endraw)\\s*-?%}",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.liquid"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "entity.name.tag.liquid"
+        }
+      },
+      "name": "meta.entity.tag.raw.liquid",
+      "contentName": "string.unquoted.liquid",
+      "patterns": [
+        {
+          "match": "(.(?!{%-?\\s*endraw\\s*-?%}))*."
+        }
+      ]
+    },
+    "comment_block": {
+      "begin": "{%-?\\s*comment\\s*-?%}",
+      "end": "{%-?\\s*endcomment\\s*-?%}",
+      "name": "comment.block.liquid",
+      "patterns": [
+        {
+          "match": "(.(?!{%-?\\s*endcomment\\s*-?%}))*."
+        }
+      ]
+    },
+    "comment_inline": {
+      "begin": "{%-?\\s*#",
+      "end": "-?%}",
+      "name": "comment.line.number-sign.liquid"
+    },
+    "style_codefence": {
+      "begin": "({%-?)\\s*(style)\\s*(-?%})",
+      "end": "({%-?)\\s*(endstyle)\\s*(-?%})",
+      "beginCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.style.start.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.style.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.style.end.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.end.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.style.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "name": "meta.block.style.liquid",
+      "contentName": "meta.embedded.block.css",
+      "patterns": [
+        {
+          "include": "source.css"
+        }
+      ]
+    },
+    "json_codefence": {
+      "begin": "({%-?)\\s*(schema)\\s*(-?%})",
+      "end": "({%-?)\\s*(endschema)\\s*(-?%})",
+      "beginCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.schema.start.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.schema.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.schema.end.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.end.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.schema.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "name": "meta.block.schema.liquid",
+      "contentName": "meta.embedded.block.json",
+      "patterns": [
+        {
+          "include": "source.json"
+        }
+      ]
+    },
+    "javascript_codefence": {
+      "begin": "({%-?)\\s*(javascript)\\s*(-?%})",
+      "end": "({%-?)\\s*(endjavascript)\\s*(-?%})",
+      "beginCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.javascript.start.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.javascript.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "meta.tag.metadata.javascript.end.liquid"
+        },
+        "1": {
+          "name": "punctuation.definition.tag.end.liquid"
+        },
+        "2": {
+          "name": "entity.name.tag.javascript.liquid"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "name": "meta.block.javascript.liquid",
+      "contentName": "meta.embedded.block.js",
+      "patterns": [
+        {
+          "include": "source.js"
+        }
+      ]
+    },
+    "tag": {
+      "begin": "(?<!comment %})(?<!comment -%})(?<!comment%})(?<!comment-%})(?<!raw %})(?<!raw -%})(?<!raw%})(?<!raw-%}){%-?",
+      "end": "-?%}",
+      "name": "meta.tag.liquid",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#tag_body"
+        }
+      ]
+    },
+    "tag_injection": {
+      "begin": "(?<!comment %})(?<!comment -%})(?<!comment%})(?<!comment-%})(?<!raw %})(?<!raw -%})(?<!raw%})(?<!raw-%}){%-?(?!-?\\s*(endstyle|endjavascript|endcomment|endraw))",
+      "end": "-?%}",
+      "name": "meta.tag.liquid",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#tag_body"
+        }
+      ]
+    },
+    "tag_body": {
+      "patterns": [
+        {
+          "include": "#tag_liquid"
+        },
+        {
+          "include": "#tag_assign"
+        },
+        {
+          "include": "#tag_case"
+        },
+        {
+          "include": "#tag_conditional"
+        },
+        {
+          "include": "#tag_for"
+        },
+        {
+          "include": "#tag_paginate"
+        },
+        {
+          "include": "#tag_render"
+        },
+        {
+          "include": "#tag_tablerow"
+        },
+        {
+          "include": "#tag_expression"
+        }
+      ]
+    },
+    "tag_liquid": {
+      "name": "meta.entity.tag.liquid.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(liquid)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.liquid.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#tag_comment_liquid"
+        },
+        {
+          "include": "#tag_assign_liquid"
+        },
+        {
+          "include": "#tag_case_liquid"
+        },
+        {
+          "include": "#tag_conditional_liquid"
+        },
+        {
+          "include": "#tag_for_liquid"
+        },
+        {
+          "include": "#tag_paginate_liquid"
+        },
+        {
+          "include": "#tag_render_liquid"
+        },
+        {
+          "include": "#tag_tablerow_liquid"
+        },
+        {
+          "include": "#tag_expression_liquid"
+        }
+      ]
+    },
+    "tag_comment_liquid": {
+      "name": "comment.block.liquid",
+      "begin": "(?:^\\s*)(comment)\\b",
+      "end": "(?:^\\s*)(endcomment)\\b"
+    },
+    "tag_tablerow": {
+      "name": "meta.entity.tag.tablerow.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(tablerow)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.tablerow.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#tag_tablerow_body"
+        }
+      ]
+    },
+    "tag_tablerow_liquid": {
+      "name": "meta.entity.tag.tablerow.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(tablerow)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.tablerow.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#tag_tablerow_body"
+        }
+      ]
+    },
+    "tag_tablerow_body": {
+      "patterns": [
+        {
+          "match": "\\b(in)\\b",
+          "name": "keyword.control.liquid"
+        },
+        {
+          "match": "\\b(cols|offset|limit):",
+          "name": "keyword.control.liquid"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_for": {
+      "name": "meta.entity.tag.for.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(for)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.for.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#tag_for_body"
+        }
+      ]
+    },
+    "tag_for_liquid": {
+      "name": "meta.entity.tag.for.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(for)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.for.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#tag_for_body"
+        }
+      ]
+    },
+    "tag_for_body": {
+      "patterns": [
+        {
+          "match": "\\b(in|reversed)\\b",
+          "name": "keyword.control.liquid"
+        },
+        {
+          "match": "\\b(offset|limit):",
+          "name": "keyword.control.liquid"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_assign": {
+      "name": "meta.entity.tag.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(assign|echo)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#filter"
+        },
+        {
+          "include": "#attribute"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_assign_liquid": {
+      "name": "meta.entity.tag.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(assign|echo)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#filter"
+        },
+        {
+          "include": "#attribute_liquid"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_render": {
+      "name": "meta.entity.tag.render.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(render)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.render.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#tag_render_special_keywords"
+        },
+        {
+          "include": "#attribute"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_render_liquid": {
+      "name": "meta.entity.tag.render.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(render)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.render.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#tag_render_special_keywords"
+        },
+        {
+          "include": "#attribute_liquid"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_render_special_keywords": {
+      "match": "\\b(with|as|for)\\b",
+      "name": "keyword.control.other.liquid"
+    },
+    "tag_paginate": {
+      "name": "meta.entity.tag.paginate.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(paginate)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.paginate.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#tag_paginate_body"
+        }
+      ]
+    },
+    "tag_paginate_liquid": {
+      "name": "meta.entity.tag.paginate.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(paginate)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.paginate.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#tag_paginate_body"
+        }
+      ]
+    },
+    "tag_paginate_body": {
+      "patterns": [
+        {
+          "match": "\\b(by)\\b",
+          "name": "keyword.control.liquid"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_conditional": {
+      "name": "meta.entity.tag.conditional.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(if|elsif|unless)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.conditional.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_conditional_liquid": {
+      "name": "meta.entity.tag.conditional.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(if|elsif|unless)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.conditional.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_case": {
+      "name": "meta.entity.tag.case.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(case|when)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.case.liquid"
+        }
+      },
+      "end": "(?=%})",
+      "patterns": [
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_case_liquid": {
+      "name": "meta.entity.tag.case.liquid",
+      "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(case|when)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.case.liquid"
+        }
+      },
+      "end": "$",
+      "patterns": [
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "tag_expression_without_arguments": {
+      "patterns": [
+        {
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(endunless|endif)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.conditional.liquid"
+            }
+          }
+        },
+        {
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(endfor|endtablerow|endpaginate)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.loop.liquid"
+            }
+          }
+        },
+        {
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(endcase)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.case.liquid"
+            }
+          }
+        },
+        {
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(capture|case|comment|for|form|if|javascript|paginate|schema|style)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.other.liquid"
+            }
+          }
+        },
+        {
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(endcapture|endcase|endcomment|endfor|endform|endif|endjavascript|endpaginate|endschema|endstyle)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.other.liquid"
+            }
+          }
+        },
+        {
+          "match": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(else|break|continue)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.other.liquid"
+            }
+          }
+        }
+      ]
+    },
+    "tag_expression": {
+      "patterns": [
+        {
+          "include": "#tag_expression_without_arguments"
+        },
+        {
+          "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(\\w+)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.tag.liquid"
+            }
+          },
+          "end": "(?=%})",
+          "name": "meta.entity.tag.liquid",
+          "patterns": [
+            {
+              "include": "#value_expression"
+            }
+          ]
+        }
+      ]
+    },
+    "tag_expression_liquid": {
+      "patterns": [
+        {
+          "include": "#tag_expression_without_arguments"
+        },
+        {
+          "begin": "(?:(?:(?<={%)|(?<={%-)|^)\\s*)(\\w+)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.tag.liquid"
+            }
+          },
+          "end": "$",
+          "name": "meta.entity.tag.liquid",
+          "patterns": [
+            {
+              "include": "#value_expression"
+            }
+          ]
+        }
+      ]
+    },
+    "object": {
+      "begin": "(?<!comment %})(?<!comment -%})(?<!comment%})(?<!comment-%})(?<!raw %})(?<!raw -%})(?<!raw%})(?<!raw-%}){{-?",
+      "end": "-?}}",
+      "name": "meta.object.liquid",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.begin.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.end.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#filter"
+        },
+        {
+          "include": "#attribute"
+        },
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "invalid_range": {
+      "match": "\\((.(?!\\.\\.))+\\)",
+      "name": "invalid.illegal.range.liquid"
+    },
+    "range": {
+      "begin": "\\(",
+      "end": "\\)",
+      "name": "meta.range.liquid",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.parens.begin.liquid"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.parens.end.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "match": "\\.\\.",
+          "name": "punctuation.range.liquid"
+        },
+        {
+          "include": "#variable_lookup"
+        },
+        {
+          "include": "#number"
+        }
+      ]
+    },
+    "number": {
+      "match": "((-|\\+)\\s*)?[0-9]+(\\.[0-9]+)?",
+      "name": "constant.numeric.liquid"
+    },
+    "string": {
+      "patterns": [
+        {
+          "include": "#string_single"
+        },
+        {
+          "include": "#string_double"
+        }
+      ]
+    },
+    "string_double": {
+      "begin": "\"",
+      "end": "\"",
+      "name": "string.quoted.double.liquid"
+    },
+    "string_single": {
+      "begin": "'",
+      "end": "'",
+      "name": "string.quoted.single.liquid"
+    },
+    "operator": {
+      "match": "(?:(?<=\\s)|\\b)(\\=\\=|!\\=|\\>|\\<|\\>\\=|\\<\\=|or|and|contains)(?:(?=\\s)|\\b)",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.expression.liquid"
+        }
+      }
+    },
+    "language_constant": {
+      "match": "\\b(false|true|nil|blank)\\b|empty(?!\\?)",
+      "name": "constant.language.liquid"
+    },
+    "attribute": {
+      "begin": "\\w+:",
+      "end": "(?=,|%}|}}|\\|)",
+      "beginCaptures": {
+        "0": {
+          "name": "entity.other.attribute-name.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "attribute_liquid": {
+      "begin": "\\w+:",
+      "end": "(?=,|\\|)|$",
+      "beginCaptures": {
+        "0": {
+          "name": "entity.other.attribute-name.liquid"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#value_expression"
+        }
+      ]
+    },
+    "filter": {
+      "match": "\\|\\s*((?![\\.0-9])[a-zA-Z0-9_-]+\\:?)\\s*",
+      "captures": {
+        "1": {
+          "name": "support.function.liquid"
+        }
+      }
+    },
+    "value_expression": {
+      "patterns": [
+        {
+          "match": "(\\[)(\\|)(?=[^\\]]*)(?=\\])",
+          "captures": {
+            "2": {
+              "name": "invalid.illegal.filter.liquid"
+            },
+            "3": {
+              "name": "invalid.illegal.filter.liquid"
+            }
+          }
+        },
+        {
+          "match": "(?<=\\s)(\\+|\\-|\\/|\\*)(?=\\s)",
+          "name": "invalid.illegal.filter.liquid"
+        },
+        {
+          "include": "#language_constant"
+        },
+        {
+          "include": "#operator"
+        },
+        {
+          "include": "#invalid_range"
+        },
+        {
+          "include": "#range"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#variable_lookup"
+        }
+      ]
+    },
+    "variable_lookup": {
+      "patterns": [
+        {
+          "match": "\\b(additional_checkout_buttons|address|all_country_option_tags|all_products|article|articles|block|blog|blogs|canonical_url|cart|checkout|collection|collections|comment|content_for_additional_checkout_buttons|content_for_header|content_for_index|content_for_layout|country_option_tags|currency|current_page|current_tags|customer|customer_address|discount_allocation|discount_application|external_video|font|forloop|form|fulfillment|gift_card|handle|image|images|line_item|link|linklist|linklists|location|localization|metafield|model|model_source|order|page|page_description|page_image|page_title|pages|paginate|part|policy|powered_by_link|predictive_search|product|product_option|product_variant|recommendations|request|routes|script|scripts|search|section|selling_plan|selling_plan_allocation|selling_plan_group|settings|shipping_method|shop|shop_locale|store_availability|tablerow|tax_line|template|theme|transaction|unit_price_measurement|variant|video|video_source)\\b",
+          "name": "variable.language.liquid"
+        },
+        {
+          "match": "((?<=\\w\\:\\s)\\w+)",
+          "name": "variable.parameter.liquid"
+        },
+        {
+          "begin": "(?<=\\w)\\[",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.brackets.begin.liquid"
+            }
+          },
+          "end": "\\]",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.brackets.end.liquid"
+            }
+          },
+          "name": "meta.brackets.liquid",
+          "patterns": [
+            {
+              "include": "#string"
+            }
+          ]
+        },
+        {
+          "match": "(?<=(\\w|\\])\\.)([-\\w]+\\??)",
+          "name": "variable.other.member.liquid"
+        },
+        {
+          "match": "(?<=\\w)\\.(?=\\w)",
+          "name": "punctuation.accessor.liquid"
+        },
+        {
+          "match": "(?i)[a-z_](\\w|(?:-(?!\\}\\})))*",
+          "name": "variable.other.liquid"
+        }
+      ]
+    }
+  }
+}

--- a/packages/shiki/samples/liquid.sample
+++ b/packages/shiki/samples/liquid.sample
@@ -1,0 +1,14 @@
+<h3>Recommended Products</h3>
+<ul class="recommended_products">
+  {% assign recommended_products =  product.metafields.my_fields.rec_products.value %}
+  {% for product in recommended_products  %}
+    <li>
+      <a href="{{ product.url }}">
+        {{ product.featured_image | image_url: width: 400 | image_tag: loading: 'lazy' }}
+        {{product.title}}
+      </a>
+    </li>
+  {% endfor %}
+</ul>
+
+{%- comment -%} From https://www.codeshopify.com/blog_posts/related-products-with-product_list-sections-metafields {%- endcomment -%}

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -65,6 +65,7 @@ export type Lang =
   | 'kotlin'
   | 'latex'
   | 'less'
+  | 'liquid'
   | 'lisp'
   | 'logo'
   | 'lua'
@@ -529,6 +530,13 @@ export const languages: ILanguageRegistration[] = [
     embeddedLangs: ['css']
   },
   {
+    id: 'liquid',
+    scopeName: 'text.html.liquid',
+    path: 'liquid.tmLanguage.json',
+    samplePath: 'liquid.sample',
+    embeddedLangs: ['html', 'css', 'json', 'javascript']
+  },
+  {
     id: 'lisp',
     scopeName: 'source.lisp',
     path: 'lisp.tmLanguage.json'
@@ -903,7 +911,7 @@ export const languages: ILanguageRegistration[] = [
     id: 'vue',
     scopeName: 'source.vue',
     path: 'vue.tmLanguage.json',
-    embeddedLangs: ['json', 'markdown', 'pug', 'haml', 'vue-html', 'sass', 'scss', 'less', 'stylus', 'postcss', 'css', 'typescript', 'coffee', 'javascript']
+    embeddedLangs: ['json', 'markdown', 'pug', 'haml', 'liquid', 'vue-html', 'sass', 'scss', 'less', 'stylus', 'postcss', 'css', 'typescript', 'coffee', 'javascript']
   },
   {
     id: 'wasm',

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -155,6 +155,7 @@ export const githubGrammarSources: [string, string][] = [
   ],
   ['latex', 'https://github.com/James-Yu/LaTeX-Workshop/blob/master/syntax/LaTeX.tmLanguage.json'],
   ['lisp', 'https://github.com/mattn/vscode-lisp/blob/master/syntaxes/Lisp.tmLanguage'],
+  ['liquid', 'https://github.com/Shopify/liquid-tm-grammar/blob/main/grammars/liquid.tmLanguage.json'],
   ['logo', 'https://github.com/textmate/logo.tmbundle/blob/master/Syntaxes/Logo.tmLanguage'],
   ['marko', 'https://github.com/marko-js/marko-tmbundle/blob/master/Syntaxes/Marko.tmLanguage'],
   [


### PR DESCRIPTION
- [ ] Add a test if possible
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

- [x] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [x] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [x] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.

---

Your [contributing guidelines](https://github.com/shikijs/shiki/blob/main/.github/CONTRIBUTING.md#coding-conventions) suggest using the "lang" commit scope for these commits/PRs however recent PRs instead seem to follow "feat: add [lang] lang" convention so I've continued with that, please let me know if you'd prefer I change it.