### PR TITLE
fix: add 'kt' and 'kts' alias for kotlin

### DIFF
--- a/packages/shiki/src/languages.ts
+++ b/packages/shiki/src/languages.ts
@@ -84,7 +84,7 @@ export type Lang =
   | 'jssm' | 'fsl'
   | 'jsx'
   | 'julia'
-  | 'kotlin'
+  | 'kotlin' | 'kt' | 'kts'
   | 'kusto' | 'kql'
   | 'latex'
   | 'less'
@@ -781,7 +781,8 @@ export const languages: ILanguageRegistration[] = [
     scopeName: 'source.kotlin',
     path: 'kotlin.tmLanguage.json',
     displayName: 'Kotlin',
-    samplePath: 'kotlin.sample'
+    samplePath: 'kotlin.sample',
+    aliases: ['kt', 'kts']
   },
   {
     id: 'kusto',

--- a/scripts/grammarSources.ts
+++ b/scripts/grammarSources.ts
@@ -372,6 +372,7 @@ export const languageAliases = {
   ini: ['properties'],
   javascript: ['js'],
   jssm: ['fsl'],
+  kotlin: ['kt', 'kts'],
   kusto: ['kql'],
   make: ['makefile'],
   markdown: ['md'],


### PR DESCRIPTION
add file aliases `kt` and `kts` for kotlin

