### PR TITLE
feat: adds cs alias to csharp so it matches the file extension

### DIFF
--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -27,7 +27,7 @@ export type Lang =
   | 'coffee'
   | 'cpp'
   | 'crystal'
-  | 'csharp' | 'c#'
+  | 'csharp' | 'c#' | 'cs'
   | 'css'
   | 'cue'
   | 'd'


### PR DESCRIPTION
this will improve syntax when using it inside vitepress and we won't need to specify the language while importing code from cs files.

- [ ] Add a test if possible
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

<!-- If fixing a bug -->

- [ ] This PR fixes #

<!-- If adding a theme -->

- [ ] I have read docs for [adding a theme](https://github.com/shikijs/shiki/blob/main/docs/themes.md#adding-theme).

<!-- If adding a language -->

- [ ] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [ ] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [ ] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.