### PR TITLE
docs: Markdown It -> markdown-it

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -26,7 +26,7 @@ const REFERENCES: DefaultTheme.NavItemWithLink[] = [
 
 const INTEGRATIONS: DefaultTheme.NavItemWithLink[] = [
   { text: 'TypeScript Twoslash', link: '/packages/twoslash' },
-  { text: 'Markdown It', link: '/packages/markdown-it' },
+  { text: 'markdown-it', link: '/packages/markdown-it' },
   { text: 'Rehype', link: '/packages/rehype' },
   { text: 'Monaco Editor', link: '/packages/monaco' },
   { text: 'VitePress', link: '/packages/vitepress' },

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -31,7 +31,7 @@ bun add -D shiki
 
 We also provide some integrations:
 
-- [Markdown It Plugin](/packages/markdown-it)
+- [markdown-it Plugin](/packages/markdown-it)
 - [Rehype Plugin](/packages/rehype)
 - [TypeScript Twoslash Integration](/packages/twoslash)
 - [Monaco Editor Syntax Highlight](/packages/monaco)

--- a/docs/packages/markdown-it.md
+++ b/docs/packages/markdown-it.md
@@ -2,7 +2,7 @@
 
 <Badges name="@shikijs/markdown-it" />
 
-[Markdown It](https://markdown-it.github.io/) plugin for Shiki.
+[markdown-it](https://markdown-it.github.io/) plugin for Shiki.
 
 ## Install
 

--- a/packages/markdown-it/README.md
+++ b/packages/markdown-it/README.md
@@ -1,6 +1,6 @@
 # @shikijs/markdown-it
 
-[Markdown It](https://markdown-it.github.io/) plugin for [shiki](https://github.com/shikijs/shiki)
+[markdown-it](https://markdown-it.github.io/) plugin for [shiki](https://github.com/shikijs/shiki)
 
 [Documentation](https://shiki.style/packages/markdown-it)
 


### PR DESCRIPTION
### Description

markdown-it seems to go by the capitalization/spelling of `markdown-it` in all places that I can find. I feel it is best to respect their branding!

### Linked Issues

N/A

### Additional context

N/A
