### PR TITLE
feat(lang): add alias dockerfile -> docker

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -85,7 +85,7 @@ export type Lang =
   | 'dart'
   | 'dax'
   | 'diff'
-  | 'docker'
+  | 'docker' | 'dockerfile'
   | 'dream-maker'
   | 'elixir'
   | 'elm'

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -35,7 +35,7 @@ export type Lang =
   | 'dart'
   | 'dax'
   | 'diff'
-  | 'docker'
+  | 'docker' | 'dockerfile'
   | 'dream-maker'
   | 'elixir'
   | 'elm'
@@ -374,7 +374,8 @@ export const languages: ILanguageRegistration[] = [
     id: 'docker',
     scopeName: 'source.dockerfile',
     path: 'docker.tmLanguage.json',
-    samplePath: 'docker.sample'
+    samplePath: 'docker.sample',
+    aliases: ['dockerfile']
   },
   {
     id: 'dream-maker',

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -314,6 +314,7 @@ export const languageAliases = {
   clojure: ['clj'],
   codeql: ['ql'],
   csharp: ['c#', 'cs'],
+  docker: ['dockerfile'],
   erlang: ['erl'],
   fsharp: ['f#', 'fs'],
   haskell: ['hs'],


### PR DESCRIPTION
Adds an alias language ID `dockerfile` for language ID `docker`. This provides parity with [GHFM](https://github.com/github/linguist/blob/40421516a3842120a2227032420e4ef5791b234d/lib/linguist/languages.yml#L1528) (which actually doesn’t support `docker`, only `dockerfile`), [GLFM](https://github.com/rouge-ruby/rouge/wiki/List-of-supported-languages-and-lexers), and [Prism](https://prismjs.com/#supported-languages)

---

- [ ] **N/A &mdash;** Add a test if possible
- [X] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

<!-- If adding a language -->

- [X] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [ ] **N/A &mdash;** I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [ ] **N/A &mdash;** I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.