### PR TITLE
chore: Update Dart grammar for change from inline classes to extension types

### DIFF
--- a/packages/shiki/languages/dart.tmLanguage.json
+++ b/packages/shiki/languages/dart.tmLanguage.json
@@ -1,6 +1,6 @@
 {
   "name": "dart",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "fileTypes": ["dart"],
   "scopeName": "source.dart",
   "foldingStartMarker": "\\{\\s*$",
@@ -330,7 +330,7 @@
         },
         {
           "name": "keyword.declaration.dart",
-          "match": "(?<!\\$)\\b(abstract|sealed|base|interface|inline class|class|enum|extends|extension|external|factory|implements|get(?!\\()|mixin|native|operator|set(?!\\()|typedef|with|covariant)\\b(?!\\$)"
+          "match": "(?<!\\$)\\b(abstract|sealed|base|interface|class|enum|extends|extension type|extension|external|factory|implements|get(?!\\()|mixin|native|operator|set(?!\\()|typedef|with|covariant)\\b(?!\\$)"
         },
         {
           "name": "storage.modifier.dart",


### PR DESCRIPTION
Updates to the latest release of the official Dart syntax: https://github.com/dart-lang/dart-syntax-highlight/blob/master/grammars/dart.json