### PR TITLE
feat: add narrat grammar

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -146,6 +146,7 @@ export type Lang =
   | 'matlab'
   | 'mdx'
   | 'mermaid'
+  | 'narrat' | 'nar'
   | 'nextflow' | 'nf'
   | 'nginx'
   | 'nim'

--- a/packages/shiki/languages/narrat.tmLanguage.json
+++ b/packages/shiki/languages/narrat.tmLanguage.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "narrat",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#expression"
+    }
+  ],
+  "repository": {
+    "expression": {
+      "patterns": [
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#commands"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#primitives"
+        },
+        {
+          "include": "#strings"
+        },
+        {
+          "include": "#paren-expression"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.narrat",
+          "match": "\\b(if|else|choice)\\b"
+        },
+        {
+          "name": "variable.value.narrat",
+          "match": "\\$[\\w|\\.]+\\b"
+        },
+        {
+          "name": "entity.name.function.narrat",
+          "match": "(?x)                  # Ignore comments\n  ^\\w+                # Find label name\n  (?=(\\s|\\w)*:)       # Positive lookahead for ':'\n"
+        },
+        {
+          "name": "invalid.label.narrat",
+          "match": "(?x)                  # Ignore comments\n  ^\\w+                # Find label name\n  (?!(\\s|\\w)*:)        # Negative lookahead for ':'\n"
+        },
+        {
+          "name": "entity.other.attribute-name",
+          "match": "(?<=\\w)[^^](\\b\\w+\\b)(?=(\\s|\\w)*:)"
+        }
+      ]
+    },
+    "commands": {
+      "patterns": [
+        {
+          "name": "keyword.commands.variables.narrat",
+          "match": "\\b(set|var)\\b"
+        },
+        {
+          "name": "keyword.commands.text.narrat",
+          "match": "\\b(talk|think)\\b"
+        },
+        {
+          "name": "keyword.commands.flow.narrat",
+          "match": "\\b(jump|run|wait|return|save|save_prompt)"
+        },
+        {
+          "name": "keyword.commands.helpers.narrat",
+          "match": "\\b(log|clear_dialog)\\b"
+        },
+        {
+          "name": "keyword.commands.screens.narrat",
+          "match": "\\b(set_screen|empty_layer|set_button)"
+        },
+        {
+          "name": "keyword.commands.audio.narrat",
+          "match": "\\b(play|pause|stop)\\b"
+        },
+        {
+          "name": "keyword.commands.notifications.narrat",
+          "match": "\\b(notify|enable_notifications|disable_notifications)\\b"
+        },
+        {
+          "name": "keyword.commands.stats.narrat",
+          "match": "\\b(set_stat|get_stat_value|add_stat)"
+        },
+        {
+          "name": "keyword.commands.math.narrat",
+          "match": "\\b(neg|abs|random|random_float|random_from_args|min|max|clamp|floor|round|ceil|sqrt|^)\\b"
+        },
+        {
+          "name": "keyword.commands.string.narrat",
+          "match": "\\b(concat|join)\\b"
+        },
+        {
+          "name": "keyword.commands.text_field.narrat",
+          "match": "\\b(text_field)\\b"
+        },
+        {
+          "name": "keyword.commands.skills.narrat",
+          "match": "\\b(add_level|set_level|add_xp|roll|get_level|get_xp)\\b"
+        },
+        {
+          "name": "keyword.commands.inventory.narrat",
+          "match": "\\b(add_item|remove_item|enable_interaction|disable_interaction|has_item?|item_amount?)"
+        },
+        {
+          "name": "keyword.commands.quests.narrat",
+          "match": "\\b(start_quest|start_objective|complete_objective|complete_quest|quest_started?|objective_started?|quest_completed?|objective_completed?)"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.logic.narrat",
+          "match": "(&&|\\|\\||!=|==|>=|<=|<|>|!|\\?)\\s"
+        },
+        {
+          "name": "keyword.operator.arithmetic.narrat",
+          "match": "(\\+|-|\\*|\\/)\\s"
+        }
+      ]
+    },
+    "interpolation": {
+      "patterns": [
+        {
+          "name": "variable.interpolation.narrat",
+          "match": "(\\w|\\.)+"
+        }
+      ]
+    },
+    "strings": {
+      "name": "string.quoted.double.narrat",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "constant.character.escape.narrat",
+          "match": "\\\\."
+        },
+        {
+          "name": "expression.template",
+          "begin": "%{",
+          "end": "}",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.template.open"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.template.close.narrat"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#expression"
+            },
+            {
+              "include": "#interpolation"
+            }
+          ]
+        }
+      ]
+    },
+    "paren-expression": {
+      "begin": "\\(",
+      "end": "\\)",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.paren.open"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.paren.close"
+        }
+      },
+      "name": "expression.group",
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "primitives": {
+      "patterns": [
+        {
+          "name": "constant.numeric.narrat",
+          "match": "\\b\\d+\\b"
+        },
+        {
+          "name": "constant.language.true.narrat",
+          "match": "\\btrue\\b"
+        },
+        {
+          "name": "constant.language.false.narrat",
+          "match": "\\bfalse\\b"
+        },
+        {
+          "name": "constant.language.null.narrat",
+          "match": "\\bnull\\b"
+        },
+        {
+          "name": "constant.language.undefined.narrat",
+          "match": "\\bundefined\\b"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.narrat",
+          "match": "\\/\\/.*$"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.narrat"
+}

--- a/packages/shiki/samples/narrat.sample
+++ b/packages/shiki/samples/narrat.sample
@@ -1,0 +1,92 @@
+quest_demo:
+  set_button shopButton true
+  set_button parkButton greyed
+  jump bread_quest
+
+bread_quest:
+  choice:
+    talk helper idle "Can you get 2 pieces of bread for me?"
+    "Yes":
+      talk helper idle "Thanks, that's very nice!"
+      talk helper idle "I'll be waiting for you at the park"
+      jump bread_start
+    "No":
+      talk helper idle "Oh, okay"
+      jump quest_demo
+
+bread_start:
+  start_quest breadShopping
+  talk inner idle "Time to go to the shop to buy some bread then."
+  set_screen map
+  set_button shopButton true
+
+shopButton:
+  // set_screen default
+  "You visit the bread shop"
+  talk shopkeeper idle "Hello, I'm a little baker selling bread and drinks!"
+  set data.breadPrice 5
+  jump shop_menu
+
+parkButton:
+  choice:
+    talk helper idle "Ah, so do you have my bread?"
+    "Yes!" if (>= $items.bread.amount 2):
+      talk helper idle "Thanks a lot!"
+      add_item bread -2
+      complete_objective breadShopping delivery
+      complete_quest breadShopping
+      set_button parkButton false
+      jump demo_end
+    "No :(":
+      talk helper idle "Oh okay"
+
+shop_menu:
+  choice:
+    talk shopkeeper idle "So, do you want some bread?"
+    "Buy bread (costs %{$$data.breadPrice})" if (>= $stats.money.value $data.breadPrice):
+      add_item bread 1
+      if (== $data.breadPrice 5):
+        add_stat money -5
+      else:
+        add_stat money -4
+      jump map_update
+    roll bread_haggle haggling 50 "Try to haggle for bread" hideAfterRoll:
+      success "You explain that helper cat needs bread to feed his poor family":
+        add_xp haggling 10
+        set data.breadPrice 4
+        talk shopkeeper idle "I guess I can sell you bread for 4 coins"
+        jump shop_menu
+      failure "You try to pity trip the shopkeeper but he won't bulge":
+        add_xp haggling 5
+        talk shopkeeper idle "The price is 5 coins, nothing less, nothing more."
+        jump shop_menu
+    "Exit":
+      jump map_update
+
+show_map:
+  set_button parkButton false
+  set_button shopButton true
+  set_screen map
+
+map_update:
+  set_button parkButton false
+  set_button shopButton true
+  log $items.bread
+  if (>= $items.bread.amount 2):
+    complete_objective breadShopping bread
+    talk inner idle "I've got enough bread now, I'm going to go to the park."
+    start_objective breadShopping delivery
+    set_screen map
+    set_button parkButton true
+    set_button shopButton false
+  else:
+    talk inner idle "Hmm, I still need to buy more bread for helper cat."
+    set_screen map
+
+eat_bread:
+  talk player idle "hmm, bread"
+
+read_book:
+  talk inner idle "It's full of ocult rituals. I'm not sure what they are, but I'm sure they are useful."
+
+// From: https://github.com/liana-p/narrat-engine/blob/main/packages/narrat/examples/games/demo/data/quest.narrat

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -96,6 +96,7 @@ export type Lang =
   | 'matlab'
   | 'mdx'
   | 'mermaid'
+  | 'narrat' | 'nar'
   | 'nextflow' | 'nf'
   | 'nginx'
   | 'nim'
@@ -828,6 +829,14 @@ export const languages: ILanguageRegistration[] = [
     scopeName: 'source.mermaid',
     path: 'mermaid.tmLanguage.json',
     displayName: 'Mermaid'
+  },
+  {
+    id: 'narrat',
+    scopeName: 'source.narrat',
+    path: 'narrat.tmLanguage.json',
+    displayName: 'Narrat Language',
+    samplePath: 'narrat.sample',
+    aliases: ['nar']
   },
   {
     id: 'nextflow',

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -204,6 +204,10 @@ export const githubGrammarSources: [string, string][] = [
   ],
   ['mdx', 'https://github.com/wooorm/markdown-tm-language/blob/main/source.mdx.tmLanguage'],
   [
+    'narrat',
+    'https://github.com/liana-p/narrat-syntax-highlighting-vscode/blob/main/syntaxes/narrat.tmLanguage.yaml'
+  ],
+  [
     'nextflow',
     'https://github.com/nextflow-io/vscode-language-nextflow/blob/master/syntaxes/nextflow.tmLanguage.json'
   ],
@@ -348,6 +352,7 @@ export const languageAliases = {
   kusto: ['kql'],
   make: ['makefile'],
   markdown: ['md'],
+  narrat: ['nar'],
   nextflow: ['nf'],
   'objective-c': ['objc'],
   powershell: ['ps', 'ps1'],
@@ -379,12 +384,12 @@ export const languageDisplayOverrides: Record<string, string> = {
   apl: 'APL',
   asm: 'Assembly',
   clarity: 'Clarity',
-  'codeql': 'CodeQL',
+  codeql: 'CodeQL',
   dax: 'DAX',
   erb: 'ERB',
   fish: 'Fish',
-  'gdresource': 'GDResource',
-  'gnuplot': 'Gnuplot',
+  gdresource: 'GDResource',
+  gnuplot: 'Gnuplot',
   http: 'HTTP',
   ini: 'INI',
   'jinja-html': 'Jinja',


### PR DESCRIPTION
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
g a language -->

- [x] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [x] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [x] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.