### PR TITLE
feat: add glimmer syntax

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -104,6 +104,8 @@ export type Lang =
   | 'gherkin'
   | 'git-commit'
   | 'git-rebase'
+  | 'glimmer-js' | 'gjs'
+  | 'glimmer-ts' | 'gts'
   | 'glsl'
   | 'gnuplot'
   | 'go'

--- a/packages/shiki/languages/glimmer-js.tmLanguage.json
+++ b/packages/shiki/languages/glimmer-js.tmLanguage.json
@@ -1,0 +1,9 @@
+{
+  "scopeName": "source.gjs",
+  "patterns": [
+    {
+      "include": "source.js"
+    }
+  ],
+  "name": "glimmer-js"
+}

--- a/packages/shiki/languages/glimmer-ts.tmLanguage.json
+++ b/packages/shiki/languages/glimmer-ts.tmLanguage.json
@@ -1,0 +1,9 @@
+{
+  "scopeName": "source.gts",
+  "patterns": [
+    {
+      "include": "source.ts"
+    }
+  ],
+  "name": "glimmer-ts"
+}

--- a/packages/shiki/samples/gjs.sample
+++ b/packages/shiki/samples/gjs.sample
@@ -1,0 +1,18 @@
+import { helper } from '@ember/component/helper';
+import { modifier } from 'ember-modifier';
+
+const plusOne = helper(([num]) => num + 1);
+
+const setScrollPosition = modifier((element, [position]) => {
+  element.scrollTop = position
+});
+
+<template>
+  <div class="scroll-container" {{setScrollPosition @scrollPos}}>
+    {{#each @items as |item index|}}
+      Item #{{plusOne index}}: {{item}}
+    {{/each}}
+  </div>
+</template>
+
+# From https://github.com/ember-template-imports/ember-template-imports

--- a/packages/shiki/samples/gts.sample
+++ b/packages/shiki/samples/gts.sample
@@ -1,0 +1,7 @@
+import type { TemplateOnlyComponent } from '@glimmer/component';
+
+const Greet: TemplateOnlyComponent<{ name: string }> = <template>
+  <p>Hello, {{@name}}!</p>
+</template>
+
+# From https://rfcs.emberjs.com/id/0779-first-class-component-templates

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -54,6 +54,8 @@ export type Lang =
   | 'gherkin'
   | 'git-commit'
   | 'git-rebase'
+  | 'glimmer-js' | 'gjs'
+  | 'glimmer-ts' | 'gts'
   | 'glsl'
   | 'gnuplot'
   | 'go'
@@ -536,6 +538,22 @@ export const languages: ILanguageRegistration[] = [
     path: 'git-rebase.tmLanguage.json',
     displayName: 'Git Rebase Message',
     embeddedLangs: ['shellscript']
+  },
+  {
+    id: 'glimmer-js',
+    scopeName: 'source.gjs',
+    path: 'glimmer-js.tmLanguage.json',
+    displayName: 'Glimmer-js',
+    aliases: ['gjs'],
+    embeddedLangs: ['javascript']
+  },
+  {
+    id: 'glimmer-ts',
+    scopeName: 'source.gts',
+    path: 'glimmer-ts.tmLanguage.json',
+    displayName: 'Glimmer-ts',
+    aliases: ['gts'],
+    embeddedLangs: ['typescript']
   },
   {
     id: 'glsl',

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -340,6 +340,8 @@ export const languageAliases = {
   docker: ['dockerfile'],
   erlang: ['erl'],
   fsharp: ['f#', 'fs'],
+  'glimmer-js': ['gjs'],
+  'glimmer-ts': ['gts'],
   haskell: ['hs'],
   handlebars: ['hbs'],
   ini: ['properties'],
@@ -432,5 +434,6 @@ export const embeddedLanguagesToExclude = [
  * Value is a list of language ids, as can be found by F1 -> Change Language Mode. For example `astro`
  */
 export const marketplaceGrammarSources: Record<string, string[]> = {
-  'bpruitt-goddard.mermaid-markdown-syntax-highlighting': ['mermaid']
+  'bpruitt-goddard.mermaid-markdown-syntax-highlighting': ['mermaid'],
+  'chiragpat.vscode-glimmer': ['glimmer-js', 'glimmer-ts']
 }


### PR DESCRIPTION
- [ ] Add a test if possible
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [x] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [x] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.

Seems like the tool doesn't fetch the grammar correctly from the VS Code extension?