### PR TITLE
feat: add onedark and onelight themes

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -113,6 +113,8 @@ export type Theme =
   | 'monokai'
   | 'nord'
   | 'one-dark-pro'
+  | 'onelight'
+  | 'onedark'
   | 'poimandres'
   | 'rose-pine-dawn'
   | 'rose-pine-moon'

--- a/packages/shiki/src/themes.ts
+++ b/packages/shiki/src/themes.ts
@@ -18,6 +18,8 @@ export type Theme =
   | 'monokai'
   | 'nord'
   | 'one-dark-pro'
+  | 'onelight'
+  | 'onedark'
   | 'poimandres'
   | 'rose-pine-dawn'
   | 'rose-pine-moon'
@@ -49,6 +51,8 @@ export const themes: Theme[] = [
   'monokai',
   'nord',
   'one-dark-pro',
+  'onedark',
+  'onelight',
   'poimandres',
   'rose-pine-dawn',
   'rose-pine-moon',

--- a/packages/shiki/themes/onedark.json
+++ b/packages/shiki/themes/onedark.json
@@ -1,0 +1,1374 @@
+{
+  "author": "akamud",
+  "name": "OneDark",
+  "colors": {
+    "activityBar.background": "#333842",
+    "activityBar.foreground": "#D7DAE0",
+    "activityBarBadge.background": "#528BFF",
+    "activityBarBadge.foreground": "#D7DAE0",
+    "button.background": "#4D78CC",
+    "button.foreground": "#FFFFFF",
+    "button.hoverBackground": "#6087CF",
+    "diffEditor.insertedTextBackground": "#00809B33",
+    "dropdown.background": "#353b45",
+    "dropdown.border": "#181A1F",
+    "editorIndentGuide.activeBackground": "#626772",
+    "editor.background": "#282C34",
+    "editor.foreground": "#ABB2BF",
+    "editor.lineHighlightBackground": "#99BBFF0A",
+    "editor.selectionBackground": "#3E4451",
+    "editorCursor.foreground": "#528BFF",
+    "editor.findMatchHighlightBackground": "#528BFF3D",
+    "editorGroup.background": "#21252B",
+    "editorGroup.border": "#181A1F",
+    "editorGroupHeader.tabsBackground": "#21252B",
+    "editorIndentGuide.background": "#ABB2BF26",
+    "editorLineNumber.foreground": "#636D83",
+    "editorLineNumber.activeForeground": "#ABB2BF",
+    "editorWhitespace.foreground": "#ABB2BF26",
+    "editorRuler.foreground": "#ABB2BF26",
+    "editorHoverWidget.background": "#21252B",
+    "editorHoverWidget.border": "#181A1F",
+    "editorSuggestWidget.background": "#21252B",
+    "editorSuggestWidget.border": "#181A1F",
+    "editorSuggestWidget.selectedBackground": "#2C313A",
+    "editorWidget.background": "#21252B",
+    "editorWidget.border": "#3A3F4B",
+    "input.background": "#1B1D23",
+    "input.border": "#181A1F",
+    "focusBorder": "#528BFF",
+    "list.activeSelectionBackground": "#2C313A",
+    "list.activeSelectionForeground": "#D7DAE0",
+    "list.focusBackground": "#2C313A",
+    "list.hoverBackground": "#2C313A66",
+    "list.highlightForeground": "#D7DAE0",
+    "list.inactiveSelectionBackground": "#2C313A",
+    "list.inactiveSelectionForeground": "#D7DAE0",
+    "notification.background": "#21252B",
+    "pickerGroup.border": "#528BFF",
+    "scrollbarSlider.background": "#4E566680",
+    "scrollbarSlider.activeBackground": "#747D9180",
+    "scrollbarSlider.hoverBackground": "#5A637580",
+    "sideBar.background": "#21252B",
+    "sideBarSectionHeader.background": "#333842",
+    "statusBar.background": "#21252B",
+    "statusBar.foreground": "#9DA5B4",
+    "statusBarItem.hoverBackground": "#2C313A",
+    "statusBar.noFolderBackground": "#21252B",
+    "tab.activeBackground": "#282C34",
+    "tab.activeForeground": "#D7DAE0",
+    "tab.border": "#181A1F",
+    "tab.inactiveBackground": "#21252B",
+    "titleBar.activeBackground": "#21252B",
+    "titleBar.activeForeground": "#9DA5B4",
+    "titleBar.inactiveBackground": "#21252B",
+    "titleBar.inactiveForeground": "#9DA5B4",
+    "statusBar.debuggingForeground": "#FFFFFF",
+    "extensionButton.prominentBackground": "#2BA143",
+    "extensionButton.prominentHoverBackground": "#37AF4E",
+    "badge.background": "#528BFF",
+    "badge.foreground": "#D7DAE0",
+    "peekView.border": "#528BFF",
+    "peekViewResult.background": "#21252B",
+    "peekViewResult.selectionBackground": "#2C313A",
+    "peekViewTitle.background": "#1B1D23",
+    "peekViewEditor.background": "#1B1D23"
+  },
+  "tokenColors": [
+    {
+      "name": "Comment",
+      "scope": ["comment"],
+      "settings": { "foreground": "#5C6370", "fontStyle": "italic" }
+    },
+    {
+      "name": "Comment Markup Link",
+      "scope": ["comment markup.link"],
+      "settings": { "foreground": "#5C6370" }
+    },
+    {
+      "name": "Entity Name Type",
+      "scope": ["entity.name.type"],
+      "settings": { "foreground": "#E5C07B" }
+    },
+    {
+      "name": "Entity Other Inherited Class",
+      "scope": ["entity.other.inherited-class"],
+      "settings": { "foreground": "#E5C07B" }
+    },
+    {
+      "name": "Keyword",
+      "scope": ["keyword"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Keyword Control",
+      "scope": ["keyword.control"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Keyword Operator",
+      "scope": ["keyword.operator"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Keyword Other Special Method",
+      "scope": ["keyword.other.special-method"],
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "Keyword Other Unit",
+      "scope": ["keyword.other.unit"],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "Storage",
+      "scope": ["storage"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Storage Type Annotation,storage Type Primitive",
+      "scope": ["storage.type.annotation", "storage.type.primitive"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Storage Modifier Package,storage Modifier Import",
+      "scope": ["storage.modifier.package", "storage.modifier.import"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Constant",
+      "scope": ["constant"],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "Constant Variable",
+      "scope": ["constant.variable"],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "Constant Character Escape",
+      "scope": ["constant.character.escape"],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "Constant Numeric",
+      "scope": ["constant.numeric"],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "Constant Other Color",
+      "scope": ["constant.other.color"],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "Constant Other Symbol",
+      "scope": ["constant.other.symbol"],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "Variable",
+      "scope": ["variable"],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Variable Interpolation",
+      "scope": ["variable.interpolation"],
+      "settings": { "foreground": "#BE5046" }
+    },
+    {
+      "name": "Variable Parameter",
+      "scope": ["variable.parameter"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "String",
+      "scope": ["string"],
+      "settings": { "foreground": "#98C379" }
+    },
+    {
+      "name": "String > Source,string Embedded",
+      "scope": ["string > source", "string embedded"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "String Regexp",
+      "scope": ["string.regexp"],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "String Regexp Source Ruby Embedded",
+      "scope": ["string.regexp source.ruby.embedded"],
+      "settings": { "foreground": "#E5C07B" }
+    },
+    {
+      "name": "String Other Link",
+      "scope": ["string.other.link"],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Punctuation Definition Comment",
+      "scope": ["punctuation.definition.comment"],
+      "settings": { "foreground": "#5C6370" }
+    },
+    {
+      "name": "Punctuation Definition Method Parameters,punctuation Definition Function Parameters,punctuation Definition Parameters,punctuation Definition Separator,punctuation Definition Seperator,punctuation Definition Array",
+      "scope": [
+        "punctuation.definition.method-parameters",
+        "punctuation.definition.function-parameters",
+        "punctuation.definition.parameters",
+        "punctuation.definition.separator",
+        "punctuation.definition.seperator",
+        "punctuation.definition.array"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Punctuation Definition Heading,punctuation Definition Identity",
+      "scope": [
+        "punctuation.definition.heading",
+        "punctuation.definition.identity"
+      ],
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "Punctuation Definition Bold",
+      "scope": ["punctuation.definition.bold"],
+      "settings": { "foreground": "#E5C07B", "fontStyle": "bold" }
+    },
+    {
+      "name": "Punctuation Definition Italic",
+      "scope": ["punctuation.definition.italic"],
+      "settings": { "foreground": "#C678DD", "fontStyle": "italic" }
+    },
+    {
+      "name": "Punctuation Section Embedded",
+      "scope": ["punctuation.section.embedded"],
+      "settings": { "foreground": "#BE5046" }
+    },
+    {
+      "name": "Punctuation Section Method,punctuation Section Class,punctuation Section Inner Class",
+      "scope": [
+        "punctuation.section.method",
+        "punctuation.section.class",
+        "punctuation.section.inner-class"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Support Class",
+      "scope": ["support.class"],
+      "settings": { "foreground": "#E5C07B" }
+    },
+    {
+      "name": "Support Type",
+      "scope": ["support.type"],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "Support Function",
+      "scope": ["support.function"],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "Support Function Any Method",
+      "scope": ["support.function.any-method"],
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "Entity Name Function",
+      "scope": ["entity.name.function"],
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "Entity Name Class,entity Name Type Class",
+      "scope": ["entity.name.class", "entity.name.type.class"],
+      "settings": { "foreground": "#E5C07B" }
+    },
+    {
+      "name": "Entity Name Section",
+      "scope": ["entity.name.section"],
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "Entity Name Tag",
+      "scope": ["entity.name.tag"],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Entity Other Attribute Name",
+      "scope": ["entity.other.attribute-name"],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "Entity Other Attribute Name Id",
+      "scope": ["entity.other.attribute-name.id"],
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "Meta Class",
+      "scope": ["meta.class"],
+      "settings": { "foreground": "#E5C07B" }
+    },
+    {
+      "name": "Meta Class Body",
+      "scope": ["meta.class.body"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Meta Method Call,meta Method",
+      "scope": ["meta.method-call", "meta.method"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Meta Definition Variable",
+      "scope": ["meta.definition.variable"],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Meta Link",
+      "scope": ["meta.link"],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "Meta Require",
+      "scope": ["meta.require"],
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "Meta Selector",
+      "scope": ["meta.selector"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Meta Separator",
+      "scope": ["meta.separator"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Meta Tag",
+      "scope": ["meta.tag"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Underline",
+      "scope": ["underline"],
+      "settings": { "text-decoration": "underline" }
+    },
+    {
+      "name": "None",
+      "scope": ["none"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Invalid Deprecated",
+      "scope": ["invalid.deprecated"],
+      "settings": { "foreground": "#523D14", "background": "#E0C285" }
+    },
+    {
+      "name": "Invalid Illegal",
+      "scope": ["invalid.illegal"],
+      "settings": { "foreground": "white", "background": "#E05252" }
+    },
+    {
+      "name": "Markup Bold",
+      "scope": ["markup.bold"],
+      "settings": { "foreground": "#D19A66", "fontStyle": "bold" }
+    },
+    {
+      "name": "Markup Changed",
+      "scope": ["markup.changed"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Markup Deleted",
+      "scope": ["markup.deleted"],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Markup Italic",
+      "scope": ["markup.italic"],
+      "settings": { "foreground": "#C678DD", "fontStyle": "italic" }
+    },
+    {
+      "name": "Markup Heading",
+      "scope": ["markup.heading"],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Markup Heading Punctuation Definition Heading",
+      "scope": ["markup.heading punctuation.definition.heading"],
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "Markup Link",
+      "scope": ["markup.link"],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "Markup Inserted",
+      "scope": ["markup.inserted"],
+      "settings": { "foreground": "#98C379" }
+    },
+    {
+      "name": "Markup Quote",
+      "scope": ["markup.quote"],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "Markup Raw",
+      "scope": ["markup.raw"],
+      "settings": { "foreground": "#98C379" }
+    },
+    {
+      "name": "Source C Keyword Operator",
+      "scope": ["source.c keyword.operator"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Source Cpp Keyword Operator",
+      "scope": ["source.cpp keyword.operator"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Source Cs Keyword Operator",
+      "scope": ["source.cs keyword.operator"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Source Css Property Name,source Css Property Value",
+      "scope": ["source.css property-name", "source.css property-value"],
+      "settings": { "foreground": "#828997" }
+    },
+    {
+      "name": "Source Css Property Name Support,source Css Property Value Support",
+      "scope": [
+        "source.css property-name.support",
+        "source.css property-value.support"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Source Elixir Source Embedded Source",
+      "scope": ["source.elixir source.embedded.source"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Source Elixir Constant Language,source Elixir Constant Numeric,source Elixir Constant Definition",
+      "scope": [
+        "source.elixir constant.language",
+        "source.elixir constant.numeric",
+        "source.elixir constant.definition"
+      ],
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "Source Elixir Variable Definition,source Elixir Variable Anonymous",
+      "scope": [
+        "source.elixir variable.definition",
+        "source.elixir variable.anonymous"
+      ],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Source Elixir Parameter Variable Function",
+      "scope": ["source.elixir parameter.variable.function"],
+      "settings": { "foreground": "#D19A66", "fontStyle": "italic" }
+    },
+    {
+      "name": "Source Elixir Quoted",
+      "scope": ["source.elixir quoted"],
+      "settings": { "foreground": "#98C379" }
+    },
+    {
+      "name": "Source Elixir Keyword Special Method,source Elixir Embedded Section,source Elixir Embedded Source Empty",
+      "scope": [
+        "source.elixir keyword.special-method",
+        "source.elixir embedded.section",
+        "source.elixir embedded.source.empty"
+      ],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Source Elixir Readwrite Module Punctuation",
+      "scope": ["source.elixir readwrite.module punctuation"],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Source Elixir Regexp Section,source Elixir Regexp String",
+      "scope": ["source.elixir regexp.section", "source.elixir regexp.string"],
+      "settings": { "foreground": "#BE5046" }
+    },
+    {
+      "name": "Source Elixir Separator,source Elixir Keyword Operator",
+      "scope": ["source.elixir separator", "source.elixir keyword.operator"],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "Source Elixir Variable Constant",
+      "scope": ["source.elixir variable.constant"],
+      "settings": { "foreground": "#E5C07B" }
+    },
+    {
+      "name": "Source Elixir Array,source Elixir Scope,source Elixir Section",
+      "scope": [
+        "source.elixir array",
+        "source.elixir scope",
+        "source.elixir section"
+      ],
+      "settings": { "foreground": "#828997" }
+    },
+    {
+      "name": "Source Gfm Markup",
+      "scope": ["source.gfm markup"],
+      "settings": { "-webkit-font-smoothing": "auto" }
+    },
+    {
+      "name": "Source Gfm Link Entity",
+      "scope": ["source.gfm link entity"],
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "Source Go Storage Type String",
+      "scope": ["source.go storage.type.string"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Source Ini Keyword Other Definition Ini",
+      "scope": ["source.ini keyword.other.definition.ini"],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Source Java Storage Modifier Import",
+      "scope": ["source.java storage.modifier.import"],
+      "settings": { "foreground": "#E5C07B" }
+    },
+    {
+      "name": "Source Java Storage Type",
+      "scope": ["source.java storage.type"],
+      "settings": { "foreground": "#E5C07B" }
+    },
+    {
+      "name": "Source Java Keyword Operator Instanceof",
+      "scope": ["source.java keyword.operator.instanceof"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Source Java Properties Meta Key Pair",
+      "scope": ["source.java-properties meta.key-pair"],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Source Java Properties Meta Key Pair > Punctuation",
+      "scope": ["source.java-properties meta.key-pair > punctuation"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Source Js Keyword Operator",
+      "scope": ["source.js keyword.operator"],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "Source Js Keyword Operator Delete,source Js Keyword Operator In,source Js Keyword Operator Of,source Js Keyword Operator Instanceof,source Js Keyword Operator New,source Js Keyword Operator Typeof,source Js Keyword Operator Void",
+      "scope": [
+        "source.js keyword.operator.delete",
+        "source.js keyword.operator.in",
+        "source.js keyword.operator.of",
+        "source.js keyword.operator.instanceof",
+        "source.js keyword.operator.new",
+        "source.js keyword.operator.typeof",
+        "source.js keyword.operator.void"
+      ],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Source Ts Keyword Operator",
+      "scope": ["source.ts keyword.operator"],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "Source Flow Keyword Operator",
+      "scope": ["source.flow keyword.operator"],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > String Quoted Json",
+      "scope": [
+        "source.json meta.structure.dictionary.json > string.quoted.json"
+      ],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > String Quoted Json > Punctuation String",
+      "scope": [
+        "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string"
+      ],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > Value Json > String Quoted Json,source Json Meta Structure Array Json > Value Json > String Quoted Json,source Json Meta Structure Dictionary Json > Value Json > String Quoted Json > Punctuation,source Json Meta Structure Array Json > Value Json > String Quoted Json > Punctuation",
+      "scope": [
+        "source.json meta.structure.dictionary.json > value.json > string.quoted.json",
+        "source.json meta.structure.array.json > value.json > string.quoted.json",
+        "source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation",
+        "source.json meta.structure.array.json > value.json > string.quoted.json > punctuation"
+      ],
+      "settings": { "foreground": "#98C379" }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > Constant Language Json,source Json Meta Structure Array Json > Constant Language Json",
+      "scope": [
+        "source.json meta.structure.dictionary.json > constant.language.json",
+        "source.json meta.structure.array.json > constant.language.json"
+      ],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "Ng Interpolation",
+      "scope": ["ng.interpolation"],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Ng Interpolation Begin,ng Interpolation End",
+      "scope": ["ng.interpolation.begin", "ng.interpolation.end"],
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "Ng Interpolation Function",
+      "scope": ["ng.interpolation function"],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "Ng Interpolation Function Begin,ng Interpolation Function End",
+      "scope": [
+        "ng.interpolation function.begin",
+        "ng.interpolation function.end"
+      ],
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "Ng Interpolation Bool",
+      "scope": ["ng.interpolation bool"],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "Ng Interpolation Bracket",
+      "scope": ["ng.interpolation bracket"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Ng Pipe,ng Operator",
+      "scope": ["ng.pipe", "ng.operator"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Ng Tag",
+      "scope": ["ng.tag"],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "Ng Attribute With Value Attribute Name",
+      "scope": ["ng.attribute-with-value attribute-name"],
+      "settings": { "foreground": "#E5C07B" }
+    },
+    {
+      "name": "Ng Attribute With Value String",
+      "scope": ["ng.attribute-with-value string"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Ng Attribute With Value String Begin,ng Attribute With Value String End",
+      "scope": [
+        "ng.attribute-with-value string.begin",
+        "ng.attribute-with-value string.end"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Source Ruby Constant Other Symbol > Punctuation",
+      "scope": ["source.ruby constant.other.symbol > punctuation"],
+      "settings": { "foreground": "inherit" }
+    },
+    {
+      "name": "Source Php Class Bracket",
+      "scope": ["source.php class.bracket"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "Source Python Keyword Operator Logical Python",
+      "scope": ["source.python keyword.operator.logical.python"],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "Source Python Variable Parameter",
+      "scope": ["source.python variable.parameter"],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "customrule",
+      "scope": "customrule",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Support Type Property Name",
+      "scope": "support.type.property-name",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Punctuation for Quoted String",
+      "scope": "string.quoted.double punctuation",
+      "settings": { "foreground": "#98C379" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Support Constant",
+      "scope": "support.constant",
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Property Name",
+      "scope": "support.type.property-name.json",
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
+      "scope": "support.type.property-name.json punctuation",
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Punctuation for key-value",
+      "scope": [
+        "punctuation.separator.key-value.ts",
+        "punctuation.separator.key-value.js",
+        "punctuation.separator.key-value.tsx"
+      ],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Embedded Operator",
+      "scope": [
+        "source.js.embedded.html keyword.operator",
+        "source.ts.embedded.html keyword.operator"
+      ],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Variable Other Readwrite",
+      "scope": [
+        "variable.other.readwrite.js",
+        "variable.other.readwrite.ts",
+        "variable.other.readwrite.tsx"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Support Variable Dom",
+      "scope": ["support.variable.dom.js", "support.variable.dom.ts"],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Support Variable Property Dom",
+      "scope": [
+        "support.variable.property.dom.js",
+        "support.variable.property.dom.ts"
+      ],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Interpolation String Punctuation",
+      "scope": [
+        "meta.template.expression.js punctuation.definition",
+        "meta.template.expression.ts punctuation.definition"
+      ],
+      "settings": { "foreground": "#BE5046" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Punctuation Type Parameters",
+      "scope": [
+        "source.ts punctuation.definition.typeparameters",
+        "source.js punctuation.definition.typeparameters",
+        "source.tsx punctuation.definition.typeparameters"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Definition Block",
+      "scope": [
+        "source.ts punctuation.definition.block",
+        "source.js punctuation.definition.block",
+        "source.tsx punctuation.definition.block"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Punctuation Separator Comma",
+      "scope": [
+        "source.ts punctuation.separator.comma",
+        "source.js punctuation.separator.comma",
+        "source.tsx punctuation.separator.comma"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Variable Property",
+      "scope": [
+        "support.variable.property.js",
+        "support.variable.property.ts",
+        "support.variable.property.tsx"
+      ],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Default Keyword",
+      "scope": [
+        "keyword.control.default.js",
+        "keyword.control.default.ts",
+        "keyword.control.default.tsx"
+      ],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Instanceof Keyword",
+      "scope": [
+        "keyword.operator.expression.instanceof.js",
+        "keyword.operator.expression.instanceof.ts",
+        "keyword.operator.expression.instanceof.tsx"
+      ],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Of Keyword",
+      "scope": [
+        "keyword.operator.expression.of.js",
+        "keyword.operator.expression.of.ts",
+        "keyword.operator.expression.of.tsx"
+      ],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Braces/Brackets",
+      "scope": [
+        "meta.brace.round.js",
+        "meta.array-binding-pattern-variable.js",
+        "meta.brace.square.js",
+        "meta.brace.round.ts",
+        "meta.array-binding-pattern-variable.ts",
+        "meta.brace.square.ts",
+        "meta.brace.round.tsx",
+        "meta.array-binding-pattern-variable.tsx",
+        "meta.brace.square.tsx"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Punctuation Accessor",
+      "scope": [
+        "source.js punctuation.accessor",
+        "source.ts punctuation.accessor",
+        "source.tsx punctuation.accessor"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Punctuation Terminator Statement",
+      "scope": [
+        "punctuation.terminator.statement.js",
+        "punctuation.terminator.statement.ts",
+        "punctuation.terminator.statement.tsx"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Array variables",
+      "scope": [
+        "meta.array-binding-pattern-variable.js variable.other.readwrite.js",
+        "meta.array-binding-pattern-variable.ts variable.other.readwrite.ts",
+        "meta.array-binding-pattern-variable.tsx variable.other.readwrite.tsx"
+      ],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Support Variables",
+      "scope": [
+        "source.js support.variable",
+        "source.ts support.variable",
+        "source.tsx support.variable"
+      ],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Support Variables",
+      "scope": [
+        "variable.other.constant.property.js",
+        "variable.other.constant.property.ts",
+        "variable.other.constant.property.tsx"
+      ],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Keyword New",
+      "scope": [
+        "keyword.operator.new.ts",
+        "keyword.operator.new.j",
+        "keyword.operator.new.tsx"
+      ],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] TS Keyword Operator",
+      "scope": ["source.ts keyword.operator", "source.tsx keyword.operator"],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Punctuation Parameter Separator",
+      "scope": [
+        "punctuation.separator.parameter.js",
+        "punctuation.separator.parameter.ts",
+        "punctuation.separator.parameter.tsx "
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Import",
+      "scope": [
+        "constant.language.import-export-all.js",
+        "constant.language.import-export-all.ts"
+      ],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSX/TSX Import",
+      "scope": [
+        "constant.language.import-export-all.jsx",
+        "constant.language.import-export-all.tsx"
+      ],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Keyword Control As",
+      "scope": [
+        "keyword.control.as.js",
+        "keyword.control.as.ts",
+        "keyword.control.as.jsx",
+        "keyword.control.as.tsx"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Variable Alias",
+      "scope": [
+        "variable.other.readwrite.alias.js",
+        "variable.other.readwrite.alias.ts",
+        "variable.other.readwrite.alias.jsx",
+        "variable.other.readwrite.alias.tsx"
+      ],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Constants",
+      "scope": [
+        "variable.other.constant.js",
+        "variable.other.constant.ts",
+        "variable.other.constant.jsx",
+        "variable.other.constant.tsx"
+      ],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Export Variable",
+      "scope": [
+        "meta.export.default.js variable.other.readwrite.js",
+        "meta.export.default.ts variable.other.readwrite.ts"
+      ],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Template Strings Punctuation Accessor",
+      "scope": [
+        "source.js meta.template.expression.js punctuation.accessor",
+        "source.ts meta.template.expression.ts punctuation.accessor",
+        "source.tsx meta.template.expression.tsx punctuation.accessor"
+      ],
+      "settings": { "foreground": "#98C379" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Import equals",
+      "scope": [
+        "source.js meta.import-equals.external.js keyword.operator",
+        "source.jsx meta.import-equals.external.jsx keyword.operator",
+        "source.ts meta.import-equals.external.ts keyword.operator",
+        "source.tsx meta.import-equals.external.tsx keyword.operator"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Type Module",
+      "scope": "entity.name.type.module.js,entity.name.type.module.ts,entity.name.type.module.jsx,entity.name.type.module.tsx",
+      "settings": { "foreground": "#98C379" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Meta Class",
+      "scope": "meta.class.js,meta.class.ts,meta.class.jsx,meta.class.tsx",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Property Definition Variable",
+      "scope": [
+        "meta.definition.property.js variable",
+        "meta.definition.property.ts variable",
+        "meta.definition.property.jsx variable",
+        "meta.definition.property.tsx variable"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Meta Type Parameters Type",
+      "scope": [
+        "meta.type.parameters.js support.type",
+        "meta.type.parameters.jsx support.type",
+        "meta.type.parameters.ts support.type",
+        "meta.type.parameters.tsx support.type"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Meta Tag Keyword Operator",
+      "scope": [
+        "source.js meta.tag.js keyword.operator",
+        "source.jsx meta.tag.jsx keyword.operator",
+        "source.ts meta.tag.ts keyword.operator",
+        "source.tsx meta.tag.tsx keyword.operator"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Meta Tag Punctuation",
+      "scope": [
+        "meta.tag.js punctuation.section.embedded",
+        "meta.tag.jsx punctuation.section.embedded",
+        "meta.tag.ts punctuation.section.embedded",
+        "meta.tag.tsx punctuation.section.embedded"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Meta Array Literal Variable",
+      "scope": [
+        "meta.array.literal.js variable",
+        "meta.array.literal.jsx variable",
+        "meta.array.literal.ts variable",
+        "meta.array.literal.tsx variable"
+      ],
+      "settings": { "foreground": "#E5C07B" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Module Exports",
+      "scope": [
+        "support.type.object.module.js",
+        "support.type.object.module.jsx",
+        "support.type.object.module.ts",
+        "support.type.object.module.tsx"
+      ],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Constants",
+      "scope": ["constant.language.json"],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Object Constants",
+      "scope": [
+        "variable.other.constant.object.js",
+        "variable.other.constant.object.jsx",
+        "variable.other.constant.object.ts",
+        "variable.other.constant.object.tsx"
+      ],
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Properties Keyword",
+      "scope": [
+        "storage.type.property.js",
+        "storage.type.property.jsx",
+        "storage.type.property.ts",
+        "storage.type.property.tsx"
+      ],
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Single Quote Inside Templated String",
+      "scope": [
+        "meta.template.expression.js string.quoted punctuation.definition",
+        "meta.template.expression.jsx string.quoted punctuation.definition",
+        "meta.template.expression.ts string.quoted punctuation.definition",
+        "meta.template.expression.tsx string.quoted punctuation.definition"
+      ],
+      "settings": { "foreground": "#98C379" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Backtick inside Templated String",
+      "scope": [
+        "meta.template.expression.js string.template punctuation.definition.string.template",
+        "meta.template.expression.jsx string.template punctuation.definition.string.template",
+        "meta.template.expression.ts string.template punctuation.definition.string.template",
+        "meta.template.expression.tsx string.template punctuation.definition.string.template"
+      ],
+      "settings": { "foreground": "#98C379" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS In Keyword for Loops",
+      "scope": [
+        "keyword.operator.expression.in.js",
+        "keyword.operator.expression.in.jsx",
+        "keyword.operator.expression.in.ts",
+        "keyword.operator.expression.in.tsx"
+      ],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Variable Other Object",
+      "scope": ["variable.other.object.js", "variable.other.object.ts"],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Meta Object Literal Key",
+      "scope": ["meta.object-literal.key.js", "meta.object-literal.key.ts"],
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Constants Other",
+      "scope": "source.python constant.other",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Constants",
+      "scope": "source.python constant",
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Placeholder Character",
+      "scope": "constant.character.format.placeholder.other.python storage",
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Magic",
+      "scope": "support.variable.magic.python",
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Meta Function Parameters",
+      "scope": "meta.function.parameters.python",
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Function Separator Annotation",
+      "scope": "punctuation.separator.annotation.python",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Function Separator Punctuation",
+      "scope": "punctuation.separator.parameters.python",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Fields",
+      "scope": "entity.name.variable.field.cs",
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Keyword Operators",
+      "scope": "source.cs keyword.operator",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Variables",
+      "scope": "variable.other.readwrite.cs",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Variables Other",
+      "scope": "variable.other.object.cs",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Property Other",
+      "scope": "variable.other.object.property.cs",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Property",
+      "scope": "entity.name.variable.property.cs",
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Storage Type",
+      "scope": "storage.type.cs",
+      "settings": { "foreground": "#E5C07B" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Unsafe Keyword",
+      "scope": "keyword.other.unsafe.rust",
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Entity Name Type",
+      "scope": "entity.name.type.rust",
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Storage Modifier Lifetime",
+      "scope": "storage.modifier.lifetime.rust",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Entity Name Lifetime",
+      "scope": "entity.name.lifetime.rust",
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Storage Type Core",
+      "scope": "storage.type.core.rust",
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Meta Attribute",
+      "scope": "meta.attribute.rust",
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Storage Class Std",
+      "scope": "storage.class.std.rust",
+      "settings": { "foreground": "#56B6C2" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Raw Block",
+      "scope": "markup.raw.block.markdown",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Shell Variables Punctuation Definition",
+      "scope": "punctuation.definition.variable.shell",
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Css Support Constant Value",
+      "scope": "support.constant.property-value.css",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Css Punctuation Definition Constant",
+      "scope": "punctuation.definition.constant.css",
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Sass Punctuation for key-value",
+      "scope": "punctuation.separator.key-value.scss",
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Sass Punctuation for constants",
+      "scope": "punctuation.definition.constant.scss",
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Sass Punctuation for key-value",
+      "scope": "meta.property-list.scss punctuation.separator.key-value.scss",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Java Storage Type Primitive Array",
+      "scope": "storage.type.primitive.array.java",
+      "settings": { "foreground": "#E5C07B" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown headings",
+      "scope": "entity.name.section.markdown",
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
+      "scope": "punctuation.definition.heading.markdown",
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading setext",
+      "scope": "markup.heading.setext",
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
+      "scope": "punctuation.definition.bold.markdown",
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.markdown",
+      "settings": { "foreground": "#98C379" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
+      "scope": "beginning.punctuation.definition.list.markdown",
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Quote",
+      "scope": "markup.quote.markdown",
+      "settings": { "foreground": "#5C6370", "fontStyle": "italic" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
+      "scope": [
+        "punctuation.definition.string.begin.markdown",
+        "punctuation.definition.string.end.markdown",
+        "punctuation.definition.metadata.markdown"
+      ],
+      "settings": { "foreground": "#ABB2BF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
+      "scope": "punctuation.definition.metadata.markdown",
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
+      "scope": [
+        "markup.underline.link.markdown",
+        "markup.underline.link.image.markdown"
+      ],
+      "settings": { "foreground": "#C678DD" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
+      "scope": [
+        "string.other.link.title.markdown",
+        "string.other.link.description.markdown"
+      ],
+      "settings": { "foreground": "#61AFEF" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Ruby Punctuation Separator Variable",
+      "scope": "punctuation.separator.variable.ruby",
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Ruby Other Constant Variable",
+      "scope": "variable.other.constant.ruby",
+      "settings": { "foreground": "#D19A66" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Ruby Keyword Operator Other",
+      "scope": "keyword.operator.other.ruby",
+      "settings": { "foreground": "#98C379" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] PHP Punctuation Variable Definition",
+      "scope": "punctuation.definition.variable.php",
+      "settings": { "foreground": "#E06C75" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] PHP Meta Class",
+      "scope": "meta.class.php",
+      "settings": { "foreground": "#ABB2BF" }
+    }
+  ],
+  "uuid": "32bd64fa-d60a-4858-a5fc-5164cc49a2b8"
+}

--- a/packages/shiki/themes/onelight.json
+++ b/packages/shiki/themes/onelight.json
@@ -1,0 +1,1374 @@
+{
+  "author": "akamud",
+  "name": "OneLight",
+  "colors": {
+    "activityBar.background": "#FAFAFA",
+    "activityBar.foreground": "#121417",
+    "activityBarBadge.background": "#526FFF",
+    "activityBarBadge.foreground": "#FFFFFF",
+    "button.background": "#5871EF",
+    "button.foreground": "#FFFFFF",
+    "button.hoverBackground": "#6B83ED",
+    "diffEditor.insertedTextBackground": "#00809B33",
+    "dropdown.background": "#FFFFFF",
+    "dropdown.border": "#DBDBDC",
+    "editorIndentGuide.activeBackground": "#626772",
+    "editor.background": "#FAFAFA",
+    "editor.foreground": "#383A42",
+    "editor.lineHighlightBackground": "#383A420C",
+    "editor.selectionBackground": "#E5E5E6",
+    "editorCursor.foreground": "#526FFF",
+    "editor.findMatchHighlightBackground": "#526FFF33",
+    "editorGroup.background": "#EAEAEB",
+    "editorGroup.border": "#DBDBDC",
+    "editorGroupHeader.tabsBackground": "#EAEAEB",
+    "editorIndentGuide.background": "#383A4233",
+    "editorLineNumber.foreground": "#9D9D9F",
+    "editorLineNumber.activeForeground": "#383A42",
+    "editorWhitespace.foreground": "#383A4233",
+    "editorRuler.foreground": "#383A4233",
+    "editorHoverWidget.background": "#EAEAEB",
+    "editorHoverWidget.border": "#DBDBDC",
+    "editorSuggestWidget.background": "#EAEAEB",
+    "editorSuggestWidget.border": "#DBDBDC",
+    "editorSuggestWidget.selectedBackground": "#FFFFFF",
+    "editorWidget.background": "#EAEAEB",
+    "editorWidget.border": "#E5E5E6",
+    "input.background": "#FFFFFF",
+    "input.border": "#DBDBDC",
+    "focusBorder": "#526FFF",
+    "list.activeSelectionBackground": "#DBDBDC",
+    "list.activeSelectionForeground": "#232324",
+    "list.focusBackground": "#DBDBDC",
+    "list.hoverBackground": "#DBDBDC66",
+    "list.highlightForeground": "#121417",
+    "list.inactiveSelectionBackground": "#DBDBDC",
+    "list.inactiveSelectionForeground": "#232324",
+    "notification.background": "#333333",
+    "pickerGroup.border": "#526FFF",
+    "scrollbarSlider.background": "#4E566680",
+    "scrollbarSlider.activeBackground": "#747D9180",
+    "scrollbarSlider.hoverBackground": "#5A637580",
+    "sideBar.background": "#EAEAEB",
+    "sideBarSectionHeader.background": "#FAFAFA",
+    "statusBar.background": "#EAEAEB",
+    "statusBar.foreground": "#424243",
+    "statusBarItem.hoverBackground": "#DBDBDC",
+    "statusBar.noFolderBackground": "#EAEAEB",
+    "tab.activeBackground": "#FAFAFA",
+    "tab.activeForeground": "#121417",
+    "tab.border": "#DBDBDC",
+    "tab.inactiveBackground": "#EAEAEB",
+    "titleBar.activeBackground": "#EAEAEB",
+    "titleBar.activeForeground": "#424243",
+    "titleBar.inactiveBackground": "#EAEAEB",
+    "titleBar.inactiveForeground": "#424243",
+    "statusBar.debuggingForeground": "#FFFFFF",
+    "extensionButton.prominentBackground": "#3BBA54",
+    "extensionButton.prominentHoverBackground": "#4CC263",
+    "badge.background": "#526FFF",
+    "badge.foreground": "#FFFFFF",
+    "peekView.border": "#526FFF",
+    "peekViewResult.background": "#EAEAEB",
+    "peekViewResult.selectionBackground": "#DBDBDC",
+    "peekViewTitle.background": "#FFFFFF",
+    "peekViewEditor.background": "#FFFFFF"
+  },
+  "tokenColors": [
+    {
+      "name": "Comment",
+      "scope": ["comment"],
+      "settings": { "foreground": "#A0A1A7", "fontStyle": "italic" }
+    },
+    {
+      "name": "Comment Markup Link",
+      "scope": ["comment markup.link"],
+      "settings": { "foreground": "#A0A1A7" }
+    },
+    {
+      "name": "Entity Name Type",
+      "scope": ["entity.name.type"],
+      "settings": { "foreground": "#C18401" }
+    },
+    {
+      "name": "Entity Other Inherited Class",
+      "scope": ["entity.other.inherited-class"],
+      "settings": { "foreground": "#C18401" }
+    },
+    {
+      "name": "Keyword",
+      "scope": ["keyword"],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Keyword Control",
+      "scope": ["keyword.control"],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Keyword Operator",
+      "scope": ["keyword.operator"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Keyword Other Special Method",
+      "scope": ["keyword.other.special-method"],
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "Keyword Other Unit",
+      "scope": ["keyword.other.unit"],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "Storage",
+      "scope": ["storage"],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Storage Type Annotation,storage Type Primitive",
+      "scope": ["storage.type.annotation", "storage.type.primitive"],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Storage Modifier Package,storage Modifier Import",
+      "scope": ["storage.modifier.package", "storage.modifier.import"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Constant",
+      "scope": ["constant"],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "Constant Variable",
+      "scope": ["constant.variable"],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "Constant Character Escape",
+      "scope": ["constant.character.escape"],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "Constant Numeric",
+      "scope": ["constant.numeric"],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "Constant Other Color",
+      "scope": ["constant.other.color"],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "Constant Other Symbol",
+      "scope": ["constant.other.symbol"],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "Variable",
+      "scope": ["variable"],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Variable Interpolation",
+      "scope": ["variable.interpolation"],
+      "settings": { "foreground": "#CA1243" }
+    },
+    {
+      "name": "Variable Parameter",
+      "scope": ["variable.parameter"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "String",
+      "scope": ["string"],
+      "settings": { "foreground": "#50A14F" }
+    },
+    {
+      "name": "String > Source,string Embedded",
+      "scope": ["string > source", "string embedded"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "String Regexp",
+      "scope": ["string.regexp"],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "String Regexp Source Ruby Embedded",
+      "scope": ["string.regexp source.ruby.embedded"],
+      "settings": { "foreground": "#C18401" }
+    },
+    {
+      "name": "String Other Link",
+      "scope": ["string.other.link"],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Punctuation Definition Comment",
+      "scope": ["punctuation.definition.comment"],
+      "settings": { "foreground": "#A0A1A7" }
+    },
+    {
+      "name": "Punctuation Definition Method Parameters,punctuation Definition Function Parameters,punctuation Definition Parameters,punctuation Definition Separator,punctuation Definition Seperator,punctuation Definition Array",
+      "scope": [
+        "punctuation.definition.method-parameters",
+        "punctuation.definition.function-parameters",
+        "punctuation.definition.parameters",
+        "punctuation.definition.separator",
+        "punctuation.definition.seperator",
+        "punctuation.definition.array"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Punctuation Definition Heading,punctuation Definition Identity",
+      "scope": [
+        "punctuation.definition.heading",
+        "punctuation.definition.identity"
+      ],
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "Punctuation Definition Bold",
+      "scope": ["punctuation.definition.bold"],
+      "settings": { "foreground": "#C18401", "fontStyle": "bold" }
+    },
+    {
+      "name": "Punctuation Definition Italic",
+      "scope": ["punctuation.definition.italic"],
+      "settings": { "foreground": "#A626A4", "fontStyle": "italic" }
+    },
+    {
+      "name": "Punctuation Section Embedded",
+      "scope": ["punctuation.section.embedded"],
+      "settings": { "foreground": "#CA1243" }
+    },
+    {
+      "name": "Punctuation Section Method,punctuation Section Class,punctuation Section Inner Class",
+      "scope": [
+        "punctuation.section.method",
+        "punctuation.section.class",
+        "punctuation.section.inner-class"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Support Class",
+      "scope": ["support.class"],
+      "settings": { "foreground": "#C18401" }
+    },
+    {
+      "name": "Support Type",
+      "scope": ["support.type"],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "Support Function",
+      "scope": ["support.function"],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "Support Function Any Method",
+      "scope": ["support.function.any-method"],
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "Entity Name Function",
+      "scope": ["entity.name.function"],
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "Entity Name Class,entity Name Type Class",
+      "scope": ["entity.name.class", "entity.name.type.class"],
+      "settings": { "foreground": "#C18401" }
+    },
+    {
+      "name": "Entity Name Section",
+      "scope": ["entity.name.section"],
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "Entity Name Tag",
+      "scope": ["entity.name.tag"],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Entity Other Attribute Name",
+      "scope": ["entity.other.attribute-name"],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "Entity Other Attribute Name Id",
+      "scope": ["entity.other.attribute-name.id"],
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "Meta Class",
+      "scope": ["meta.class"],
+      "settings": { "foreground": "#C18401" }
+    },
+    {
+      "name": "Meta Class Body",
+      "scope": ["meta.class.body"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Meta Method Call,meta Method",
+      "scope": ["meta.method-call", "meta.method"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Meta Definition Variable",
+      "scope": ["meta.definition.variable"],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Meta Link",
+      "scope": ["meta.link"],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "Meta Require",
+      "scope": ["meta.require"],
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "Meta Selector",
+      "scope": ["meta.selector"],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Meta Separator",
+      "scope": ["meta.separator"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Meta Tag",
+      "scope": ["meta.tag"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Underline",
+      "scope": ["underline"],
+      "settings": { "text-decoration": "underline" }
+    },
+    {
+      "name": "None",
+      "scope": ["none"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Invalid Deprecated",
+      "scope": ["invalid.deprecated"],
+      "settings": { "foreground": "#000000", "background": "#F2A60D" }
+    },
+    {
+      "name": "Invalid Illegal",
+      "scope": ["invalid.illegal"],
+      "settings": { "foreground": "white", "background": "#FF1414" }
+    },
+    {
+      "name": "Markup Bold",
+      "scope": ["markup.bold"],
+      "settings": { "foreground": "#986801", "fontStyle": "bold" }
+    },
+    {
+      "name": "Markup Changed",
+      "scope": ["markup.changed"],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Markup Deleted",
+      "scope": ["markup.deleted"],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Markup Italic",
+      "scope": ["markup.italic"],
+      "settings": { "foreground": "#A626A4", "fontStyle": "italic" }
+    },
+    {
+      "name": "Markup Heading",
+      "scope": ["markup.heading"],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Markup Heading Punctuation Definition Heading",
+      "scope": ["markup.heading punctuation.definition.heading"],
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "Markup Link",
+      "scope": ["markup.link"],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "Markup Inserted",
+      "scope": ["markup.inserted"],
+      "settings": { "foreground": "#50A14F" }
+    },
+    {
+      "name": "Markup Quote",
+      "scope": ["markup.quote"],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "Markup Raw",
+      "scope": ["markup.raw"],
+      "settings": { "foreground": "#50A14F" }
+    },
+    {
+      "name": "Source C Keyword Operator",
+      "scope": ["source.c keyword.operator"],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Source Cpp Keyword Operator",
+      "scope": ["source.cpp keyword.operator"],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Source Cs Keyword Operator",
+      "scope": ["source.cs keyword.operator"],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Source Css Property Name,source Css Property Value",
+      "scope": ["source.css property-name", "source.css property-value"],
+      "settings": { "foreground": "#696C77" }
+    },
+    {
+      "name": "Source Css Property Name Support,source Css Property Value Support",
+      "scope": [
+        "source.css property-name.support",
+        "source.css property-value.support"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Source Elixir Source Embedded Source",
+      "scope": ["source.elixir source.embedded.source"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Source Elixir Constant Language,source Elixir Constant Numeric,source Elixir Constant Definition",
+      "scope": [
+        "source.elixir constant.language",
+        "source.elixir constant.numeric",
+        "source.elixir constant.definition"
+      ],
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "Source Elixir Variable Definition,source Elixir Variable Anonymous",
+      "scope": [
+        "source.elixir variable.definition",
+        "source.elixir variable.anonymous"
+      ],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Source Elixir Parameter Variable Function",
+      "scope": ["source.elixir parameter.variable.function"],
+      "settings": { "foreground": "#986801", "fontStyle": "italic" }
+    },
+    {
+      "name": "Source Elixir Quoted",
+      "scope": ["source.elixir quoted"],
+      "settings": { "foreground": "#50A14F" }
+    },
+    {
+      "name": "Source Elixir Keyword Special Method,source Elixir Embedded Section,source Elixir Embedded Source Empty",
+      "scope": [
+        "source.elixir keyword.special-method",
+        "source.elixir embedded.section",
+        "source.elixir embedded.source.empty"
+      ],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Source Elixir Readwrite Module Punctuation",
+      "scope": ["source.elixir readwrite.module punctuation"],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Source Elixir Regexp Section,source Elixir Regexp String",
+      "scope": ["source.elixir regexp.section", "source.elixir regexp.string"],
+      "settings": { "foreground": "#CA1243" }
+    },
+    {
+      "name": "Source Elixir Separator,source Elixir Keyword Operator",
+      "scope": ["source.elixir separator", "source.elixir keyword.operator"],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "Source Elixir Variable Constant",
+      "scope": ["source.elixir variable.constant"],
+      "settings": { "foreground": "#C18401" }
+    },
+    {
+      "name": "Source Elixir Array,source Elixir Scope,source Elixir Section",
+      "scope": [
+        "source.elixir array",
+        "source.elixir scope",
+        "source.elixir section"
+      ],
+      "settings": { "foreground": "#696C77" }
+    },
+    {
+      "name": "Source Gfm Markup",
+      "scope": ["source.gfm markup"],
+      "settings": { "-webkit-font-smoothing": "auto" }
+    },
+    {
+      "name": "Source Gfm Link Entity",
+      "scope": ["source.gfm link entity"],
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "Source Go Storage Type String",
+      "scope": ["source.go storage.type.string"],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Source Ini Keyword Other Definition Ini",
+      "scope": ["source.ini keyword.other.definition.ini"],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Source Java Storage Modifier Import",
+      "scope": ["source.java storage.modifier.import"],
+      "settings": { "foreground": "#C18401" }
+    },
+    {
+      "name": "Source Java Storage Type",
+      "scope": ["source.java storage.type"],
+      "settings": { "foreground": "#C18401" }
+    },
+    {
+      "name": "Source Java Keyword Operator Instanceof",
+      "scope": ["source.java keyword.operator.instanceof"],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Source Java Properties Meta Key Pair",
+      "scope": ["source.java-properties meta.key-pair"],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Source Java Properties Meta Key Pair > Punctuation",
+      "scope": ["source.java-properties meta.key-pair > punctuation"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Source Js Keyword Operator",
+      "scope": ["source.js keyword.operator"],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "Source Js Keyword Operator Delete,source Js Keyword Operator In,source Js Keyword Operator Of,source Js Keyword Operator Instanceof,source Js Keyword Operator New,source Js Keyword Operator Typeof,source Js Keyword Operator Void",
+      "scope": [
+        "source.js keyword.operator.delete",
+        "source.js keyword.operator.in",
+        "source.js keyword.operator.of",
+        "source.js keyword.operator.instanceof",
+        "source.js keyword.operator.new",
+        "source.js keyword.operator.typeof",
+        "source.js keyword.operator.void"
+      ],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Source Ts Keyword Operator",
+      "scope": ["source.ts keyword.operator"],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "Source Flow Keyword Operator",
+      "scope": ["source.flow keyword.operator"],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > String Quoted Json",
+      "scope": [
+        "source.json meta.structure.dictionary.json > string.quoted.json"
+      ],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > String Quoted Json > Punctuation String",
+      "scope": [
+        "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string"
+      ],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > Value Json > String Quoted Json,source Json Meta Structure Array Json > Value Json > String Quoted Json,source Json Meta Structure Dictionary Json > Value Json > String Quoted Json > Punctuation,source Json Meta Structure Array Json > Value Json > String Quoted Json > Punctuation",
+      "scope": [
+        "source.json meta.structure.dictionary.json > value.json > string.quoted.json",
+        "source.json meta.structure.array.json > value.json > string.quoted.json",
+        "source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation",
+        "source.json meta.structure.array.json > value.json > string.quoted.json > punctuation"
+      ],
+      "settings": { "foreground": "#50A14F" }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > Constant Language Json,source Json Meta Structure Array Json > Constant Language Json",
+      "scope": [
+        "source.json meta.structure.dictionary.json > constant.language.json",
+        "source.json meta.structure.array.json > constant.language.json"
+      ],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "Ng Interpolation",
+      "scope": ["ng.interpolation"],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Ng Interpolation Begin,ng Interpolation End",
+      "scope": ["ng.interpolation.begin", "ng.interpolation.end"],
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "Ng Interpolation Function",
+      "scope": ["ng.interpolation function"],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "Ng Interpolation Function Begin,ng Interpolation Function End",
+      "scope": [
+        "ng.interpolation function.begin",
+        "ng.interpolation function.end"
+      ],
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "Ng Interpolation Bool",
+      "scope": ["ng.interpolation bool"],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "Ng Interpolation Bracket",
+      "scope": ["ng.interpolation bracket"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Ng Pipe,ng Operator",
+      "scope": ["ng.pipe", "ng.operator"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Ng Tag",
+      "scope": ["ng.tag"],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "Ng Attribute With Value Attribute Name",
+      "scope": ["ng.attribute-with-value attribute-name"],
+      "settings": { "foreground": "#C18401" }
+    },
+    {
+      "name": "Ng Attribute With Value String",
+      "scope": ["ng.attribute-with-value string"],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Ng Attribute With Value String Begin,ng Attribute With Value String End",
+      "scope": [
+        "ng.attribute-with-value string.begin",
+        "ng.attribute-with-value string.end"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Source Ruby Constant Other Symbol > Punctuation",
+      "scope": ["source.ruby constant.other.symbol > punctuation"],
+      "settings": { "foreground": "inherit" }
+    },
+    {
+      "name": "Source Php Class Bracket",
+      "scope": ["source.php class.bracket"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "Source Python Keyword Operator Logical Python",
+      "scope": ["source.python keyword.operator.logical.python"],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "Source Python Variable Parameter",
+      "scope": ["source.python variable.parameter"],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "customrule",
+      "scope": "customrule",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Support Type Property Name",
+      "scope": "support.type.property-name",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Punctuation for Quoted String",
+      "scope": "string.quoted.double punctuation",
+      "settings": { "foreground": "#50A14F" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Support Constant",
+      "scope": "support.constant",
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Property Name",
+      "scope": "support.type.property-name.json",
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
+      "scope": "support.type.property-name.json punctuation",
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Punctuation for key-value",
+      "scope": [
+        "punctuation.separator.key-value.ts",
+        "punctuation.separator.key-value.js",
+        "punctuation.separator.key-value.tsx"
+      ],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Embedded Operator",
+      "scope": [
+        "source.js.embedded.html keyword.operator",
+        "source.ts.embedded.html keyword.operator"
+      ],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Variable Other Readwrite",
+      "scope": [
+        "variable.other.readwrite.js",
+        "variable.other.readwrite.ts",
+        "variable.other.readwrite.tsx"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Support Variable Dom",
+      "scope": ["support.variable.dom.js", "support.variable.dom.ts"],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Support Variable Property Dom",
+      "scope": [
+        "support.variable.property.dom.js",
+        "support.variable.property.dom.ts"
+      ],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Interpolation String Punctuation",
+      "scope": [
+        "meta.template.expression.js punctuation.definition",
+        "meta.template.expression.ts punctuation.definition"
+      ],
+      "settings": { "foreground": "#CA1243" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Punctuation Type Parameters",
+      "scope": [
+        "source.ts punctuation.definition.typeparameters",
+        "source.js punctuation.definition.typeparameters",
+        "source.tsx punctuation.definition.typeparameters"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Definition Block",
+      "scope": [
+        "source.ts punctuation.definition.block",
+        "source.js punctuation.definition.block",
+        "source.tsx punctuation.definition.block"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Punctuation Separator Comma",
+      "scope": [
+        "source.ts punctuation.separator.comma",
+        "source.js punctuation.separator.comma",
+        "source.tsx punctuation.separator.comma"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Variable Property",
+      "scope": [
+        "support.variable.property.js",
+        "support.variable.property.ts",
+        "support.variable.property.tsx"
+      ],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Default Keyword",
+      "scope": [
+        "keyword.control.default.js",
+        "keyword.control.default.ts",
+        "keyword.control.default.tsx"
+      ],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Instanceof Keyword",
+      "scope": [
+        "keyword.operator.expression.instanceof.js",
+        "keyword.operator.expression.instanceof.ts",
+        "keyword.operator.expression.instanceof.tsx"
+      ],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Of Keyword",
+      "scope": [
+        "keyword.operator.expression.of.js",
+        "keyword.operator.expression.of.ts",
+        "keyword.operator.expression.of.tsx"
+      ],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Braces/Brackets",
+      "scope": [
+        "meta.brace.round.js",
+        "meta.array-binding-pattern-variable.js",
+        "meta.brace.square.js",
+        "meta.brace.round.ts",
+        "meta.array-binding-pattern-variable.ts",
+        "meta.brace.square.ts",
+        "meta.brace.round.tsx",
+        "meta.array-binding-pattern-variable.tsx",
+        "meta.brace.square.tsx"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Punctuation Accessor",
+      "scope": [
+        "source.js punctuation.accessor",
+        "source.ts punctuation.accessor",
+        "source.tsx punctuation.accessor"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Punctuation Terminator Statement",
+      "scope": [
+        "punctuation.terminator.statement.js",
+        "punctuation.terminator.statement.ts",
+        "punctuation.terminator.statement.tsx"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Array variables",
+      "scope": [
+        "meta.array-binding-pattern-variable.js variable.other.readwrite.js",
+        "meta.array-binding-pattern-variable.ts variable.other.readwrite.ts",
+        "meta.array-binding-pattern-variable.tsx variable.other.readwrite.tsx"
+      ],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Support Variables",
+      "scope": [
+        "source.js support.variable",
+        "source.ts support.variable",
+        "source.tsx support.variable"
+      ],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Support Variables",
+      "scope": [
+        "variable.other.constant.property.js",
+        "variable.other.constant.property.ts",
+        "variable.other.constant.property.tsx"
+      ],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Keyword New",
+      "scope": [
+        "keyword.operator.new.ts",
+        "keyword.operator.new.j",
+        "keyword.operator.new.tsx"
+      ],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] TS Keyword Operator",
+      "scope": ["source.ts keyword.operator", "source.tsx keyword.operator"],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Punctuation Parameter Separator",
+      "scope": [
+        "punctuation.separator.parameter.js",
+        "punctuation.separator.parameter.ts",
+        "punctuation.separator.parameter.tsx "
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Import",
+      "scope": [
+        "constant.language.import-export-all.js",
+        "constant.language.import-export-all.ts"
+      ],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSX/TSX Import",
+      "scope": [
+        "constant.language.import-export-all.jsx",
+        "constant.language.import-export-all.tsx"
+      ],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Keyword Control As",
+      "scope": [
+        "keyword.control.as.js",
+        "keyword.control.as.ts",
+        "keyword.control.as.jsx",
+        "keyword.control.as.tsx"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Variable Alias",
+      "scope": [
+        "variable.other.readwrite.alias.js",
+        "variable.other.readwrite.alias.ts",
+        "variable.other.readwrite.alias.jsx",
+        "variable.other.readwrite.alias.tsx"
+      ],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Constants",
+      "scope": [
+        "variable.other.constant.js",
+        "variable.other.constant.ts",
+        "variable.other.constant.jsx",
+        "variable.other.constant.tsx"
+      ],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Export Variable",
+      "scope": [
+        "meta.export.default.js variable.other.readwrite.js",
+        "meta.export.default.ts variable.other.readwrite.ts"
+      ],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Template Strings Punctuation Accessor",
+      "scope": [
+        "source.js meta.template.expression.js punctuation.accessor",
+        "source.ts meta.template.expression.ts punctuation.accessor",
+        "source.tsx meta.template.expression.tsx punctuation.accessor"
+      ],
+      "settings": { "foreground": "#50A14F" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Import equals",
+      "scope": [
+        "source.js meta.import-equals.external.js keyword.operator",
+        "source.jsx meta.import-equals.external.jsx keyword.operator",
+        "source.ts meta.import-equals.external.ts keyword.operator",
+        "source.tsx meta.import-equals.external.tsx keyword.operator"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Type Module",
+      "scope": "entity.name.type.module.js,entity.name.type.module.ts,entity.name.type.module.jsx,entity.name.type.module.tsx",
+      "settings": { "foreground": "#50A14F" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Meta Class",
+      "scope": "meta.class.js,meta.class.ts,meta.class.jsx,meta.class.tsx",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Property Definition Variable",
+      "scope": [
+        "meta.definition.property.js variable",
+        "meta.definition.property.ts variable",
+        "meta.definition.property.jsx variable",
+        "meta.definition.property.tsx variable"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Meta Type Parameters Type",
+      "scope": [
+        "meta.type.parameters.js support.type",
+        "meta.type.parameters.jsx support.type",
+        "meta.type.parameters.ts support.type",
+        "meta.type.parameters.tsx support.type"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Meta Tag Keyword Operator",
+      "scope": [
+        "source.js meta.tag.js keyword.operator",
+        "source.jsx meta.tag.jsx keyword.operator",
+        "source.ts meta.tag.ts keyword.operator",
+        "source.tsx meta.tag.tsx keyword.operator"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Meta Tag Punctuation",
+      "scope": [
+        "meta.tag.js punctuation.section.embedded",
+        "meta.tag.jsx punctuation.section.embedded",
+        "meta.tag.ts punctuation.section.embedded",
+        "meta.tag.tsx punctuation.section.embedded"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Meta Array Literal Variable",
+      "scope": [
+        "meta.array.literal.js variable",
+        "meta.array.literal.jsx variable",
+        "meta.array.literal.ts variable",
+        "meta.array.literal.tsx variable"
+      ],
+      "settings": { "foreground": "#C18401" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Module Exports",
+      "scope": [
+        "support.type.object.module.js",
+        "support.type.object.module.jsx",
+        "support.type.object.module.ts",
+        "support.type.object.module.tsx"
+      ],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Constants",
+      "scope": ["constant.language.json"],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Object Constants",
+      "scope": [
+        "variable.other.constant.object.js",
+        "variable.other.constant.object.jsx",
+        "variable.other.constant.object.ts",
+        "variable.other.constant.object.tsx"
+      ],
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Properties Keyword",
+      "scope": [
+        "storage.type.property.js",
+        "storage.type.property.jsx",
+        "storage.type.property.ts",
+        "storage.type.property.tsx"
+      ],
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Single Quote Inside Templated String",
+      "scope": [
+        "meta.template.expression.js string.quoted punctuation.definition",
+        "meta.template.expression.jsx string.quoted punctuation.definition",
+        "meta.template.expression.ts string.quoted punctuation.definition",
+        "meta.template.expression.tsx string.quoted punctuation.definition"
+      ],
+      "settings": { "foreground": "#50A14F" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Backtick inside Templated String",
+      "scope": [
+        "meta.template.expression.js string.template punctuation.definition.string.template",
+        "meta.template.expression.jsx string.template punctuation.definition.string.template",
+        "meta.template.expression.ts string.template punctuation.definition.string.template",
+        "meta.template.expression.tsx string.template punctuation.definition.string.template"
+      ],
+      "settings": { "foreground": "#50A14F" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS In Keyword for Loops",
+      "scope": [
+        "keyword.operator.expression.in.js",
+        "keyword.operator.expression.in.jsx",
+        "keyword.operator.expression.in.ts",
+        "keyword.operator.expression.in.tsx"
+      ],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Variable Other Object",
+      "scope": ["variable.other.object.js", "variable.other.object.ts"],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JS/TS Meta Object Literal Key",
+      "scope": ["meta.object-literal.key.js", "meta.object-literal.key.ts"],
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Constants Other",
+      "scope": "source.python constant.other",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Constants",
+      "scope": "source.python constant",
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Placeholder Character",
+      "scope": "constant.character.format.placeholder.other.python storage",
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Magic",
+      "scope": "support.variable.magic.python",
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Meta Function Parameters",
+      "scope": "meta.function.parameters.python",
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Function Separator Annotation",
+      "scope": "punctuation.separator.annotation.python",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Python Function Separator Punctuation",
+      "scope": "punctuation.separator.parameters.python",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Fields",
+      "scope": "entity.name.variable.field.cs",
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Keyword Operators",
+      "scope": "source.cs keyword.operator",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Variables",
+      "scope": "variable.other.readwrite.cs",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Variables Other",
+      "scope": "variable.other.object.cs",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Property Other",
+      "scope": "variable.other.object.property.cs",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Property",
+      "scope": "entity.name.variable.property.cs",
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] CSharp Storage Type",
+      "scope": "storage.type.cs",
+      "settings": { "foreground": "#C18401" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Unsafe Keyword",
+      "scope": "keyword.other.unsafe.rust",
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Entity Name Type",
+      "scope": "entity.name.type.rust",
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Storage Modifier Lifetime",
+      "scope": "storage.modifier.lifetime.rust",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Entity Name Lifetime",
+      "scope": "entity.name.lifetime.rust",
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Storage Type Core",
+      "scope": "storage.type.core.rust",
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Meta Attribute",
+      "scope": "meta.attribute.rust",
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Rust Storage Class Std",
+      "scope": "storage.class.std.rust",
+      "settings": { "foreground": "#0184BC" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Raw Block",
+      "scope": "markup.raw.block.markdown",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Shell Variables Punctuation Definition",
+      "scope": "punctuation.definition.variable.shell",
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Css Support Constant Value",
+      "scope": "support.constant.property-value.css",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Css Punctuation Definition Constant",
+      "scope": "punctuation.definition.constant.css",
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Sass Punctuation for key-value",
+      "scope": "punctuation.separator.key-value.scss",
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Sass Punctuation for constants",
+      "scope": "punctuation.definition.constant.scss",
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Sass Punctuation for key-value",
+      "scope": "meta.property-list.scss punctuation.separator.key-value.scss",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Java Storage Type Primitive Array",
+      "scope": "storage.type.primitive.array.java",
+      "settings": { "foreground": "#C18401" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown headings",
+      "scope": "entity.name.section.markdown",
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
+      "scope": "punctuation.definition.heading.markdown",
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading setext",
+      "scope": "markup.heading.setext",
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
+      "scope": "punctuation.definition.bold.markdown",
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.markdown",
+      "settings": { "foreground": "#50A14F" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
+      "scope": "beginning.punctuation.definition.list.markdown",
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Quote",
+      "scope": "markup.quote.markdown",
+      "settings": { "foreground": "#A0A1A7", "fontStyle": "italic" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
+      "scope": [
+        "punctuation.definition.string.begin.markdown",
+        "punctuation.definition.string.end.markdown",
+        "punctuation.definition.metadata.markdown"
+      ],
+      "settings": { "foreground": "#383A42" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
+      "scope": "punctuation.definition.metadata.markdown",
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
+      "scope": [
+        "markup.underline.link.markdown",
+        "markup.underline.link.image.markdown"
+      ],
+      "settings": { "foreground": "#A626A4" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
+      "scope": [
+        "string.other.link.title.markdown",
+        "string.other.link.description.markdown"
+      ],
+      "settings": { "foreground": "#4078F2" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Ruby Punctuation Separator Variable",
+      "scope": "punctuation.separator.variable.ruby",
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Ruby Other Constant Variable",
+      "scope": "variable.other.constant.ruby",
+      "settings": { "foreground": "#986801" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Ruby Keyword Operator Other",
+      "scope": "keyword.operator.other.ruby",
+      "settings": { "foreground": "#50A14F" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] PHP Punctuation Variable Definition",
+      "scope": "punctuation.definition.variable.php",
+      "settings": { "foreground": "#E45649" }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] PHP Meta Class",
+      "scope": "meta.class.php",
+      "settings": { "foreground": "#383A42" }
+    }
+  ],
+  "uuid": "1446a9a1-9d70-421a-bae3-87b3b112ddb0"
+}

--- a/scripts/themeSources.ts
+++ b/scripts/themeSources.ts
@@ -64,7 +64,9 @@ export const githubThemeSources: [string, string][] = [
   [
     'rose-pine-moon',
     'https://github.com/rose-pine/vscode/blob/main/themes/rose-pine-moon-color-theme.json'
-  ]
+  ],
+  ['onelight', 'https://github.com/akamud/vscode-theme-onelight/blob/master/themes/OneLight.json'],
+  ['onedark', 'https://github.com/akamud/vscode-theme-onedark/blob/master/themes/OneDark.json']
 ]
 
 /**


### PR DESCRIPTION
- [ ] Add a test if possible
- [ ] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

<!-- If fixing a bug -->

- [ ] This PR fixes #

<!-- If adding a theme -->

- [ ] I have read docs for [adding a theme](https://github.com/shikijs/shiki/blob/main/docs/themes.md#adding-theme).

<!-- If adding a language -->

- [ ] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [ ] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [ ] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.