### PR TITLE
fix(registry): loadLanguage does not await loadGrammar

### DIFF
--- a/packages/shiki/src/__tests__/issues.test.ts
+++ b/packages/shiki/src/__tests__/issues.test.ts
@@ -34,3 +34,15 @@ test(`Don't preload any language if lang is set to an empty array (#326)`, async
   })
   expect(highlighter.getLoadedLanguages()).toHaveLength(0)
 })
+
+// https://github.com/shikijs/shiki/issues/438
+test(`Highlighter's loadLanguage is buggy (#438)`, async () => {
+  const highlighter = await getHighlighter({
+    theme: 'nord',
+    langs: []
+  })
+
+  await highlighter.loadLanguage('md')
+  await highlighter.loadLanguage('json')
+  expect(highlighter.getLoadedLanguages()).toHaveLength(2)
+})


### PR DESCRIPTION
This fix ensures that `loadGrammar` is awaited and prevents `loadLanguage` from throwing in registry.ts.

- [x] Add a test if possible
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

<!-- If fixing a bug -->

- [x] This PR fixes #438 