### PR TITLE
fix(type): `theme` field autocompletion

### DIFF
--- a/packages/shiki/src/types.ts
+++ b/packages/shiki/src/types.ts
@@ -193,12 +193,14 @@ export interface IShikiTheme extends IRawTheme {
   colors?: Record<string, string>
 }
 
+interface Nothing {}
+
 /**
  * type StringLiteralUnion<'foo'> = 'foo' | string
  * This has auto completion whereas `'foo' | string` doesn't
  * Adapted from https://github.com/microsoft/TypeScript/issues/29729
  */
-export type StringLiteralUnion<T extends U, U = string> = T | (U & {})
+export type StringLiteralUnion<T extends U, U = string> = T | (U & Nothing)
 
 export interface CodeToHtmlOptions {
   lang?: StringLiteralUnion<Lang>


### PR DESCRIPTION
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

<!-- If fixing a bug -->

- [x] This PR fixes #448 

It's suffering without autocompletion when trying to use built-in themes. But I noticed that the code has already attempted to provide it but it stoped working on `TypeScript version >= 4.7.4`.

I've tested different approaches, here's the [playground demo](https://www.typescriptlang.org/play?#code/PTAEFsHsDcFNQC4At4GMCuAnAzpTjJEVRsFMBLAOwHMAaUAQ0oBNQAHTWbbQGAZQBhALIARUAGpQ5UIFgGBIQRcEjdHNSRwbADawE5SJQCwAKGMhQARgB0oAKq7N5BAE9ETtvADujpKAcLMDJqgAN4AvgBcoML6AORKHngA1sawAB5seErO7qAAymRU1AAyjrABmjaUepTmADwAKqBpCizYtvQ2oAC8JAU0AHzdoI0APqAAFJ0AZCGhAJTGapSkiIrmkfkUNCX+gZXVdTEAgkcxoGMxAEKXMYM9MTHGT0ZmAEzWduR+Ltme3k3gRwuKj+ABmDFQsEi0S4oASmGSRhBZXBkNAADlIMhCrMUulMq4cptCjsynsqvpXg0mqkWsw2jYOkNSFtqHdhucJtMMVikIUFkYlisFKRXhs+sVSuV9pTasdTpyrjd2Q9nqYwABmayk8qEqFRSCw+GIoVZRQayLys4Xa7WiYsnEzMJzIYPIA), and finally decided to use the **empty interface** solution.

### Before:
![image](https://user-images.githubusercontent.com/30516060/227704416-fc7235ca-bab9-43d5-8a0a-c7b62e5b098b.png)

### After: 
![image](https://user-images.githubusercontent.com/30516060/227704363-31831561-2d68-4c52-adb0-64277a1d2efa.png)

