### PR TITLE
feat: add Clarity lang

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -68,6 +68,7 @@ export type Lang =
   | 'bicep'
   | 'c'
   | 'cadence' | 'cdc'
+  | 'clarity'
   | 'clojure' | 'clj'
   | 'cobol'
   | 'codeql' | 'ql'

--- a/packages/shiki/languages/clarity.tmLanguage.json
+++ b/packages/shiki/languages/clarity.tmLanguage.json
@@ -1,0 +1,869 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "clarity",
+  "scopeName": "source.clar",
+  "uuid": "f9e9871d-2ea6-4be0-afd2-fc382d704716",
+  "patterns": [
+    {
+      "include": "#expression"
+    },
+    {
+      "include": "#define-constant"
+    },
+    {
+      "include": "#define-data-var"
+    },
+    {
+      "include": "#define-map"
+    },
+    {
+      "include": "#define-function"
+    },
+    {
+      "include": "#define-fungible-token"
+    },
+    {
+      "include": "#define-non-fungible-token"
+    },
+    {
+      "include": "#define-trait"
+    },
+    {
+      "include": "#use-trait"
+    }
+  ],
+  "repository": {
+    "comment": {
+      "name": "comment.line.semicolon.clarity",
+      "match": "(?x) (?<=^|[()\\[\\]{}\",'`;\\s]) (;) .* $"
+    },
+    "expression": {
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#keyword"
+        },
+        {
+          "include": "#literal"
+        },
+        {
+          "include": "#let-func"
+        },
+        {
+          "include": "#built-in-func"
+        },
+        {
+          "include": "#get-set-func"
+        }
+      ]
+    },
+    "keyword": {
+      "name": "constant.language.clarity",
+      "match": "\\b(?:block-height|burn-block-height|contract-caller|is-in-regtest|stx-liquid-supply|tx-sender)\\b"
+    },
+    "define-function": {
+      "begin": "(?x) (\\() \\s* (define-(?:public|private|read-only)) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.define-function.start.clarity"
+        },
+        "2": {
+          "name": "keyword.declaration.define-function.clarity"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.define-function.end.clarity"
+        }
+      },
+      "name": "meta.define-function",
+      "patterns": [
+        {
+          "include": "#expression"
+        },
+        {
+          "begin": "(?x) (\\() \\s* ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s*",
+          "end": "(\\))",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.function-signature.start.clarity"
+            },
+            "2": {
+              "name": "entity.name.function.clarity"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.function-signature.end.clarity"
+            }
+          },
+          "name": "meta.define-function-signature",
+          "patterns": [
+            {
+              "begin": "(?x) (\\() \\s* ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+              "end": "(\\))",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.function-argument.start.clarity"
+                },
+                "2": {
+                  "name": "variable.parameter.clarity"
+                }
+              },
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.function-argument.end.clarity"
+                }
+              },
+              "name": "meta.function-argument",
+              "patterns": [
+                {
+                  "include": "#data-type"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "define-fungible-token": {
+      "match": "(?x) (\\() \\s* (define-fungible-token) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) (?:\\s+(u\\d+))?",
+      "captures": {
+        "1": {
+          "name": "punctuation.define-fungible-token.start.clarity"
+        },
+        "2": {
+          "name": "keyword.declaration.define-fungible-token.clarity"
+        },
+        "3": {
+          "name": "entity.name.fungible-token-name.clarity variable.other.clarity"
+        },
+        "4": {
+          "name": "constant.numeric.fungible-token-total-supply.clarity"
+        },
+        "5": {
+          "name": "punctuation.define-fungible-token.end.clarity"
+        }
+      }
+    },
+    "define-non-fungible-token": {
+      "begin": "(?x) (\\() \\s* (define-non-fungible-token) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.define-non-fungible-token.start.clarity"
+        },
+        "2": {
+          "name": "keyword.declaration.define-non-fungible-token.clarity"
+        },
+        "3": {
+          "name": "entity.name.non-fungible-token-name.clarity variable.other.clarity"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.define-non-fungible-token.end.clarity"
+        }
+      },
+      "name": "meta.define-non-fungible-token",
+      "patterns": [
+        {
+          "include": "#data-type"
+        }
+      ]
+    },
+    "define-trait": {
+      "begin": "(?x) (\\() \\s* (define-trait) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.define-trait.start.clarity"
+        },
+        "2": {
+          "name": "keyword.declaration.define-trait.clarity"
+        },
+        "3": {
+          "name": "entity.name.trait-name.clarity variable.other.clarity"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.define-trait.end.clarity"
+        }
+      },
+      "name": "meta.define-trait",
+      "patterns": [
+        {
+          "begin": "(?x) (\\() \\s*",
+          "end": "(\\))",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.define-trait-body.start.clarity"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.define-trait-body.end.clarity"
+            }
+          },
+          "name": "meta.define-trait-body",
+          "patterns": [
+            {
+              "include": "#expression"
+            },
+            {
+              "begin": "(?x) (\\() \\s* ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]+\\??) \\s+",
+              "end": "(\\))",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.trait-function.start.clarity"
+                },
+                "2": {
+                  "name": "entity.name.trait-function-name.clarity variable.other.clarity"
+                }
+              },
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.trait-function.end.clarity"
+                }
+              },
+              "name": "meta.trait-function",
+              "patterns": [
+                {
+                  "include": "#data-type"
+                },
+                {
+                  "begin": "(?x) (\\() \\s*",
+                  "end": "(\\))",
+                  "beginCaptures": {
+                    "1": {
+                      "name": "punctuation.trait-function-args.start.clarity"
+                    }
+                  },
+                  "endCaptures": {
+                    "1": {
+                      "name": "punctuation.trait-function-args.end.clarity"
+                    }
+                  },
+                  "name": "meta.trait-function-args",
+                  "patterns": [
+                    {
+                      "include": "#data-type"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "use-trait": {
+      "begin": "(?x) (\\() \\s* (use-trait) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.use-trait.start.clarity"
+        },
+        "2": {
+          "name": "keyword.declaration.use-trait.clarity"
+        },
+        "3": {
+          "name": "entity.name.trait-alias.clarity variable.other.clarity"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.use-trait.end.clarity"
+        }
+      },
+      "name": "meta.use-trait",
+      "patterns": [
+        {
+          "include": "#literal"
+        }
+      ]
+    },
+    "define-constant": {
+      "begin": "(?x) (\\() \\s* (define-constant) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.define-constant.start.clarity"
+        },
+        "2": {
+          "name": "keyword.declaration.define-constant.clarity"
+        },
+        "3": {
+          "name": "entity.name.constant-name.clarity variable.other.clarity"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.define-constant.end.clarity"
+        }
+      },
+      "name": "meta.define-constant",
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "define-data-var": {
+      "begin": "(?x) (\\() \\s* (define-data-var) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.define-data-var.start.clarity"
+        },
+        "2": {
+          "name": "keyword.declaration.define-data-var.clarity"
+        },
+        "3": {
+          "name": "entity.name.data-var-name.clarity variable.other.clarity"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.define-data-var.end.clarity"
+        }
+      },
+      "name": "meta.define-data-var",
+      "patterns": [
+        {
+          "include": "#data-type"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "define-map": {
+      "begin": "(?x) (\\() \\s* (define-map) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.define-map.start.clarity"
+        },
+        "2": {
+          "name": "keyword.declaration.define-map.clarity"
+        },
+        "3": {
+          "name": "entity.name.map-name.clarity variable.other.clarity"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.define-map.end.clarity"
+        }
+      },
+      "name": "meta.define-map",
+      "patterns": [
+        {
+          "include": "#data-type"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "literal": {
+      "patterns": [
+        {
+          "include": "#number-literal"
+        },
+        {
+          "include": "#bool-literal"
+        },
+        {
+          "include": "#string-literal"
+        },
+        {
+          "include": "#tuple-literal"
+        },
+        {
+          "include": "#principal-literal"
+        },
+        {
+          "include": "#list-literal"
+        },
+        {
+          "include": "#optional-literal"
+        },
+        {
+          "include": "#response-literal"
+        }
+      ],
+      "repository": {
+        "number-literal": {
+          "patterns": [
+            {
+              "comment": "unsigned integers",
+              "name": "constant.numeric.uint.clarity",
+              "match": "\\bu\\d+\\b"
+            },
+            {
+              "comment": "signed integers",
+              "name": "constant.numeric.int.clarity",
+              "match": "\\b\\d+\\b"
+            },
+            {
+              "comment": "hexadecimals",
+              "name": "constant.numeric.hex.clarity",
+              "match": "\\b0x[0-9a-f]*\\b"
+            }
+          ]
+        },
+        "bool-literal": {
+          "name": "constant.language.bool.clarity",
+          "match": "\\b(true|false)\\b"
+        },
+        "string-literal": {
+          "patterns": [
+            {
+              "name": "string.quoted.double.clarity",
+              "begin": "(u?)(\")",
+              "beginCaptures": {
+                "1": {
+                  "name": "string.quoted.utf8.clarity"
+                },
+                "2": {
+                  "name": "punctuation.definition.string.begin.clarity"
+                }
+              },
+              "end": "\"",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.definition.string.end.clarity"
+                }
+              }
+            }
+          ]
+        },
+        "tuple-literal": {
+          "begin": "(\\{)",
+          "end": "(\\})",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.tuple.start.clarity"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.tuple.end.clarity"
+            }
+          },
+          "name": "meta.tuple",
+          "patterns": [
+            {
+              "name": "entity.name.tag.tuple-key.clarity",
+              "match": "([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*)(?=:)"
+            },
+            {
+              "include": "#expression"
+            },
+            {
+              "include": "#user-func"
+            }
+          ]
+        },
+        "principal-literal": {
+          "name": "constant.other.principal.clarity",
+          "match": "(?x)  \\'[0-9A-Z]{28,41}(:?\\.[a-zA-Z][a-zA-Z0-9\\-]+){0,2} | (\\.[a-zA-Z][a-zA-Z0-9\\-]*){1,2} (?=[\\s(){},]|$)"
+        },
+        "list-literal": {
+          "begin": "(?x) (\\() \\s* (list) \\s+",
+          "end": "(\\))",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.list.start.clarity"
+            },
+            "2": {
+              "name": "entity.name.type.list.clarity"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "names": "punctuation.list.end.clarity"
+            }
+          },
+          "name": "meta.list",
+          "patterns": [
+            {
+              "include": "#expression"
+            },
+            {
+              "include": "#user-func"
+            }
+          ]
+        },
+        "optional-literal": {
+          "patterns": [
+            {
+              "match": "\\b(none)\\b",
+              "name": "constant.language.none.clarity"
+            },
+            {
+              "begin": "(?x) (\\() \\s* (some) \\s+",
+              "end": "(\\))",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.some.start.clarity"
+                },
+                "2": {
+                  "name": "constant.language.some.clarity"
+                }
+              },
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.some.end.clarity"
+                }
+              },
+              "name": "meta.some",
+              "patterns": [
+                {
+                  "include": "#expression"
+                }
+              ]
+            }
+          ]
+        },
+        "response-literal": {
+          "begin": "(?x) (\\() \\s* (ok|err) \\s+",
+          "end": "(\\))",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.response.start.clarity"
+            },
+            "2": {
+              "name": "constant.language.ok-err.clarity"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.response.end.clarity"
+            }
+          },
+          "name": "meta.response",
+          "patterns": [
+            {
+              "include": "#expression"
+            },
+            {
+              "include": "#user-func"
+            }
+          ]
+        }
+      }
+    },
+    "data-type": {
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "comment": "numerics",
+          "name": "entity.name.type.numeric.clarity",
+          "match": "\\b(uint|int)\\b"
+        },
+        {
+          "comment": "principal",
+          "name": "entity.name.type.principal.clarity",
+          "match": "\\b(principal)\\b"
+        },
+        {
+          "comment": "bool",
+          "name": "entity.name.type.bool.clarity",
+          "match": "\\b(bool)\\b"
+        },
+        {
+          "match": "(?x) (\\() \\s* (?:(string-ascii|string-utf8)\\s+(\\d+)) \\s* (\\))",
+          "captures": {
+            "1": {
+              "name": "punctuation.string-def.start.clarity"
+            },
+            "2": {
+              "name": "entity.name.type.string.clarity"
+            },
+            "3": {
+              "name": "constant.numeric.string-len.clarity"
+            },
+            "4": {
+              "name": "punctuation.string-def.end.clarity"
+            }
+          }
+        },
+        {
+          "match": "(?x) (\\() \\s* (buff)\\s+(\\d+)\\s* (\\))",
+          "captures": {
+            "1": {
+              "name": "punctuation.buff-def.start.clarity"
+            },
+            "2": {
+              "name": "entity.name.type.buff.clarity"
+            },
+            "3": {
+              "name": "constant.numeric.buf-len.clarity"
+            },
+            "4": {
+              "name": "punctuation.buff-def.end.clarity"
+            }
+          }
+        },
+        {
+          "comment": "optional",
+          "begin": "(?x) (\\() \\s* (optional)\\s+",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.optional-def.start.clarity"
+            },
+            "2": {
+              "name": "storage.type.modifier"
+            }
+          },
+          "end": "(\\))",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.optional-def.end.clarity"
+            }
+          },
+          "name": "meta.optional-def",
+          "patterns": [
+            {
+              "include": "#data-type"
+            }
+          ]
+        },
+        {
+          "comment": "response",
+          "begin": "(?x) (\\() \\s* (response)\\s+",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.response-def.start.clarity"
+            },
+            "2": {
+              "name": "storage.type.modifier"
+            }
+          },
+          "end": "(\\))",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.response-def.end.clarity"
+            }
+          },
+          "name": "meta.response-def",
+          "patterns": [
+            {
+              "include": "#data-type"
+            }
+          ]
+        },
+        {
+          "comment": "list",
+          "begin": "(?x) (\\() \\s* (list) \\s+ (\\d+) \\s+",
+          "end": "(\\))",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.list-def.start.clarity"
+            },
+            "2": {
+              "name": "entity.name.type.list.clarity"
+            },
+            "3": {
+              "name": "constant.numeric.list-len.clarity"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.list-def.end.clarity"
+            }
+          },
+          "name": "meta.list-def",
+          "patterns": [
+            {
+              "include": "#data-type"
+            }
+          ]
+        },
+        {
+          "begin": "(\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.tuple-def.start.clarity"
+            }
+          },
+          "end": "(\\})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.tuple-def.end.clarity"
+            }
+          },
+          "name": "meta.tuple-def",
+          "patterns": [
+            {
+              "name": "entity.name.tag.tuple-data-type-key.clarity",
+              "match": "([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*)(?=:)"
+            },
+            {
+              "include": "#data-type"
+            }
+          ]
+        }
+      ]
+    },
+    "built-in-func": {
+      "begin": "(?x) (\\() \\s* (\\-|\\+|<\\=|>\\=|<|>|\\*|/|and|append|as-contract|as-max-len\\?|asserts!|at-block|begin|concat|contract-call\\?|contract-of|default-to|element-at|filter|fold|ft-burn\\?|ft-get-balance|ft-get-supply|ft-mint\\?|ft-transfer\\?|get-block-info\\?|hash160|if|impl-trait|index-of|is-eq|is-err|is-none|is-ok|is-some|keccak256|len|log2|map|match|merge|mod|nft-burn\\?|nft-get-owner\\?|nft-mint\\?|nft-transfer\\?|not|or|pow|principal-of\\?|print|secp256k1-recover\\?|secp256k1-verify|sha256|sha512|sha512/256|sqrti|stx-burn\\?|stx-get-balance|stx-transfer\\?|to-int|to-uint|try!|unwrap-err-panic|unwrap-err!|unwrap-panic|unwrap!|xor) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.built-in-function.start.clarity"
+        },
+        "2": {
+          "name": "keyword.declaration.built-in-function.clarity"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.built-in-function.end.clarity"
+        }
+      },
+      "name": "meta.built-in-function",
+      "patterns": [
+        {
+          "include": "#expression"
+        },
+        {
+          "include": "#user-func"
+        }
+      ]
+    },
+    "get-set-func": {
+      "name": "meta.get-set-func",
+      "begin": "(?x) (\\() \\s* (var-get|var-set|map-get\\?|map-set|map-insert|map-delete|get) \\s+ ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s*",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.get-set-func.start.clarity"
+        },
+        "2": {
+          "name": "keyword.control.clarity"
+        },
+        "3": {
+          "name": "variable.other.clarity"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.get-set-func.end.clarity"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "let-func": {
+      "begin": "(?x) (\\() \\s* (let) \\s*",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.let-function.start.clarity"
+        },
+        "2": {
+          "name": "keyword.declaration.let-function.clarity"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.let-function.end.clarity"
+        }
+      },
+      "name": "meta.let-function",
+      "patterns": [
+        {
+          "include": "#expression"
+        },
+        {
+          "include": "#user-func"
+        },
+        {
+          "begin": "(?x) (\\() \\s*",
+          "end": "(\\))",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.let-var.start.clarity"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.let-var.end.clarity"
+            }
+          },
+          "name": "meta.let-var",
+          "patterns": [
+            {
+              "begin": "(?x) (\\() ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*) \\s+",
+              "end": "(\\))",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.let-local-var.start.clarity"
+                },
+                "2": {
+                  "name": "entity.name.let-local-var-name.clarity variable.parameter.clarity"
+                }
+              },
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.let-local-var.end.clarity"
+                }
+              },
+              "name": "meta.let-local-var",
+              "patterns": [
+                {
+                  "include": "#expression"
+                },
+                {
+                  "include": "#user-func"
+                }
+              ]
+            },
+            {
+              "include": "#expression"
+            }
+          ]
+        }
+      ]
+    },
+    "user-func": {
+      "begin": "(?x) (\\() \\s* (([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]*)) \\s*",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.user-function.start.clarity"
+        },
+        "2": {
+          "name": "entity.name.function.clarity"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.user-function.end.clarity"
+        }
+      },
+      "name": "meta.user-function",
+      "patterns": [
+        {
+          "include": "#expression"
+        },
+        {
+          "include": "$self"
+        }
+      ]
+    }
+  }
+}

--- a/packages/shiki/samples/clarity.sample
+++ b/packages/shiki/samples/clarity.sample
@@ -1,0 +1,53 @@
+(impl-trait .sip010-ft-trait.sip010-ft-trait)
+
+;; SIP010 trait on mainnet
+;; (impl-trait 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait)
+
+(define-constant contract-owner tx-sender)
+(define-constant err-owner-only (err u100))
+(define-constant err-not-token-owner (err u101))
+
+;; No maximum supply!
+(define-fungible-token clarity-coin)
+
+(define-public (transfer (amount uint) (sender principal) (recipient principal) (memo (optional (buff 34))))
+  (begin
+    (asserts! (is-eq tx-sender sender) err-owner-only)
+    (try! (ft-transfer? clarity-coin amount sender recipient))
+    (match memo to-print (print to-print) 0x)
+    (ok true)
+  )
+)
+
+(define-read-only (get-name)
+  (ok "Clarity Coin")
+)
+
+(define-read-only (get-symbol)
+  (ok "CC")
+)
+
+(define-read-only (get-decimals)
+  (ok u0)
+)
+
+(define-read-only (get-balance (who principal))
+  (ok (ft-get-balance clarity-coin who))
+)
+
+(define-read-only (get-total-supply)
+  (ok (ft-get-supply clarity-coin))
+)
+
+(define-read-only (get-token-uri)
+  (ok none)
+)
+
+(define-public (mint (amount uint) (recipient principal))
+  (begin
+    (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+    (ft-mint? clarity-coin amount recipient)
+  )
+)
+
+;; From https://github.com/clarity-lang/book/blob/main/projects/sip010-ft/contracts/clarity-coin.clar

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -18,6 +18,7 @@ export type Lang =
   | 'bicep'
   | 'c'
   | 'cadence' | 'cdc'
+  | 'clarity'
   | 'clojure' | 'clj'
   | 'cobol'
   | 'codeql' | 'ql'
@@ -244,6 +245,12 @@ export const languages: ILanguageRegistration[] = [
     path: 'cadence.tmLanguage.json',
     samplePath: 'cadence.sample',
     aliases: ['cdc']
+  },
+  {
+    id: 'clarity',
+    scopeName: 'source.clar',
+    path: 'clarity.tmLanguage.json',
+    samplePath: 'clarity.sample'
   },
   {
     id: 'clojure',

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -98,6 +98,10 @@ export const githubGrammarSources: [string, string][] = [
     'cadence',
     'https://github.com/onflow/vscode-cadence/blob/master/syntaxes/cadence.tmGrammar.json'
   ],
+  [
+    'clarity',
+    'https://github.com/hirosystems/clarity-lsp/blob/develop/syntaxes/clarity.tmLanguage.json'
+  ],
   ['cobol', 'https://github.com/spgennard/vscode_cobol/blob/master/syntaxes/COBOL.tmLanguage.json'],
   ['codeql', 'https://github.com/github/vscode-codeql/blob/main/syntaxes/ql.tmLanguage.json'],
   [
@@ -159,7 +163,10 @@ export const githubGrammarSources: [string, string][] = [
   ],
   ['latex', 'https://github.com/James-Yu/LaTeX-Workshop/blob/master/syntax/LaTeX.tmLanguage.json'],
   ['lisp', 'https://github.com/mattn/vscode-lisp/blob/master/syntaxes/Lisp.tmLanguage'],
-  ['liquid', 'https://github.com/Shopify/liquid-tm-grammar/blob/main/grammars/liquid.tmLanguage.json'],
+  [
+    'liquid',
+    'https://github.com/Shopify/liquid-tm-grammar/blob/main/grammars/liquid.tmLanguage.json'
+  ],
   ['logo', 'https://github.com/textmate/logo.tmbundle/blob/master/Syntaxes/Logo.tmLanguage'],
   ['marko', 'https://github.com/marko-js/marko-tmbundle/blob/master/Syntaxes/Marko.tmLanguage'],
   [


### PR DESCRIPTION
- ~~Add a test if possible~~
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

<!-- If adding a language -->

- [x] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [x] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [x] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.

Note: There is an earlier PR adding this: https://github.com/shikijs/shiki/pull/48
It was closed saying only top 50 languages were being added at that time, but based on recent PRs I assume that's no longer the case