### PR TITLE
feat: add aliases for fortran formats

### DIFF
--- a/packages/shiki/src/assets/langs-bundle-full.ts
+++ b/packages/shiki/src/assets/langs-bundle-full.ts
@@ -271,11 +271,23 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
   {
     'id': 'fortran-fixed-form',
     'name': 'Fortran (Fixed Form)',
+    'aliases': [
+      'f',
+      'for',
+      'f77'
+    ],
     'import': (() => import('./langs/fortran-fixed-form')) as DynamicImportLanguageRegistration
   },
   {
     'id': 'fortran-free-form',
     'name': 'Fortran (Free Form)',
+    'aliases': [
+      'f90',
+      'f95',
+      'f03',
+      'f08',
+      'f18'
+    ],
     'import': (() => import('./langs/fortran-free-form')) as DynamicImportLanguageRegistration
   },
   {


### PR DESCRIPTION
### Description

Adds aliases for the two forms of Fortran.

### Linked Issues

N/A

### Additional context

N/A