### PR TITLE
doc: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ The default functionality of rendering code blocks would use `codeToHtml` from t
 If you want to render the tokens into a code yourself, Shiki exposes two key methods to do that.
 
 - `codeToThemedTokens` takes a code string and a language id and returns an array of tokens. A token represents a single part of the code, for example a keyword, a string, a comment, etc.
-- `renderToHTML` takes an array of tokens and returns an HTML string that represents the provided code.
+- `renderToHtml` takes an array of tokens and returns an HTML string that represents the provided code.
 
 ```js
 import shiki, { getHighlighter } from 'shiki'
@@ -389,15 +389,15 @@ const code = `console.log("Here is your code.");`
 const tokens = highlighter.codeToThemedTokens(code, 'javascript')
 
 // This will return an HTML string that represents the provided code.
-const html = shiki.renderToHTML(tokens)
+const html = shiki.renderToHtml(tokens)
 ```
 
-Alternatively you can add to `renderToHTML` the desired element shape for `pre`, `code`, `line (span)`, and `token (span)`, and override the theme colors for background and foreground.
+Alternatively you can add to `renderToHtml` the desired element shape for `pre`, `code`, `line (span)`, and `token (span)`, and override the theme colors for background and foreground.
 
 For more about that, or to build your own renderer, check out the implementation in [shiki](./packages/shiki/src/renderer.ts).
 
 ```js
-const html = shiki.renderToHTML(tokens, {
+const html = shiki.renderToHtml(tokens, {
   fg: highlighter.getForegroundColor('nord'), // Set a specific foreground color.
   bg: highlighter.getBackgroundColor('nord'), // Set a specific background color.
   // Specified elements override the default elements.


### PR DESCRIPTION
# doc: typo issue for renderToHTML

Thanks for building the nice tool to beatify our codes.
I'm using the custom rendering functionality to customize the output, but got `undefined` when using `renderToHTML` via both Nodejs & CDN.
<img width="1095" alt="Screen Shot 2023-11-29 at 11 40 25 PM" src="https://github.com/shikijs/shiki/assets/107535020/87f4b959-a865-486a-b587-2b659f98d138">
I also checked the source code and confirmed it should be `renderToHtml` rather than `renderToHTML`, after using  `renderToHtml` everything is working fine

# checklist 
- [x] only documentation updated