### PR TITLE
Add support for the css-variables theme to ansi rendering

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -87,9 +87,44 @@ Note that this client-side theme is less granular than most other supported VSCo
     --shiki-token-string-expression: #CC0000;
     --shiki-token-punctuation: #DD0000;
     --shiki-token-link: #EE0000;
+
+    /* Only required if using ansiToHtml function */
+    --shiki-color-ansi-black: #000000;
+    --shiki-color-ansi-black-dim: #00000080;
+    --shiki-color-ansi-red: #bb0000;
+    --shiki-color-ansi-red-dim: #bb000080;
+    --shiki-color-ansi-green: #00bb00;
+    --shiki-color-ansi-green-dim: #00bb0080;
+    --shiki-color-ansi-yellow: #bbbb00;
+    --shiki-color-ansi-yellow-dim: #bbbb0080;
+    --shiki-color-ansi-blue: #0000bb;
+    --shiki-color-ansi-blue-dim: #0000bb80;
+    --shiki-color-ansi-magenta: #ff00ff;
+    --shiki-color-ansi-magenta-dim: #ff00ff80;
+    --shiki-color-ansi-cyan: #00bbbb;
+    --shiki-color-ansi-cyan-dim: #00bbbb80;
+    --shiki-color-ansi-white: #eeeeee;
+    --shiki-color-ansi-white-dim: #eeeeee80;
+    --shiki-color-ansi-bright-black: #555555;
+    --shiki-color-ansi-bright-black-dim: #55555580;
+    --shiki-color-ansi-bright-red: #ff5555;
+    --shiki-color-ansi-bright-red-dim: #ff555580;
+    --shiki-color-ansi-bright-green: #00ff00;
+    --shiki-color-ansi-bright-green-dim: #00ff0080;
+    --shiki-color-ansi-bright-yellow: #ffff55;
+    --shiki-color-ansi-bright-yellow-dim: #ffff5580;
+    --shiki-color-ansi-bright-blue: #5555ff;
+    --shiki-color-ansi-bright-blue-dim: #5555ff80;
+    --shiki-color-ansi-bright-magenta: #ff55ff;
+    --shiki-color-ansi-bright-magenta-dim: #ff55ff80;
+    --shiki-color-ansi-bright-cyan: #55ffff;
+    --shiki-color-ansi-bright-cyan-dim: #55ffff80;
+    --shiki-color-ansi-bright-white: #ffffff;
+    --shiki-color-ansi-bright-white-dim: #ffffff80;
   }
 </style>
 ```
+
 ## All Themes
 
 ```ts

--- a/packages/shiki/src/__tests__/__snapshots__/ansi.test.ts.snap
+++ b/packages/shiki/src/__tests__/__snapshots__/ansi.test.ts.snap
@@ -1,5 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders ansi to html with css-variables theme 1`] = `
+"<pre class=\\"shiki css-variables\\" style=\\"background-color: var(--shiki-color-background)\\"><code><span class=\\"line\\"></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-black)\\">black</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-black-dim)\\">black (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-red)\\">red</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-red-dim)\\">red (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-green)\\">green</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-green-dim)\\">green (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-yellow)\\">yellow</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-yellow-dim)\\">yellow (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-blue)\\">blue</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-blue-dim)\\">blue (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-magenta)\\">magenta</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-magenta-dim)\\">magenta (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-cyan)\\">cyan</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-cyan-dim)\\">cyan (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-white)\\">white</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-white-dim)\\">white (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-black)\\">brightBlack</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-black-dim)\\">brightBlack (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-red)\\">brightRed</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-red-dim)\\">brightRed (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-green)\\">brightGreen</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-green-dim)\\">brightGreen (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-yellow)\\">brightYellow</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-yellow-dim)\\">brightYellow (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-blue)\\">brightBlue</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-blue-dim)\\">brightBlue (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-magenta)\\">brightMagenta</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-magenta-dim)\\">brightMagenta (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-cyan)\\">brightCyan</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-cyan-dim)\\">brightCyan (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-white)\\">brightWhite</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-bright-white-dim)\\">brightWhite (dim)</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-text); font-weight: bold\\">bold</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-text); font-style: italic\\">italic</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-text); font-style: italic\\">underline</span></span>
+<span class=\\"line\\"><span style=\\"color: var(--shiki-color-text)\\">strikethrough</span></span>
+<span class=\\"line\\"></span></code></pre>"
+`;
+
 exports[`renders ansi to html with default theme 1`] = `
 "<pre class=\\"shiki monokai\\" style=\\"background-color: #272822\\" tabindex=\\"0\\"><code><span class=\\"line\\"><span style=\\"color: #333333\\"> WARN </span><span style=\\"color: #F8F8F2\\"> using --force I sure hope you know what you are doing</span></span>
 <span class=\\"line\\"><span style=\\"color: #F8F8F2\\">Scope: all 6 workspace projects</span></span>

--- a/packages/shiki/src/__tests__/__snapshots__/ansi.test.ts.snap
+++ b/packages/shiki/src/__tests__/__snapshots__/ansi.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders ansi to html with css-variables theme 1`] = `
-"<pre class=\\"shiki css-variables\\" style=\\"background-color: var(--shiki-color-background)\\"><code><span class=\\"line\\"></span>
+"<pre class=\\"shiki css-variables\\" style=\\"background-color: var(--shiki-color-background)\\" tabindex=\\"0\\"><code><span class=\\"line\\"></span>
 <span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-black)\\">black</span></span>
 <span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-black-dim)\\">black (dim)</span></span>
 <span class=\\"line\\"><span style=\\"color: var(--shiki-color-ansi-red)\\">red</span></span>

--- a/packages/shiki/src/__tests__/ansi.test.ts
+++ b/packages/shiki/src/__tests__/ansi.test.ts
@@ -45,3 +45,52 @@ Done in 15.7s`)
 
   expect(out).toMatchSnapshot()
 })
+
+test('renders ansi to html with css-variables theme', async () => {
+  const highlighter = await getHighlighter({
+    theme: 'css-variables'
+  })
+
+  const allAnsiStyles = `
+[30mblack[0m
+[30;2mblack (dim)[0m
+[31mred[0m
+[31;2mred (dim)[0m
+[32mgreen[0m
+[32;2mgreen (dim)[0m
+[33myellow[0m
+[33;2myellow (dim)[0m
+[34mblue[0m
+[34;2mblue (dim)[0m
+[35mmagenta[0m
+[35;2mmagenta (dim)[0m
+[36mcyan[0m
+[36;2mcyan (dim)[0m
+[37mwhite[0m
+[37;2mwhite (dim)[0m
+[90mbrightBlack[0m
+[90;2mbrightBlack (dim)[0m
+[91mbrightRed[0m
+[91;2mbrightRed (dim)[0m
+[92mbrightGreen[0m
+[92;2mbrightGreen (dim)[0m
+[93mbrightYellow[0m
+[93;2mbrightYellow (dim)[0m
+[94mbrightBlue[0m
+[94;2mbrightBlue (dim)[0m
+[95mbrightMagenta[0m
+[95;2mbrightMagenta (dim)[0m
+[96mbrightCyan[0m
+[96;2mbrightCyan (dim)[0m
+[97mbrightWhite[0m
+[97;2mbrightWhite (dim)[0m
+[1mbold[0m
+[3mitalic[0m
+[3munderline[0m
+[9mstrikethrough[0m
+`
+
+  const out = highlighter.ansiToHtml(allAnsiStyles)
+
+  expect(out).toMatchSnapshot()
+})

--- a/packages/shiki/src/ansiThemedTokenizer.ts
+++ b/packages/shiki/src/ansiThemedTokenizer.ts
@@ -77,4 +77,6 @@ function dimColor(color: string) {
   if (cssVarMatch) {
     return `var(${cssVarMatch[1]}-dim)`
   }
+
+  return color
 }

--- a/packages/shiki/src/ansiThemedTokenizer.ts
+++ b/packages/shiki/src/ansiThemedTokenizer.ts
@@ -51,7 +51,7 @@ export function tokenizeAnsiWithTheme(theme: IShikiTheme, fileContents: string):
 }
 
 /**
- * Adds 50% alpha to a hex color string
+ * Adds 50% alpha to a hex color string or the "-dim" postfix to a CSS variable
  */
 function dimColor(color: string) {
   const hexMatch = color.match(/#([0-9a-f]{3})([0-9a-f]{3})?([0-9a-f]{2})?/)
@@ -72,5 +72,9 @@ function dimColor(color: string) {
         .join('')}80`
     }
   }
-  return color
+
+  const cssVarMatch = color.match(/var\((--shiki-color-ansi-[\w-]+)\)/)
+  if (cssVarMatch) {
+    return `var(${cssVarMatch[1]}-dim)`
+  }
 }

--- a/packages/shiki/themes/css-variables.json
+++ b/packages/shiki/themes/css-variables.json
@@ -3,7 +3,23 @@
   "type": "css",
   "colors": {
     "editor.foreground": "#000001",
-    "editor.background": "#000002"
+    "editor.background": "#000002",
+    "terminal.ansiBlack": "#A00000",
+    "terminal.ansiRed": "#A00001",
+    "terminal.ansiGreen": "#A00002",
+    "terminal.ansiYellow": "#A00003",
+    "terminal.ansiBlue": "#A00004",
+    "terminal.ansiMagenta": "#A00005",
+    "terminal.ansiCyan": "#A00006",
+    "terminal.ansiWhite": "#A00007",
+    "terminal.ansiBrightBlack": "#A00008",
+    "terminal.ansiBrightRed": "#A00009",
+    "terminal.ansiBrightGreen": "#A00010",
+    "terminal.ansiBrightYellow": "#A00011",
+    "terminal.ansiBrightBlue": "#A00012",
+    "terminal.ansiBrightMagenta": "#A00013",
+    "terminal.ansiBrightCyan": "#A00014",
+    "terminal.ansiBrightWhite": "#A00015"
   },
   "tokenColors": [
     {


### PR DESCRIPTION
I realized while integrating the recent ANSI support into Nextra that Nextra uses the css-variables functionality which was not working with ANSI colors. I've updated the default color replacements and css-variables theme to support ANSI colors and updated the ANSI tokenizer to use a separate `-dim` variable for dimmed colors since we can no longer add opacity ourselves.

- [x] Add a test if possible
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

<!-- If fixing a bug -->

- [ ] This PR fixes #

<!-- If adding a theme -->

- [ ] I have read docs for [adding a theme](https://github.com/shikijs/shiki/blob/main/docs/themes.md#adding-theme).

<!-- If adding a language -->

- [ ] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [ ] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [ ] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.