### PR TITLE
doc: Fix a way to access `renderToHTML`

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ If you want to render the tokens into a code yourself, Shiki exposes two key met
 - `renderToHTML` takes an array of tokens and returns an HTML string that represents the provided code.
 
 ```js
-import { getHighlighter } from 'shiki'
+import shiki, { getHighlighter } from 'shiki'
 
 const highlighter = await getHighlighter({
   theme: 'nord',
@@ -379,7 +379,7 @@ const code = `console.log("Here is your code.");`
 const tokens = highlighter.codeToThemedTokens(code, 'javascript')
 
 // This will return an HTML string that represents the provided code.
-const html = highlighter.renderToHTML(tokens)
+const html = shiki.renderToHTML(tokens)
 ```
 
 Alternatively you can add to `renderToHTML` the desired element shape for `pre`, `code`, `line (span)`, and `token (span)`, and override the theme colors for background and foreground.
@@ -387,7 +387,7 @@ Alternatively you can add to `renderToHTML` the desired element shape for `pre`,
 For more about that, or to build your own renderer, check out the implementation in [shiki](./packages/shiki/src/renderer.ts).
 
 ```js
-const html = highlighter.renderToHTML(tokens, {
+const html = shiki.renderToHTML(tokens, {
   fg: highlighter.getForegroundColor('nord'), // Set a specific foreground color.
   bg: highlighter.getBackgroundColor('nord'), // Set a specific background color.
   // Specified elements override the default elements.


### PR DESCRIPTION
## checklists
- [x] Add a test if possible
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

