### PR TITLE
fix: add `protobuf` language id alias

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -151,7 +151,7 @@ export type Lang =
   | 'powershell' | 'ps' | 'ps1'
   | 'prisma'
   | 'prolog'
-  | 'proto'
+  | 'proto' | 'protobuf'
   | 'pug' | 'jade'
   | 'puppet'
   | 'purescript'

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -101,7 +101,7 @@ export type Lang =
   | 'powershell' | 'ps' | 'ps1'
   | 'prisma'
   | 'prolog'
-  | 'proto'
+  | 'proto' | 'protobuf'
   | 'pug' | 'jade'
   | 'puppet'
   | 'purescript'
@@ -765,6 +765,7 @@ export const languages: ILanguageRegistration[] = [
     id: 'proto',
     scopeName: 'source.proto',
     path: 'proto.tmLanguage.json',
+    aliases: ['protobuf'],
     samplePath: 'proto.sample'
   },
   {


### PR DESCRIPTION
- [ ] Add a test if possible
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

<!-- If fixing a bug -->

- [x] This PR fixes the `protobuf` id (common: used in linguist, highlight.js, and refractor) for protobuf code

<!-- If adding a theme -->

- [ ] I have read docs for [adding a theme](https://github.com/shikijs/shiki/blob/main/docs/themes.md#adding-theme).

<!-- If adding a language -->

- [ ] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [ ] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [ ] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.