### PR TITLE
feat: add reg grammar

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -162,6 +162,7 @@ export type Lang =
   | 'r'
   | 'raku' | 'perl6'
   | 'razor'
+  | 'reg'
   | 'rel'
   | 'riscv'
   | 'rst'

--- a/packages/shiki/languages/reg.tmLanguage.json
+++ b/packages/shiki/languages/reg.tmLanguage.json
@@ -1,0 +1,133 @@
+{
+  "fileTypes": ["reg", "REG"],
+  "name": "reg",
+  "patterns": [
+    {
+      "match": "Windows Registry Editor Version 5\\.00|REGEDIT4",
+      "name": "keyword.control.import.reg"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.comment.reg"
+        }
+      },
+      "match": "(;).*$",
+      "name": "comment.line.semicolon.reg"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.section.reg"
+        },
+        "2": {
+          "name": "entity.section.reg"
+        },
+        "3": {
+          "name": "punctuation.definition.section.reg"
+        }
+      },
+      "match": "^\\s*(\\[(?!-))(.*?)(\\])",
+      "name": "entity.name.function.section.add.reg"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.section.reg"
+        },
+        "2": {
+          "name": "entity.section.reg"
+        },
+        "3": {
+          "name": "punctuation.definition.section.reg"
+        }
+      },
+      "match": "^\\s*(\\[-)(.*?)(\\])",
+      "name": "entity.name.function.section.delete.reg"
+    },
+    {
+      "captures": {
+        "2": {
+          "name": "punctuation.definition.quote.reg"
+        },
+        "3": {
+          "name": "support.function.regname.ini"
+        },
+        "4": {
+          "name": "punctuation.definition.quote.reg"
+        },
+        "5": {
+          "name": "punctuation.definition.equals.reg"
+        },
+        "7": {
+          "name": "keyword.operator.arithmetic.minus.reg"
+        },
+        "9": {
+          "name": "punctuation.definition.quote.reg"
+        },
+        "10": {
+          "name": "string.name.regdata.reg"
+        },
+        "11": {
+          "name": "punctuation.definition.quote.reg"
+        },
+        "13": {
+          "name": "support.type.dword.reg"
+        },
+        "14": {
+          "name": "keyword.operator.arithmetic.colon.reg"
+        },
+        "15": {
+          "name": "constant.numeric.dword.reg"
+        },
+        "17": {
+          "name": "support.type.dword.reg"
+        },
+        "18": {
+          "name": "keyword.operator.arithmetic.parenthesis.reg"
+        },
+        "19": {
+          "name": "keyword.operator.arithmetic.parenthesis.reg"
+        },
+        "20": {
+          "name": "constant.numeric.hex.size.reg"
+        },
+        "21": {
+          "name": "keyword.operator.arithmetic.parenthesis.reg"
+        },
+        "22": {
+          "name": "keyword.operator.arithmetic.colon.reg"
+        },
+        "23": {
+          "name": "constant.numeric.hex.reg"
+        },
+        "24": {
+          "name": "keyword.operator.arithmetic.linecontinuation.reg"
+        },
+        "25": {
+          "name": "comment.declarationline.semicolon.reg"
+        }
+      },
+      "match": "^(\\s*([\"']?)(.+?)([\"']?)\\s*(=))?\\s*((-)|(([\"'])(.*?)([\"']))|(((?i:dword))(\\:)\\s*([\\dabcdefABCDEF]{1,8}))|(((?i:hex))((\\()([\\d]*)(\\)))?(\\:)(.*?)(\\\\?)))\\s*(;.*)?$",
+      "name": "meta.declaration.reg"
+    },
+    {
+      "match": "[0-9]+",
+      "name": "constant.numeric.reg"
+    },
+    {
+      "match": "[a-fA-F]+",
+      "name": "constant.numeric.hex.reg"
+    },
+    {
+      "match": ",+",
+      "name": "constant.numeric.hex.comma.reg"
+    },
+    {
+      "match": "\\\\",
+      "name": "keyword.operator.arithmetic.linecontinuation.reg"
+    }
+  ],
+  "scopeName": "source.reg",
+  "uuid": "B7773F5B-C43A-4BB9-843A-4AC119250EBD"
+}

--- a/packages/shiki/samples/reg.sample
+++ b/packages/shiki/samples/reg.sample
@@ -1,0 +1,26 @@
+Windows Registry Editor Version 5.00
+
+
+; WARNING: before run replace PATH_TO_APP with correct value
+; Example: C:\\Anaconda3
+
+[HKEY_CLASSES_ROOT\Directory\shell\AnacondaJupyterNotebook]
+; This will make it appear when you right click ON a folder
+; The "Icon" line can be removed if you don't want the icon to appear
+@="&Jupyter Notebook There"
+"Icon"="\"PATH_TO_APP\\Menu\\jupyter.ico""
+
+[HKEY_CLASSES_ROOT\Directory\shell\AnacondaJupyterNotebook\command]
+@="cmd /K pushd \"%1\" && \"PATH_TO_APP\\Scripts\\activate.bat\" && jupyter-notebook"
+
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\AnacondaJupyterNotebook]
+; This will make it appear when you right click INSIDE a folder
+; The "Icon" line can be removed if you don't want the icon to appear
+@="&Jupyter Notebook Here"
+"Icon"="\"PATH_TO_APP\\Menu\\jupyter.ico\""
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\AnacondaJupyterNotebook\command]
+@="cmd /K \"PATH_TO_APP\\Scripts\\activate.bat\" && jupyter-notebook"
+
+; From https://github.com/NickVeld/win-registry-snippets/blob/main/AnacondaJupyterNotebookHere.reg

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -685,7 +685,6 @@ export const languages: ILanguageRegistration[] = [
     id: 'marko',
     scopeName: 'text.marko',
     path: 'marko.tmLanguage.json',
-    samplePath: 'marko.sample',
     embeddedLangs: ['css', 'less', 'scss', 'javascript']
   },
   {

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -112,6 +112,7 @@ export type Lang =
   | 'r'
   | 'raku' | 'perl6'
   | 'razor'
+  | 'reg'
   | 'rel'
   | 'riscv'
   | 'rst'
@@ -684,6 +685,7 @@ export const languages: ILanguageRegistration[] = [
     id: 'marko',
     scopeName: 'text.marko',
     path: 'marko.tmLanguage.json',
+    samplePath: 'marko.sample',
     embeddedLangs: ['css', 'less', 'scss', 'javascript']
   },
   {
@@ -831,6 +833,12 @@ export const languages: ILanguageRegistration[] = [
     scopeName: 'text.aspnetcorerazor',
     path: 'razor.tmLanguage.json',
     embeddedLangs: ['html', 'csharp']
+  },
+  {
+    id: 'reg',
+    scopeName: 'source.reg',
+    path: 'reg.tmLanguage.json',
+    samplePath: 'reg.sample'
   },
   {
     id: 'rel',

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -231,6 +231,7 @@ export const githubGrammarSources: [string, string][] = [
     'razor',
     'https://github.com/dotnet/aspnetcore-tooling/blob/master/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json'
   ],
+  ['reg', 'https://github.com/mihai-vlc/reg-vscode/blob/master/syntaxes/reg.tmLanguage'],
   [
     'rel',
     'https://github.com/relationalai-oss/rel_vscode/blob/master/syntaxes/rel.tmLanguage.json'


### PR DESCRIPTION
This adds the grammar for Windows Registry Editor syntax

closes #450 

<!-- If adding a language -->

- [x] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [x] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [x] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.