### PR TITLE
fix: corrected introduced loader issue / fixes jsDelivr and unpkg bundles

### DIFF
--- a/packages/shiki/rollup.config.mjs
+++ b/packages/shiki/rollup.config.mjs
@@ -1,9 +1,9 @@
 //@ts-check
 
 // Re: https://github.com/rollup/plugins/issues/1366
-import { fileURLToPath } from 'url';
-const __filename = fileURLToPath(import.meta.url);
-global['__filename'] = __filename;
+import { fileURLToPath } from 'url'
+const __filename = fileURLToPath(import.meta.url)
+global['__filename'] = __filename
 
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
@@ -15,8 +15,6 @@ import rollupReplace from '@rollup/plugin-replace'
 import { defineConfig } from 'rollup'
 import { resolve } from 'path'
 import { readFileSync } from 'fs'
-
-
 
 const replace = opts => {
   return rollupReplace({
@@ -78,7 +76,6 @@ export default defineConfig([
   },
   {
     input: 'src/index.ts',
-    external,
     output: {
       file: 'dist/index.unpkg.iife.js',
       format: 'iife',
@@ -99,7 +96,6 @@ export default defineConfig([
   },
   {
     input: 'src/index.ts',
-    external,
     output: {
       file: 'dist/index.jsdelivr.iife.js',
       format: 'iife',

--- a/packages/shiki/src/loader.ts
+++ b/packages/shiki/src/loader.ts
@@ -46,7 +46,7 @@ let _onigurumaPromise: Promise<IOnigLib> = null
 export async function getOniguruma(wasmPath?: string): Promise<IOnigLib> {
   if (!_onigurumaPromise) {
     let loader: Promise<void>
-    if (wasmPath === 'vscode-oniguruma') {
+    if (wasmPath) {
       if (typeof WASM === 'string') {
         loader = loadWASM({
           data: await fetch(_resolvePath(join(...dirpathparts(wasmPath), 'onig.wasm')))

--- a/packages/shiki/src/loader.ts
+++ b/packages/shiki/src/loader.ts
@@ -46,7 +46,7 @@ let _onigurumaPromise: Promise<IOnigLib> = null
 export async function getOniguruma(wasmPath?: string): Promise<IOnigLib> {
   if (!_onigurumaPromise) {
     let loader: Promise<void>
-    if (wasmPath) {
+    if (isBrowser) {
       if (typeof WASM === 'string') {
         loader = loadWASM({
           data: await fetch(_resolvePath(join(...dirpathparts(wasmPath), 'onig.wasm')))

--- a/packages/shiki/src/loader.ts
+++ b/packages/shiki/src/loader.ts
@@ -14,7 +14,7 @@ export const isNode =
 export const isBrowser = isWebWorker || !isNode
 
 // to be replaced by rollup
-let CDN_ROOT = '____'
+let CDN_ROOT = '__CDN_ROOT__'
 let WASM: string | ArrayBuffer | Response = ''
 export const WASM_PATH = 'dist/'
 


### PR DESCRIPTION
@orta Unfortunately I introduced a bug with/for 0.12.0 [that breaks browser environments](https://github.com/shikijs/shiki/compare/main...muenzpraeger:shiki:rw/loader-fix?expand=1#diff-e34964bc43c8f1c17b359513e4ef22495a5ac8db4d44391c1fbbbc6859d13787L49).

While I was there I at least fixed the Rollup builds (back to the state of bundling like 0.10.1), so that unpkg and jsDelivr are working agin. This fixes #338 and fixes #365
