### PR TITLE
feat: add splunk grammar

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -191,6 +191,7 @@ export type Lang =
   | 'smalltalk'
   | 'solidity'
   | 'sparql'
+  | 'splunk' | 'spl'
   | 'sql'
   | 'ssh-config'
   | 'stata'

--- a/packages/shiki/languages/splunk.tmLanguage.json
+++ b/packages/shiki/languages/splunk.tmLanguage.json
@@ -1,0 +1,87 @@
+{
+  "fileTypes": ["splunk", "spl"],
+  "name": "splunk",
+  "patterns": [
+    {
+      "comment": "Splunk Built-in functions",
+      "match": "(?<=(\\||\\[))([\\s]*)\\b(abstract|accum|addcoltotals|addinfo|addtotals|analyzefields|anomalies|anomalousvalue|append|appendcols|appendpipe|arules|associate|audit|autoregress|bucket|bucketdir|chart|cluster|collect|concurrency|contingency|convert|correlate|crawl|datamodel|dbinspect|dbxquery|dbxlookup|dedup|delete|delta|diff|dispatch|erex|eval|eventcount|eventstats|extract|fieldformat|fields|fieldsummary|file|filldown|fillnull|findtypes|folderize|foreach|format|from|gauge|gentimes|geostats|head|highlight|history|input|inputcsv|inputlookup|iplocation|join|kmeans|kvform|loadjob|localize|localop|lookup|makecontinuous|makemv|makeresults|map|metadata|metasearch|multikv|multisearch|mvcombine|mvexpand|nomv|outlier|outputcsv|outputlookup|outputtext|overlap|pivot|predict|rangemap|rare|regex|relevancy|reltime|rename|replace|rest|return|reverse|rex|rtorder|run|savedsearch|script|scrub|search|searchtxn|selfjoin|sendemail|set|setfields|sichart|sirare|sistats|sitimechart|sitop|sort|spath|stats|strcat|streamstats|table|tags|tail|timechart|top|transaction|transpose|trendline|tscollect|tstats|typeahead|typelearner|typer|uniq|untable|where|x11|xmlkv|xmlunescape|xpath|xyseries)\\b(?=[\\s])",
+      "name": "support.class.splunk_search"
+    },
+    {
+      "comment": "Splunk Eval functions",
+      "match": "\\b(abs|acos|acosh|asin|asinh|atan|atan2|atanh|case|cidrmatch|ceiling|coalesce|commands|cos|cosh|exact|exp|floor|hypot|if|in|isbool|isint|isnotnull|isnull|isnum|isstr|len|like|ln|log|lower|ltrim|match|max|md5|min|mvappend|mvcount|mvdedup|mvfilter|mvfind|mvindex|mvjoin|mvrange|mvsort|mvzip|now|null|nullif|pi|pow|printf|random|relative_time|replace|round|rtrim|searchmatch|sha1|sha256|sha512|sigfig|sin|sinh|spath|split|sqrt|strftime|strptime|substr|tan|tanh|time|tonumber|tostring|trim|typeof|upper|urldecode|validate)(?=\\()\\b",
+      "name": "support.function.splunk_search"
+    },
+    {
+      "comment": "Splunk Transforming functions",
+      "match": "\\b(avg|count|distinct_count|estdc|estdc_error|eval|max|mean|median|min|mode|percentile|range|stdev|stdevp|sum|sumsq|var|varp|first|last|list|values|earliest|earliest_time|latest|latest_time|per_day|per_hour|per_minute|per_second|rate)\\b",
+      "name": "support.function.splunk_search"
+    },
+    {
+      "comment": "Splunk Macro Names",
+      "match": "(?<=\\`)[\\w]+(?=\\(|\\`)",
+      "name": "entity.name.function.splunk_search"
+    },
+    {
+      "comment": "Digits",
+      "match": "\\b(\\d+)\\b",
+      "name": "constant.numeric.splunk_search"
+    },
+    {
+      "comment": "Escape Characters",
+      "match": "(\\\\\\\\|\\\\\\||\\\\\\*|\\\\\\=)",
+      "name": "contant.character.escape.splunk_search"
+    },
+    {
+      "comment": "Splunk Operators",
+      "match": "(\\|,)",
+      "name": "keyword.operator.splunk_search"
+    },
+    {
+      "comment": "Splunk Language Constants",
+      "match": "(?i)\\b(as|by|or|and|over|where|output|outputnew)\\b|(?-i)\\b(NOT|true|false)\\b",
+      "name": "constant.language.splunk_search"
+    },
+    {
+      "comment": "Splunk Macro Parameters",
+      "match": "(?<=\\(|,|[^=]\\s{300})([^\\(\\)\\\",=]+)(?=\\)|,)",
+      "name": "variable.parameter.splunk_search"
+    },
+    {
+      "comment": "Splunk Variables",
+      "match": "([\\w\\.]+)(\\[\\]|\\{\\})?([\\s]*)(?=\\=)",
+      "name": "variable.splunk_search"
+    },
+    {
+      "comment": "Comparison or assignment",
+      "match": "=",
+      "name": "keyword.operator.splunk_search"
+    },
+    {
+      "begin": "(?<!\\\\)\"",
+      "end": "(?<!\\\\)\"",
+      "name": "string.quoted.double.splunk_search"
+    },
+    {
+      "begin": "(?<!\\\\)'",
+      "end": "(?<!\\\\)'",
+      "name": "string.quoted.single.splunk_search"
+    },
+    {
+      "begin": "query=\\\"",
+      "end": "(?<!\\\\)\"",
+      "name": "meta.embedded.block.sql"
+    },
+    {
+      "begin": "(?<!\\\\)```",
+      "end": "(?<!\\\\)```",
+      "name": "comment.block.splunk_search"
+    },
+    {
+      "begin": "`comment\\(",
+      "end": "\\)`",
+      "name": "comment.block.splunk_search"
+    }
+  ],
+  "scopeName": "source.splunk_search"
+}

--- a/packages/shiki/samples/splunk.sample
+++ b/packages/shiki/samples/splunk.sample
@@ -1,0 +1,15 @@
+# CPU/Memory usage
+`dmc_set_index_introspection` sourcetype=splunk_resource_usage component=Hostwide host=*  | eval CPU_Usage=('data.cpu_system_pct' + 'data.cpu_user_pct')   | timechart avg(CPU_Usage) by  host
+
+
+index=_introspection host=* sourcetype=splunk_resource_usage component=Hostwide
+| `drop_dm_object_name("data")`
+| timechart limit=0 useother=f span=30s avg(cpu_user_pct) AS avg,max(cpu_user_pct) AS max by host
+
+index=_introspection host=* sourcetype=splunk_resource_usage component=Hostwide
+| `drop_dm_object_name("data")`
+| eval used_pct=round((mem_used/mem)*100,2)
+| eval swap_used_pct=round((swap_used/swap)*100,2)
+| timechart limit=0 useother=f span=1m max(used_pct) AS max_used,max(swap_used_pct) AS max_swap_used by host
+
+# https://github.com/getkub/SplunkScriplets/blob/master/docs/splunk_tips/searches/cpu_memory.txt

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -141,6 +141,7 @@ export type Lang =
   | 'smalltalk'
   | 'solidity'
   | 'sparql'
+  | 'splunk' | 'spl'
   | 'sql'
   | 'ssh-config'
   | 'stata'
@@ -1145,6 +1146,14 @@ export const languages: ILanguageRegistration[] = [
     displayName: 'SPARQL',
     samplePath: 'sparql.sample',
     embeddedLangs: ['turtle']
+  },
+  {
+    id: 'splunk',
+    scopeName: 'source.splunk_search',
+    path: 'splunk.tmLanguage.json',
+    displayName: 'Splunk Query Language',
+    samplePath: 'splunk.sample',
+    aliases: ['spl']
   },
   {
     id: 'sql',

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -292,6 +292,10 @@ export const githubGrammarSources: [string, string][] = [
     'https://github.com/stardog-union/stardog-vsc/blob/master/stardog-rdf-grammars/syntaxes/sparql.tmLanguage.json'
   ],
   [
+    'splunk',
+    'https://github.com/arcsector/vscode-splunk-search-syntax/blob/master/syntaxes/splunk_search.tmLanguage'
+  ],
+  [
     'ssh-config',
     'https://github.com/textmate/ssh-config.tmbundle/blob/master/Syntaxes/SSH-Config.tmLanguage'
   ],
@@ -383,6 +387,7 @@ export const languageAliases = {
   shaderlab: ['shader'],
   shellscript: ['bash', 'sh', 'shell', 'zsh'],
   shellsession: ['console'],
+  splunk: ['spl'],
   stylus: ['styl'],
   typescript: ['ts'],
   vb: ['cmd'],


### PR DESCRIPTION
This adds support for the [splunk search processing language](https://www.splunk.com/) syntax

- [x] I have read docs for [adding a language](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar).
- [x] I have searched around and this is the most up-to-date, actively maintained version of the language grammar.
- [x] I have added a sample file that includes a variety of language syntaxes and succinctly captures the idiosyncrasy of a language. See [docs](https://github.com/shikijs/shiki/blob/main/docs/languages.md#adding-grammar) for requirement.