### PR TITLE
fix: vue template syntax bug #503

### DIFF
--- a/packages/shiki/languages/vue.tmLanguage.json
+++ b/packages/shiki/languages/vue.tmLanguage.json
@@ -861,7 +861,7 @@
               "include": "#html-stuff"
             }
           ]
-        }
+                }
       ]
     },
     "template-tag-2": {
@@ -911,10 +911,7 @@
           "include": "#template-tag"
         },
         {
-          "include": "text.html.derivative"
-        },
-        {
-          "include": "text.html.basic"
+          "include": "text.html.vue-html"
         }
       ]
     },


### PR DESCRIPTION
- [x] Format all commit messages with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] This PR fixes #503

This bug is caused by fact that the `vue.tmLanguage.json` in [`Volar` repo](https://github.com/vuejs/language-tools/tree/master/extensions/vscode/syntaxes) doesn't support Vue directives and interpolations,the Volar uses `Injections` instead.The PR use `vue-html` syntax to render the code in tag `template` to fix the bug.

- the original：
  ![Snipaste_2023-11-28_20-27-18](https://github.com/shikijs/shiki/assets/97817985/54c11552-eb0d-425a-bdd8-3a5be82118ad)
- use `vue-html`： 
  ![Snipaste_2023-11-28_20-29-05](https://github.com/shikijs/shiki/assets/97817985/d121ad34-4a72-4069-a746-86710f9f8832)
