### PR TITLE
fix: Compiler errors in Node

### DIFF
--- a/packages/shiki/src/global.d.ts
+++ b/packages/shiki/src/global.d.ts
@@ -10,10 +10,6 @@ declare global {
 
   var self: Window & typeof globalThis
   function fetch(url: string): Promise<Response>
-  interface Response {
-    json(): Promise<any>
-    text(): Promise<any>
-  }
 }
 
 // This export is here so that all variables above would be added to the global scope

--- a/packages/shiki/src/loader.ts
+++ b/packages/shiki/src/loader.ts
@@ -1,5 +1,15 @@
 /// <reference path="./global.d.ts" />
 
+// This is declared here rather than in global.d.ts because it is part of our
+// public api due to setWasm. We need it because it won't be defined otherwise
+// for Node users without "DOM" in their lib.
+declare global {
+  interface Response {
+    json(): Promise<any>
+    text(): Promise<any>
+  }
+}
+
 import { join, dirpathparts } from './utils'
 import type { IGrammar, IOnigLib, IRawTheme } from 'vscode-textmate'
 import { loadWASM, createOnigScanner, createOnigString } from 'vscode-oniguruma'

--- a/packages/shiki/tsconfig.json
+++ b/packages/shiki/tsconfig.json
@@ -5,7 +5,8 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "lib": ["ESNext"],
-    "sourceMap": true
+    "sourceMap": true,
+    "skipLibCheck": true
   },
   "exclude": ["samples"]
 }


### PR DESCRIPTION
TypeDoc doesn't have "DOM" in the lib, so doesn't have a global `Response` interface like DOM types do. The changes in #384 (cc @orta) broke me because it references that type now. This moves the interface into loader.ts so that it gets bundled in the declaration file output.