### PR TITLE
fix: avoid poisoning global scope

### DIFF
--- a/packages/shiki/src/global.d.ts
+++ b/packages/shiki/src/global.d.ts
@@ -1,1 +1,20 @@
-declare var __BROWSER__: boolean
+declare global {
+  var __BROWSER__: boolean
+
+  // These will not be defined for Node which don't have "DOM" in their lib.
+  // So declare the minimal interface we need.
+  // They are defined here and not in `loader.ts` to avoid getting injected in the built code.
+  interface Window {
+    WorkerGlobalScope: any
+  }
+
+  var self: Window & typeof globalThis
+  function fetch(url: string): Promise<Response>
+  interface Response {
+    json(): Promise<any>
+    text(): Promise<any>
+  }
+}
+
+// This export is here so that all variables above would be added to the global scope
+export {}

--- a/packages/shiki/src/loader.ts
+++ b/packages/shiki/src/loader.ts
@@ -1,22 +1,10 @@
+/// <reference path="./global.d.ts" />
+
 import { join, dirpathparts } from './utils'
 import type { IGrammar, IOnigLib, IRawTheme } from 'vscode-textmate'
 import { loadWASM, createOnigScanner, createOnigString } from 'vscode-oniguruma'
 import { parse, ParseError } from 'jsonc-parser'
 import type { IShikiTheme } from './types'
-
-// These will not be defined for Node which don't have "DOM" in their lib.
-// So declare the minimal interface we need.
-declare global {
-  interface Window {
-    WorkerGlobalScope: any
-  }
-  var self: Window & typeof globalThis
-  function fetch(url: string): Promise<Response>
-  interface Response {
-    json(): Promise<any>
-    text(): Promise<any>
-  }
-}
 
 export const isWebWorker =
   typeof self !== 'undefined' && typeof self.WorkerGlobalScope !== 'undefined'


### PR DESCRIPTION
- [ ] Add a test if possible
   I didn't add any automated test, but I checked that after running `pnpm build`, there was no mention of `Window` in the `index.d.ts` file:
  <img width="1170" alt="image" src="https://user-images.githubusercontent.com/22725671/229074323-7222e34e-054a-417b-b50f-707da156f47b.png">
   I didn't add any test because:
   -  this test would require to be ran **after** `pnpm build`
   - if we wanted to write to test to ensure that we aren't poisoning the global scope, we need to do something like "is Response, or Window, etc., in the generated code?" But `Response` is used so we cannot use that, and other may be used in the future. So I don't know which test we could write that could be future proof for this.
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] This PR fixes https://github.com/shikijs/shiki/issues/454



I couldn't use just `declare var fetch` and others, because we need to add to the global scope `Window` and others as they are used by shiki's node_modules (and so when running tests locally, we need them, see https://github.com/shikijs/shiki/actions/runs/4572982584/jobs/8072860830).

So I moved those to a `global.d.ts` so that they'd be present in the project, but not in the built code.
