### PR TITLE
Specify langs in browser based example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ If you don't have a Node.js project, or if you just want to use the build in the
 <script>
   shiki
     .getHighlighter({
-      theme: 'nord'
+      theme: 'nord',
+      langs: ['js'],
     })
     .then(highlighter => {
       const code = highlighter.codeToHtml(`console.log('shiki');`, { lang: 'js' })


### PR DESCRIPTION
The browser based example will download 162 JSON files if not specified, which leads to 10+ second loading times. I'm pretty sure I was also getting rate limited by unpkg as well because I was getting random broken loads. 

Might be worth making the languages opt-in when working in the browser, but at least this PR will make the initial demo work smoothly.

re: https://github.com/shikijs/shiki/issues/306 