### PR TITLE
fix: alias `c++` to `cpp`

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -80,7 +80,7 @@ export type Lang =
   | 'cobol'
   | 'codeql' | 'ql'
   | 'coffee'
-  | 'cpp'
+  | 'cpp' | 'c++'
   | 'crystal'
   | 'csharp' | 'c#' | 'cs'
   | 'css'

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -30,7 +30,7 @@ export type Lang =
   | 'cobol'
   | 'codeql' | 'ql'
   | 'coffee'
-  | 'cpp'
+  | 'cpp' | 'c++'
   | 'crystal'
   | 'csharp' | 'c#' | 'cs'
   | 'css'

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -360,6 +360,7 @@ export const languageAliases = {
   cadence: ['cdc'],
   clojure: ['clj'],
   codeql: ['ql'],
+  cpp: ['c++'],
   csharp: ['c#', 'cs'],
   cypher: ['cql'],
   docker: ['dockerfile'],


### PR DESCRIPTION
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
