### PR TITLE
feat: add beancount grammar

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -64,6 +64,7 @@ export type Lang =
   | 'awk'
   | 'ballerina'
   | 'bat' | 'batch'
+  | 'beancount'
   | 'berry' | 'be'
   | 'bibtex'
   | 'bicep'

--- a/packages/shiki/languages/beancount.tmLanguage.json
+++ b/packages/shiki/languages/beancount.tmLanguage.json
@@ -1,0 +1,829 @@
+{
+  "fileTypes": ["beancount"],
+  "name": "beancount",
+  "patterns": [
+    {
+      "comment": "Comments",
+      "match": ";.*",
+      "name": "comment.line.beancount"
+    },
+    {
+      "begin": "^\\s*(poptag|pushtag)\\s+(#)([A-Za-z0-9\\-_/.]+)",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.beancount"
+        },
+        "2": {
+          "name": "keyword.operator.tag.beancount"
+        },
+        "3": {
+          "name": "entity.name.tag.beancount"
+        }
+      },
+      "comment": "Tag directive",
+      "end": "(?=(^\\s*$|^\\S))",
+      "name": "meta.directive.tag.beancount",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    {
+      "begin": "^\\s*(include)\\s+(\\\".*\\\")",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.beancount"
+        },
+        "2": {
+          "name": "string.quoted.double.beancount"
+        }
+      },
+      "comment": "Include directive",
+      "end": "(?=(^\\s*$|^\\S))",
+      "name": "meta.directive.include.beancount",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    {
+      "begin": "^\\s*(option)\\s+(\\\".*\\\")\\s+(\\\".*\\\")",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.beancount"
+        },
+        "2": {
+          "name": "support.variable.beancount"
+        },
+        "3": {
+          "name": "string.quoted.double.beancount"
+        }
+      },
+      "comment": "Option directive",
+      "end": "(?=(^\\s*$|^\\S))",
+      "name": "meta.directive.option.beancount",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    {
+      "begin": "^\\s*(plugin)\\s*(\"(.*?)\")\\s*(\".*?\")?",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.beancount"
+        },
+        "2": {
+          "name": "string.quoted.double.beancount"
+        },
+        "3": {
+          "name": "entity.name.function.beancount"
+        },
+        "4": {
+          "name": "string.quoted.double.beancount"
+        }
+      },
+      "comment": "Plugin directive",
+      "end": "(?=(^\\s*$|^\\S))",
+      "name": "keyword.operator.directive.beancount",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    {
+      "begin": "([0-9]{4})([\\-|/])([0-9]{2})([\\-|/])([0-9]{2})\\s+(open|close|pad)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "constant.numeric.date.year.beancount"
+        },
+        "2": {
+          "name": "punctuation.separator.beancount"
+        },
+        "3": {
+          "name": "constant.numeric.date.month.beancount"
+        },
+        "4": {
+          "name": "punctuation.separator.beancount"
+        },
+        "5": {
+          "name": "constant.numeric.date.day.beancount"
+        },
+        "6": {
+          "name": "support.function.beancount"
+        }
+      },
+      "comment": "Open/Close/Pad directive",
+      "end": "(?=(^\\s*$|^\\S))",
+      "name": "meta.directive.dated.beancount",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#meta"
+        },
+        {
+          "include": "#account"
+        },
+        {
+          "include": "#commodity"
+        },
+        {
+          "match": "\\,",
+          "name": "punctuation.separator.beancount"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    {
+      "begin": "([0-9]{4})([\\-|/])([0-9]{2})([\\-|/])([0-9]{2})\\s+(custom)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "constant.numeric.date.year.beancount"
+        },
+        "2": {
+          "name": "punctuation.separator.beancount"
+        },
+        "3": {
+          "name": "constant.numeric.date.month.beancount"
+        },
+        "4": {
+          "name": "punctuation.separator.beancount"
+        },
+        "5": {
+          "name": "constant.numeric.date.day.beancount"
+        },
+        "6": {
+          "name": "support.function.beancount"
+        }
+      },
+      "comment": "Custom directive",
+      "end": "(?=(^\\s*$|^\\S))",
+      "name": "meta.directive.dated.beancount",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#meta"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#bool"
+        },
+        {
+          "include": "#amount"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#date"
+        },
+        {
+          "include": "#account"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    {
+      "begin": "([0-9]{4})([\\-|/])([0-9]{2})([\\-|/])([0-9]{2})\\s(event)",
+      "beginCaptures": {
+        "1": {
+          "name": "constant.numeric.date.year.beancount"
+        },
+        "2": {
+          "name": "punctuation.separator.beancount"
+        },
+        "3": {
+          "name": "constant.numeric.date.month.beancount"
+        },
+        "4": {
+          "name": "punctuation.separator.beancount"
+        },
+        "5": {
+          "name": "constant.numeric.date.day.beancount"
+        },
+        "6": {
+          "name": "support.function.directive.beancount"
+        }
+      },
+      "comment": "Event directive",
+      "end": "(?=(^\\s*$|^\\S))",
+      "name": "meta.directive.dated.beancount",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#meta"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    {
+      "begin": "([0-9]{4})([\\-|/])([0-9]{2})([\\-|/])([0-9]{2})\\s(commodity)",
+      "beginCaptures": {
+        "1": {
+          "name": "constant.numeric.date.year.beancount"
+        },
+        "2": {
+          "name": "punctuation.separator.beancount"
+        },
+        "3": {
+          "name": "constant.numeric.date.month.beancount"
+        },
+        "4": {
+          "name": "punctuation.separator.beancount"
+        },
+        "5": {
+          "name": "constant.numeric.date.day.beancount"
+        },
+        "6": {
+          "name": "support.function.directive.beancount"
+        }
+      },
+      "comment": "Commodity directive",
+      "end": "(?=(^\\s*$|^\\S))",
+      "name": "meta.directive.dated.beancount",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#meta"
+        },
+        {
+          "include": "#commodity"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    {
+      "name": "meta.directive.notetotext.beancount",
+      "comment": "Note as Oneliner Transaction directive",
+      "begin": "([0-9]{4})([\\-|/])([0-9]{2})([\\-|/])([0-9]{2})\\s+(note)(?=(.*\\*\\\"\\s))",
+      "beginCaptures": {
+        "1": {
+          "name": "constant.numeric.date.year.beancount"
+        },
+        "2": {
+          "name": "punctuation.separator.beancount"
+        },
+        "3": {
+          "name": "constant.numeric.date.month.beancount"
+        },
+        "4": {
+          "name": "punctuation.separator.beancount"
+        },
+        "5": {
+          "name": "constant.numeric.date.day.beancount"
+        },
+        "6": {
+          "name": "support.function.directive.beancount"
+        }
+      },
+      "end": "(?=(^\\s*$|^\\S))",
+      "patterns": [
+        {
+          "include": "#meta"
+        },
+        {
+          "include": "#account"
+        },
+        {
+          "name": "punctuation.separator.beancount",
+          "match": "(?<=\\s)\\\""
+        },
+        {
+          "include": "#cost"
+        },
+        {
+          "include": "#amount"
+        },
+        {
+          "begin": "(\\*|\\!)",
+          "beginCaptures": {
+            "0": {
+              "name": "support.function.directive.beancount"
+            }
+          },
+          "end": "(\\*\\\")",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.separator.beancount"
+            }
+          },
+          "patterns": [
+            {
+              "name": "constant.character.escape.beancount",
+              "match": "\\\\."
+            },
+            {
+              "include": "#tag"
+            },
+            {
+              "name": "string.quoted.double.beancount",
+              "match": "([^\\\"])"
+            }
+          ]
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    {
+      "begin": "([0-9]{4})([\\-|/])([0-9]{2})([\\-|/])([0-9]{2})\\s(note|document)",
+      "beginCaptures": {
+        "1": {
+          "name": "constant.numeric.date.year.beancount"
+        },
+        "2": {
+          "name": "punctuation.separator.beancount"
+        },
+        "3": {
+          "name": "constant.numeric.date.month.beancount"
+        },
+        "4": {
+          "name": "punctuation.separator.beancount"
+        },
+        "5": {
+          "name": "constant.numeric.date.day.beancount"
+        },
+        "6": {
+          "name": "support.function.directive.beancount"
+        }
+      },
+      "comment": "Note/Document directive",
+      "end": "(?=(^\\s*$|^\\S))",
+      "name": "meta.directive.dated.beancount",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#meta"
+        },
+        {
+          "include": "#account"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    {
+      "begin": "([0-9]{4})([\\-|/])([0-9]{2})([\\-|/])([0-9]{2})\\s(price)",
+      "beginCaptures": {
+        "1": {
+          "name": "constant.numeric.date.year.beancount"
+        },
+        "2": {
+          "name": "punctuation.separator.beancount"
+        },
+        "3": {
+          "name": "constant.numeric.date.month.beancount"
+        },
+        "4": {
+          "name": "punctuation.separator.beancount"
+        },
+        "5": {
+          "name": "constant.numeric.date.day.beancount"
+        },
+        "6": {
+          "name": "support.function.directive.beancount"
+        }
+      },
+      "comment": "Price directives",
+      "end": "(?=(^\\s*$|^\\S))",
+      "name": "meta.directive.dated.beancount",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#meta"
+        },
+        {
+          "include": "#commodity"
+        },
+        {
+          "include": "#amount"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    {
+      "begin": "([0-9]{4})([\\-|/])([0-9]{2})([\\-|/])([0-9]{2})\\s(balance)",
+      "beginCaptures": {
+        "1": {
+          "name": "constant.numeric.date.year.beancount"
+        },
+        "2": {
+          "name": "punctuation.separator.beancount"
+        },
+        "3": {
+          "name": "constant.numeric.date.month.beancount"
+        },
+        "4": {
+          "name": "punctuation.separator.beancount"
+        },
+        "5": {
+          "name": "constant.numeric.date.day.beancount"
+        },
+        "6": {
+          "name": "support.function.directive.beancount"
+        }
+      },
+      "comment": "Balance directives",
+      "end": "(?=(^\\s*$|^\\S))",
+      "name": "meta.directive.dated.beancount",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#meta"
+        },
+        {
+          "include": "#account"
+        },
+        {
+          "include": "#amount"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    {
+      "begin": "([0-9]{4})([\\-|/])([0-9]{2})([\\-|/])([0-9]{2})\\s*(txn|[*!&#?%PSTCURM])\\s*(\".*?\")?\\s*(\".*?\")?",
+      "beginCaptures": {
+        "1": {
+          "name": "constant.numeric.date.year.beancount"
+        },
+        "2": {
+          "name": "punctuation.separator.beancount"
+        },
+        "3": {
+          "name": "constant.numeric.date.month.beancount"
+        },
+        "4": {
+          "name": "punctuation.separator.beancount"
+        },
+        "5": {
+          "name": "constant.numeric.date.day.beancount"
+        },
+        "6": {
+          "name": "support.function.directive.beancount"
+        },
+        "7": {
+          "name": "string.quoted.tiers.beancount"
+        },
+        "8": {
+          "name": "string.quoted.narration.beancount"
+        }
+      },
+      "comment": "Transaction directive",
+      "end": "(?=(^\\s*$|^\\S))",
+      "name": "meta.directive.transaction.beancount",
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#posting"
+        },
+        {
+          "include": "#meta"
+        },
+        {
+          "include": "#tag"
+        },
+        {
+          "include": "#link"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    }
+  ],
+  "repository": {
+    "account": {
+      "begin": "([A-Z][a-z]+)(:)",
+      "beginCaptures": {
+        "1": {
+          "name": "constant.language.beancount"
+        },
+        "2": {
+          "name": "punctuation.separator.beancount"
+        }
+      },
+      "end": "\\s",
+      "name": "meta.account.beancount",
+      "patterns": [
+        {
+          "begin": "(\\S+)([:]?)",
+          "beginCaptures": {
+            "1": {
+              "name": "variable.account.beancount"
+            },
+            "2": {
+              "name": "punctuation.separator.beancount"
+            }
+          },
+          "comment": "Sub accounts",
+          "end": "([:]?)|(\\s)",
+          "patterns": [
+            {
+              "include": "$self"
+            },
+            {
+              "include": "#illegal"
+            }
+          ]
+        }
+      ]
+    },
+    "bool": {
+      "captures": {
+        "0": {
+          "name": "constant.language.bool.beancount"
+        },
+        "2": {
+          "name": "constant.numeric.currency.beancount"
+        },
+        "3": {
+          "name": "entity.type.commodity.beancount"
+        }
+      },
+      "match": "TRUE|FALSE"
+    },
+    "number": {
+      "captures": {
+        "1": {
+          "name": "keyword.operator.modifier.beancount"
+        },
+        "2": {
+          "name": "constant.numeric.currency.beancount"
+        }
+      },
+      "match": "([\\-|\\+]?)(\\d+(?:,\\d{3})*(?:\\.\\d*)?)"
+    },
+    "amount": {
+      "captures": {
+        "1": {
+          "name": "keyword.operator.modifier.beancount"
+        },
+        "2": {
+          "name": "constant.numeric.currency.beancount"
+        },
+        "3": {
+          "name": "entity.type.commodity.beancount"
+        }
+      },
+      "match": "([\\-|\\+]?)(\\d+(?:,\\d{3})*(?:\\.\\d*)?)\\s*([A-Z][A-Z0-9\\'\\.\\_\\-]{0,22}[A-Z0-9])",
+      "name": "meta.amount.beancount"
+    },
+    "comments": {
+      "captures": {
+        "1": {
+          "name": "comment.line.beancount"
+        }
+      },
+      "match": "(;.*)$"
+    },
+    "commodity": {
+      "match": "([A-Z][A-Z0-9\\'\\.\\_\\-]{0,22}[A-Z0-9])",
+      "name": "entity.type.commodity.beancount"
+    },
+    "cost": {
+      "begin": "\\{\\{?",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.operator.assignment.beancount"
+        }
+      },
+      "end": "\\}\\}?",
+      "endCaptures": {
+        "0": {
+          "name": "keyword.operator.assignment.beancount"
+        }
+      },
+      "name": "meta.cost.beancount",
+      "patterns": [
+        {
+          "include": "#amount"
+        },
+        {
+          "include": "#date"
+        },
+        {
+          "match": "\\,",
+          "name": "punctuation.separator.beancount"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    "date": {
+      "captures": {
+        "1": {
+          "name": "constant.numeric.date.year.beancount"
+        },
+        "2": {
+          "name": "punctuation.separator.beancount"
+        },
+        "3": {
+          "name": "constant.numeric.date.month.beancount"
+        },
+        "4": {
+          "name": "punctuation.separator.beancount"
+        },
+        "5": {
+          "name": "constant.numeric.date.day.beancount"
+        }
+      },
+      "match": "([0-9]{4})([\\-|/])([0-9]{2})([\\-|/])([0-9]{2})",
+      "name": "meta.date.beancount"
+    },
+    "flag": {
+      "match": "(?<=\\s)([*!&#?%PSTCURM])(?=\\s+)",
+      "name": "keyword.other.beancount"
+    },
+    "illegal": {
+      "match": "[^\\s]",
+      "name": "invalid.illegal.unrecognized.beancount"
+    },
+    "link": {
+      "captures": {
+        "1": {
+          "name": "keyword.operator.link.beancount"
+        },
+        "2": {
+          "name": "markup.underline.link.beancount"
+        }
+      },
+      "match": "(\\^)([A-Za-z0-9\\-_/.]+)"
+    },
+    "meta": {
+      "begin": "^\\s*([a-z][A-Za-z0-9\\-_]+)([:])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.directive.beancount"
+        },
+        "2": {
+          "name": "punctuation.separator.beancount"
+        }
+      },
+      "end": "\\n",
+      "name": "meta.meta.beancount",
+      "patterns": [
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#account"
+        },
+        {
+          "include": "#bool"
+        },
+        {
+          "include": "#commodity"
+        },
+        {
+          "include": "#date"
+        },
+        {
+          "include": "#tag"
+        },
+        {
+          "include": "#amount"
+        },
+        {
+          "include": "#number"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    "posting": {
+      "begin": "^\\s+(?=([A-Z\\!]))",
+      "end": "(?=(^\\s*$|^\\S|^\\s*[A-Z]))",
+      "name": "meta.posting.beancount",
+      "patterns": [
+        {
+          "include": "#meta"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#flag"
+        },
+        {
+          "include": "#account"
+        },
+        {
+          "include": "#amount"
+        },
+        {
+          "include": "#cost"
+        },
+        {
+          "include": "#date"
+        },
+        {
+          "include": "#price"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    "price": {
+      "begin": "\\@\\@?",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.operator.assignment.beancount"
+        }
+      },
+      "end": "(?=(;|\\n))",
+      "name": "meta.price.beancount",
+      "patterns": [
+        {
+          "include": "#amount"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    "string": {
+      "begin": "\\\"",
+      "end": "\\\"",
+      "name": "string.quoted.double.beancount",
+      "patterns": [
+        {
+          "match": "\\\\.",
+          "name": "constant.character.escape.beancount"
+        }
+      ]
+    },
+    "tag": {
+      "captures": {
+        "1": {
+          "name": "keyword.operator.tag.beancount"
+        },
+        "2": {
+          "name": "entity.name.tag.beancount"
+        }
+      },
+      "match": "(#)([A-Za-z0-9\\-_/.]+)"
+    }
+  },
+  "scopeName": "text.beancount",
+  "uuid": "dbf28879-ee4d-497e-a678-a5c5a5e8d74f"
+}

--- a/packages/shiki/samples/beancount.sample
+++ b/packages/shiki/samples/beancount.sample
@@ -1,0 +1,9 @@
+2012-11-03 * "Transfer to pay credit card"
+  Assets:MyBank:Checking            -400.00 USD
+  Liabilities:CreditCard             400.00 USD
+
+2012-11-03 * "Transfer to account in Canada"
+  Assets:MyBank:Checking            -400.00 USD @ 1.09 CAD
+  Assets:FR:SocGen:Checking          436.01 CAD
+
+; https://beancount.github.io/docs/beancount_language_syntax.html#costs-and-prices

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -14,6 +14,7 @@ export type Lang =
   | 'awk'
   | 'ballerina'
   | 'bat' | 'batch'
+  | 'beancount'
   | 'berry' | 'be'
   | 'bibtex'
   | 'bicep'
@@ -238,6 +239,12 @@ export const languages: ILanguageRegistration[] = [
     path: 'bat.tmLanguage.json',
     samplePath: 'bat.sample',
     aliases: ['batch']
+  },
+  {
+    id: 'beancount',
+    scopeName: 'text.beancount',
+    path: 'beancount.tmLanguage.json',
+    samplePath: 'beancount.sample'
   },
   {
     id: 'berry',

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -91,6 +91,10 @@ export const githubGrammarSources: [string, string][] = [
     'https://github.com/ballerina-platform/ballerina-grammar/blob/master/syntaxes/ballerina.tmLanguage'
   ],
   [
+    'beancount',
+    'https://github.com/Lencerf/vscode-beancount/blob/master/syntaxes/beancount.tmLanguage'
+  ],
+  [
     'berry',
     'https://github.com/berry-lang/berry/blob/master/tools/plugins/vscode/skiars.berry-0.1.0/syntaxes/berry.json'
   ],


### PR DESCRIPTION
This adds support for the [beancount](https://beancount.github.io/docs/index.html) syntax

- [x] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [x] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [x] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.