### PR TITLE
feat: add `ara` language

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -58,6 +58,7 @@ export type Lang =
   | 'apex'
   | 'apl'
   | 'applescript'
+  | 'ara'
   | 'asm'
   | 'astro'
   | 'awk'

--- a/packages/shiki/languages/ara.tmLanguage.json
+++ b/packages/shiki/languages/ara.tmLanguage.json
@@ -1,0 +1,425 @@
+{
+  "scopeName": "source.ara",
+  "name": "ara",
+  "fileTypes": ["ara"],
+  "patterns": [
+    {
+      "include": "#namespace"
+    },
+    {
+      "include": "#named-arguments"
+    },
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#numbers"
+    },
+    {
+      "include": "#operators"
+    },
+    {
+      "include": "#type"
+    },
+    {
+      "include": "#function-call"
+    }
+  ],
+  "repository": {
+    "class-name": {
+      "patterns": [
+        {
+          "begin": "\\b(?i)(?<!\\$)(?=[\\\\a-zA-Z_])",
+          "end": "(?i)([a-z_][a-z_0-9]*)?(?=[^a-z0-9_\\\\])\\b",
+          "endCaptures": {
+            "1": {
+              "name": "support.class.ara"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#namespace"
+            }
+          ]
+        }
+      ]
+    },
+    "type": {
+      "name": "support.type.php",
+      "patterns": [
+        {
+          "match": "\\b(?:void|true|false|null|never|float|bool|int|string|dict|vec|object|mixed|nonnull|resource|self|static|parent|iterable)\\b",
+          "name": "support.type.php"
+        },
+        {
+          "begin": "([A-Za-z_][A-Za-z0-9_]*)<",
+          "beginCaptures": {
+            "1": {
+              "name": "support.class.php"
+            }
+          },
+          "end": ">",
+          "patterns": [
+            {
+              "include": "#type-annotation"
+            }
+          ]
+        },
+        {
+          "begin": "(shape\\()",
+          "end": "((,|\\.\\.\\.)?\\s*\\))",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.operator.key.php"
+            }
+          },
+          "name": "storage.type.shape.php",
+          "patterns": [
+            {
+              "include": "#type-annotation"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#constants"
+            }
+          ]
+        },
+        {
+          "begin": "\\(",
+          "end": "\\)",
+          "patterns": [
+            {
+              "include": "#type-annotation"
+            }
+          ]
+        },
+        {
+          "begin": "\\(fn\\(",
+          "end": "\\)",
+          "patterns": [
+            {
+              "include": "#type-annotation"
+            }
+          ]
+        },
+        {
+          "include": "#class-name"
+        },
+        {
+          "include": "#comments"
+        }
+      ]
+    },
+    "namespace": {
+      "begin": "(?i)((namespace)|[a-z0-9_]+)?(\\\\)(?=.*?[^a-z_0-9\\\\])",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.type.namespace.php"
+        },
+        "3": {
+          "name": "punctuation.separator.inheritance.php"
+        }
+      },
+      "end": "(?i)(?=[a-z0-9_]*[^a-z0-9_\\\\])",
+      "name": "support.other.namespace.php",
+      "patterns": [
+        {
+          "name": "entity.name.type.namespace.php",
+          "match": "(?i)[a-z0-9_]+(?=\\\\)"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.inheritance.php"
+            }
+          },
+          "match": "(?i)(\\\\)"
+        }
+      ]
+    },
+    "named-arguments": {
+      "match": "(?i)(?<=^|\\(|,)\\s*([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)\\s*(:)(?!:)",
+      "captures": {
+        "1": {
+          "name": "entity.name.variable.parameter.ara"
+        },
+        "2": {
+          "name": "punctuation.separator.colon.ara"
+        }
+      }
+    },
+    "comments": {
+      "patterns": [
+        {
+          "begin": "/\\*",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.ara"
+            }
+          },
+          "end": "\\*/",
+          "name": "comment.block.ara"
+        },
+        {
+          "begin": "(^[ \\t]+)?(?=//)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.ara"
+            }
+          },
+          "end": "(?!\\G)",
+          "patterns": [
+            {
+              "begin": "//",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.ara"
+                }
+              },
+              "end": "\\n",
+              "name": "comment.line.double-slash.ara"
+            }
+          ]
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.ara",
+          "match": "\\b(await|async|concurrently|break|continue|do|else|elseif|for|if|loop|while|foreach|match|return|try|yield|from|catch|finally|default|exit)\\b"
+        },
+        {
+          "name": "storage.decl.ara",
+          "match": "\\b(const|enum|class|interface|trait|namespace|type|case|function|fn)\\b"
+        },
+        {
+          "name": "storage.modifier.ara",
+          "match": "\\b(final|abstract|static|readonly|public|private|protected)\\b"
+        },
+        {
+          "name": "keyword.other.ara",
+          "match": "\\b(as|is|extends|implements|use|where|clone|new)\\b"
+        }
+      ]
+    },
+    "function-call": {
+      "patterns": [
+        {
+          "begin": "(?i)(?=\\\\?[a-z_0-9\\\\]+\\\\[a-z_][a-z0-9_]*\\s*(\\(|(::<)))",
+          "comment": "Functions in a user-defined namespace (overrides any built-ins)",
+          "end": "(?=\\s*(\\(|(::<)))",
+          "patterns": [
+            {
+              "include": "#user-function-call"
+            }
+          ]
+        },
+        {
+          "begin": "(?i)(\\\\)?(?=\\b[a-z_][a-z_0-9]*\\s*(\\(|(::<)))",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.separator.inheritance.php"
+            }
+          },
+          "comment": "Root namespace function calls (built-in or user)",
+          "end": "(?=\\s*(\\(|(::<)))",
+          "patterns": [
+            {
+              "include": "#user-function-call"
+            }
+          ]
+        }
+      ]
+    },
+    "user-function-call": {
+      "begin": "(?i)(?=[a-z_0-9\\\\]*[a-z_][a-z0-9_]*\\s*\\()",
+      "end": "(?i)[a-z_][a-z_0-9]*(?=\\s*\\()",
+      "endCaptures": {
+        "0": {
+          "name": "entity.name.function.php"
+        }
+      },
+      "name": "meta.function-call.php",
+      "patterns": [
+        {
+          "include": "#namespace"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.single.ara",
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            {
+              "match": "\\\\[\\\\']",
+              "name": "constant.character.escape.ara"
+            }
+          ]
+        },
+        {
+          "name": "string.quoted.double.ara",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "include": "#interpolation"
+            }
+          ]
+        }
+      ]
+    },
+    "interpolation": {
+      "patterns": [
+        {
+          "comment": "Interpolating octal values e.g. \\01 or \\07.",
+          "match": "\\\\[0-7]{1,3}",
+          "name": "constant.numeric.octal.ara"
+        },
+        {
+          "comment": "Interpolating hex values e.g. \\x1 or \\xFF.",
+          "match": "\\\\x[0-9A-Fa-f]{1,2}",
+          "name": "constant.numeric.hex.ara"
+        },
+        {
+          "comment": "Escaped characters in double-quoted strings e.g. \\n or \\t.",
+          "match": "\\\\[nrt\\\\\\$\\\"]",
+          "name": "constant.character.escape.ara"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "match": "0[xX][0-9a-fA-F]+(?:_[0-9a-fA-F]+)*",
+          "name": "constant.numeric.hex.ara"
+        },
+        {
+          "match": "0[bB][01]+(?:_[01]+)*",
+          "name": "constant.numeric.binary.ara"
+        },
+        {
+          "match": "0[oO][0-7]+(?:_[0-7]+)*",
+          "name": "constant.numeric.octal.ara"
+        },
+        {
+          "match": "0(?:_?[0-7]+)+",
+          "name": "constant.numeric.octal.ara"
+        },
+        {
+          "match": "(?x)\n(?:\n  (?:[0-9]+(?:_[0-9]+)*)?(\\.)[0-9]+(?:_[0-9]+)*(?:[eE][+-]?[0-9]+(?:_[0-9]+)*)?| # .3\n  [0-9]+(?:_[0-9]+)*(\\.)(?:[0-9]+(?:_[0-9]+)*)?(?:[eE][+-]?[0-9]+(?:_[0-9]+)*)?| # 3.\n  [0-9]+(?:_[0-9]+)*[eE][+-]?[0-9]+(?:_[0-9]+)*                                   # 2e-3\n)",
+          "name": "constant.numeric.decimal.ara",
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.decimal.period.ara"
+            },
+            "2": {
+              "name": "punctuation.separator.decimal.period.ara"
+            }
+          }
+        },
+        {
+          "match": "0|[1-9](?:_?[0-9]+)*",
+          "name": "constant.numeric.decimal.ara"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "comment": "assignment operators",
+          "name": "keyword.assignments.ara",
+          "match": "(\\+=|-=|\\*=|/=|%=|\\^=|&&=|<=|>=|&=|\\|=|<<=|>>=|\\?\\?=)"
+        },
+        {
+          "comment": "logical operators",
+          "name": "keyword.operators.ara",
+          "match": "(\\^|\\||\\|\\||&&|>>|<<|&|~|<<|>>|>|<|<=>|\\?\\?|\\?|:|\\?:)(?!=)"
+        },
+        {
+          "comment": "comparison operators",
+          "name": "keyword.operator.comparison.ara",
+          "match": "(==|===|!==|!=|<=|>=|<|>)(?!=)"
+        },
+        {
+          "comment": "math operators",
+          "name": "keyword.operator.math.ara",
+          "match": "(([+%]|(\\*(?!\\w)))(?!=))|(-(?!>))|(/(?!/))"
+        },
+        {
+          "comment": "single equal assignment operator",
+          "name": "keyword.operator.assignment.ara",
+          "match": "(?<![<>])=(?!=|>)"
+        },
+        {
+          "comment": "less than, greater than (special case)",
+          "match": "(?:\\b|(?:(\\))|(\\])|(\\})))[ \\t]+([<>])[ \\t]+(?:\\b|(?:(\\()|(\\[)|(\\{)))",
+          "captures": {
+            "1": {
+              "name": "punctuation.brackets.round.ara"
+            },
+            "2": {
+              "name": "punctuation.brackets.square.ara"
+            },
+            "3": {
+              "name": "punctuation.brackets.curly.ara"
+            },
+            "4": {
+              "name": "keyword.operator.comparison.ara"
+            },
+            "5": {
+              "name": "punctuation.brackets.round.ara"
+            },
+            "6": {
+              "name": "punctuation.brackets.square.ara"
+            },
+            "7": {
+              "name": "punctuation.brackets.curly.ara"
+            }
+          }
+        },
+        {
+          "comment": "arrow method call, arrow property access",
+          "name": "keyword.operator.arrow.ara",
+          "match": "(?x)\n(?:\n  -> | \\?-> \n)"
+        },
+        {
+          "comment": "double arrow key-value pair",
+          "name": "keyword.operator.double-arrow.ara",
+          "match": "(?x)\n(?:\n  =>\n)"
+        },
+        {
+          "comment": "static method call, static property access",
+          "name": "keyword.operator.static.ara",
+          "match": "(?x)\n(?:\n  ::\n)"
+        },
+        {
+          "comment": "closure creation",
+          "name": "keyword.operator.closure.ara",
+          "match": "(?x)\n(?:\n  \\(\\.\\.\\.\\)\n)"
+        },
+        {
+          "comment": "spread operator",
+          "name": "keyword.operator.spread.ara",
+          "match": "(?x)\n(?:\n  \\.\\.\\.\n)"
+        },
+        {
+          "comment": "namespace operator",
+          "name": "keyword.operator.namespace.ara",
+          "match": "\\\\"
+        }
+      ]
+    }
+  }
+}

--- a/packages/shiki/samples/ara.sample
+++ b/packages/shiki/samples/ara.sample
@@ -1,0 +1,29 @@
+namespace MyNamespace;
+
+use MyOtherNamespace\MyOtherClass;
+
+use function MyOtherNamespace\my_other_function;
+
+use const MyOtherNamespace\MY_OTHER_CONST;
+
+const MY_CONST = 1;
+
+type MyType = int;
+
+interface MyInterface {
+    // ...
+}
+
+class MyClass {
+    // ...
+}
+
+enum MyEnum {
+    // ...
+}
+
+function my_function(): void {
+    // ...
+}
+
+https://ara-lang.io/fundamentals/structure.html

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -8,6 +8,7 @@ export type Lang =
   | 'apex'
   | 'apl'
   | 'applescript'
+  | 'ara'
   | 'asm'
   | 'astro'
   | 'awk'
@@ -188,6 +189,12 @@ export const languages: ILanguageRegistration[] = [
     scopeName: 'source.applescript',
     path: 'applescript.tmLanguage.json',
     samplePath: 'applescript.sample'
+  },
+  {
+    id: 'ara',
+    scopeName: 'source.ara',
+    path: 'ara.tmLanguage.json',
+    samplePath: 'ara.sample'
   },
   {
     id: 'asm',

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -77,6 +77,10 @@ export const githubGrammarSources: [string, string][] = [
     'https://github.com/BowlerHatLLC/vscode-as3mxml/blob/master/distribution/src/assembly/syntaxes/AS3.tmLanguage'
   ],
   [
+    'ara',
+    'https://github.com/ara-lang/highlighting/blob/main/syntaxes/ara.json'
+  ],
+  [
     'asm',
     'https://github.com/13xforever/x86_64-assembly-vscode/blob/master/syntaxes/language-x86_64-assembly.tmLanguage'
   ],


### PR DESCRIPTION
Hi there 👋,

This PR adds support for the `ara` language (https://ara-lang.io/).

Merging this into shiki would allow us and others to have first-party support for the `ara` language code blocks on the documentation website.

Thank you for considering.

---

- [x] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [x] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [x] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.