### PR TITLE
feat: add glimmer js/ts language

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -104,6 +104,8 @@ export type Lang =
   | 'gherkin'
   | 'git-commit'
   | 'git-rebase'
+  | 'glimmer-js' | 'gjs'
+  | 'glimmer-ts' | 'gts'
   | 'glsl'
   | 'gnuplot'
   | 'go'

--- a/packages/shiki/languages/glimmer-js.tmLanguage.json
+++ b/packages/shiki/languages/glimmer-js.tmLanguage.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "glimmer-js",
+  "scopeName": "source.gjs",
+  "patterns": [
+    {
+      "include": "source.js"
+    }
+  ],
+  "injections": {
+    "L:source.gjs -comment": {
+      "patterns": [
+        {
+          "name": "meta.js.embeddedTemplateWithoutArgs",
+          "begin": "\\s*(<)(template)\\s*(>)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            },
+            "3": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "end": "(</)(template)(>)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            },
+            "3": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "patterns": [
+            {
+              "include": "text.html.handlebars"
+            }
+          ]
+        },
+        {
+          "name": "meta.js.embeddedTemplateWithArgs",
+          "begin": "(<)(template)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            }
+          },
+          "end": "(</)(template)(>)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            },
+            "3": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "(?<=\\<template)",
+              "end": "(?=\\>)",
+              "patterns": [
+                {
+                  "include": "text.html.handlebars#tag-stuff"
+                }
+              ]
+            },
+            {
+              "begin": "(>)",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.definition.tag.end.js"
+                }
+              },
+              "end": "(?=</template>)",
+              "contentName": "meta.html.embedded.block",
+              "patterns": [
+                {
+                  "include": "text.html.handlebars"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/shiki/languages/glimmer-ts.tmLanguage.json
+++ b/packages/shiki/languages/glimmer-ts.tmLanguage.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "glimmer-ts",
+  "scopeName": "source.gts",
+  "patterns": [
+    {
+      "include": "source.ts"
+    }
+  ],
+  "injections": {
+    "L:source.gts -comment": {
+      "patterns": [
+        {
+          "name": "meta.js.embeddedTemplateWithoutArgs",
+          "begin": "\\s*(<)(template)\\s*(>)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            },
+            "3": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "end": "(</)(template)(>)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            },
+            "3": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "patterns": [
+            {
+              "include": "text.html.handlebars"
+            }
+          ]
+        },
+        {
+          "name": "meta.js.embeddedTemplateWithArgs",
+          "begin": "(<)(template)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            }
+          },
+          "end": "(</)(template)(>)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.tag.html"
+            },
+            "2": {
+              "name": "entity.name.tag.other.html"
+            },
+            "3": {
+              "name": "punctuation.definition.tag.html"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "(?<=\\<template)",
+              "end": "(?=\\>)",
+              "patterns": [
+                {
+                  "include": "text.html.handlebars#tag-stuff"
+                }
+              ]
+            },
+            {
+              "begin": "(>)",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.definition.tag.end.js"
+                }
+              },
+              "end": "(?=</template>)",
+              "contentName": "meta.html.embedded.block",
+              "patterns": [
+                {
+                  "include": "text.html.handlebars"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/shiki/samples/gjs.sample
+++ b/packages/shiki/samples/gjs.sample
@@ -1,0 +1,18 @@
+import { helper } from '@ember/component/helper';
+import { modifier } from 'ember-modifier';
+
+const plusOne = helper(([num]) => num + 1);
+
+const setScrollPosition = modifier((element, [position]) => {
+  element.scrollTop = position
+});
+
+<template>
+  <div class="scroll-container" {{setScrollPosition @scrollPos}}>
+    {{#each @items as |item index|}}
+      Item #{{plusOne index}}: {{item}}
+    {{/each}}
+  </div>
+</template>
+
+# From https://github.com/ember-template-imports/ember-template-imports

--- a/packages/shiki/samples/gts.sample
+++ b/packages/shiki/samples/gts.sample
@@ -1,0 +1,7 @@
+import type { TemplateOnlyComponent } from '@glimmer/component';
+
+const Greet: TemplateOnlyComponent<{ name: string }> = <template>
+  <p>Hello, {{@name}}!</p>
+</template>
+
+# From https://rfcs.emberjs.com/id/0779-first-class-component-templates

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -543,7 +543,7 @@ export const languages: ILanguageRegistration[] = [
     id: 'glimmer-js',
     scopeName: 'source.gjs',
     path: 'glimmer-js.tmLanguage.json',
-    displayName: 'glimmer-js',
+    displayName: 'Glimmer JS',
     aliases: ['gjs'],
     embeddedLangs: ['javascript', 'handlebars']
   },
@@ -551,7 +551,7 @@ export const languages: ILanguageRegistration[] = [
     id: 'glimmer-ts',
     scopeName: 'source.gts',
     path: 'glimmer-ts.tmLanguage.json',
-    displayName: 'glimmer-ts',
+    displayName: 'Glimmer TS',
     aliases: ['gts'],
     embeddedLangs: ['typescript', 'handlebars']
   },

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -54,6 +54,8 @@ export type Lang =
   | 'gherkin'
   | 'git-commit'
   | 'git-rebase'
+  | 'glimmer-js' | 'gjs'
+  | 'glimmer-ts' | 'gts'
   | 'glsl'
   | 'gnuplot'
   | 'go'
@@ -536,6 +538,22 @@ export const languages: ILanguageRegistration[] = [
     path: 'git-rebase.tmLanguage.json',
     displayName: 'Git Rebase Message',
     embeddedLangs: ['shellscript']
+  },
+  {
+    id: 'glimmer-js',
+    scopeName: 'source.gjs',
+    path: 'glimmer-js.tmLanguage.json',
+    displayName: 'glimmer-js',
+    aliases: ['gjs'],
+    embeddedLangs: ['javascript', 'handlebars']
+  },
+  {
+    id: 'glimmer-ts',
+    scopeName: 'source.gts',
+    path: 'glimmer-ts.tmLanguage.json',
+    displayName: 'glimmer-ts',
+    aliases: ['gts'],
+    embeddedLangs: ['typescript', 'handlebars']
   },
   {
     id: 'glsl',

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -348,6 +348,8 @@ export const languageAliases = {
   docker: ['dockerfile'],
   erlang: ['erl'],
   fsharp: ['f#', 'fs'],
+  'glimmer-js': ['gjs'],
+  'glimmer-ts': ['gts'],
   haskell: ['hs'],
   handlebars: ['hbs'],
   ini: ['properties'],

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -155,6 +155,14 @@ export const githubGrammarSources: [string, string][] = [
     'gherkin',
     'https://github.com/alexkrechik/VSCucumberAutoComplete/blob/master/gclient/syntaxes/feature.tmLanguage'
   ],
+  [
+    'glimmer-js',
+    'https://github.com/IgnaceMaes/glimmer-textmate-grammar/blob/main/glimmer-js.tmLanguage.json'
+  ],
+  [
+    'glimmer-ts',
+    'https://github.com/IgnaceMaes/glimmer-textmate-grammar/blob/main/glimmer-ts.tmLanguage.json'
+  ],
   ['glsl', 'https://github.com/polym0rph/GLSL.tmbundle/blob/master/Syntaxes/GLSL.tmLanguage'],
   [
     'gnuplot',


### PR DESCRIPTION
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [x] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [x] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.

Adds support for `.gjs` and `.gts` file formats. Glimmer `<template>` tag components are the new format which power Ember.js. References:

- RFC: https://rfcs.emberjs.com/id/0779-first-class-component-templates
- Component implementation: https://github.com/ember-template-imports/ember-template-imports
- VS Code language definitions: https://github.com/chiragpat/vscode-glimmer

Local test:

<img width="681" src="https://github.com/shikijs/shiki/assets/10243652/32c233bb-f8c1-4f83-bc80-980ae025b6b3">
