### PR TITLE
fix: alias `kt` to `kotlin`

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -134,7 +134,7 @@ export type Lang =
   | 'jssm' | 'fsl'
   | 'jsx'
   | 'julia'
-  | 'kotlin'
+  | 'kotlin' | 'kt'
   | 'kusto' | 'kql'
   | 'latex'
   | 'less'

--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -84,7 +84,7 @@ export type Lang =
   | 'jssm' | 'fsl'
   | 'jsx'
   | 'julia'
-  | 'kotlin'
+  | 'kotlin' | 'kt'
   | 'kusto' | 'kql'
   | 'latex'
   | 'less'

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -372,6 +372,7 @@ export const languageAliases = {
   ini: ['properties'],
   javascript: ['js'],
   jssm: ['fsl'],
+  kotlin: ['kt'],
   kusto: ['kql'],
   make: ['makefile'],
   markdown: ['md'],


### PR DESCRIPTION
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
