### PR TITLE
fix: npm publish only `dist` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "update:grammars": "bash ./scripts/pullGrammars.sh",
     "changelog": "esno scripts/changelog/generate-changelog.ts"
   },
+  "files": [
+    "dist"
+  ],
   "gitHooks": {
     "pre-commit": "lint-staged"
   },


### PR DESCRIPTION
This PR adds the `files` allowlist to package.json which will prevent assets like `languages` and `themes` from being included twice.

For example:
- https://unpkg.com/browse/shiki@0.14.5/languages/
- https://unpkg.com/browse/shiki@0.14.5/dist/languages/

Learn more: 
- https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files

