### PR TITLE
fix isBrowser check

### DIFF
--- a/packages/shiki/src/loader.ts
+++ b/packages/shiki/src/loader.ts
@@ -6,12 +6,12 @@ import type { IShikiTheme } from './types'
 
 export const isWebWorker =
   typeof self !== 'undefined' && typeof self.WorkerGlobalScope !== 'undefined'
-
-export const isBrowser =
-  isWebWorker ||
-  (typeof window !== 'undefined' &&
-    typeof window.document !== 'undefined' &&
-    typeof fetch !== 'undefined')
+export const isNode =
+  'process' in globalThis &&
+  typeof process !== 'undefined' &&
+  typeof process.release !== 'undefined' &&
+  process.release.name === 'node'
+export const isBrowser = isWebWorker || !isNode
 
 // to be replaced by rollup
 let CDN_ROOT = '__CDN_ROOT__'


### PR DESCRIPTION
`fetch` has become available in the `global` in Node since version 18. The `isBrowser` check in Shiki looks like this:

```js
const isWebWorker = typeof self !== 'undefined' && typeof self.WorkerGlobalScope !== 'undefined';
const isBrowser = isWebWorker ||
    (typeof window !== 'undefined' &&
        typeof window.document !== 'undefined' &&
        typeof fetch !== 'undefined');
```

`typeof fetch !== 'undefined'` will now be always true starting with Node 18, which means Shiki will use `fetch` unconditionally.

This PR fixes the issue by only setting `isBrowser` to `true` if it is executing in a web worker, or if the code is most likely not executing in Node. The reason why checking for the presence of `window` and `window.document` is not enough is because users may be using `JSDOM` or similar and creating those objects in a Node environment. There is no possible way to check correctly in every scenario, but this should be a little more reliable.