### PR TITLE
feat: add length and time limit to tokenizer

### DIFF
--- a/packages/core/src/code-to-tokens-base.ts
+++ b/packages/core/src/code-to-tokens-base.ts
@@ -45,6 +45,11 @@ export function tokenizeWithTheme(
     ...options?.colorReplacements,
   }
 
+  const {
+    tokenizeMaxLineLength = 0,
+    tokenizeTimeLimit = 500,
+  } = options
+
   const lines = splitLines(code)
 
   let ruleStack = INITIAL
@@ -59,9 +64,8 @@ export function tokenizeWithTheme(
       continue
     }
 
-    // Do not attempt to tokenize if the line length is longer than the `maxTokenizationLineLength`
-    const maxTokenizationLineLength = options?.maxTokenizationLineLength ?? 0
-    if (maxTokenizationLineLength > 0 && line.length >= maxTokenizationLineLength) {
+    // Do not attempt to tokenize if the line length is longer than the `tokenizationMaxLineLength`
+    if (tokenizeMaxLineLength > 0 && line.length >= tokenizeMaxLineLength) {
       actual = []
       final.push([{
         content: line,
@@ -82,7 +86,7 @@ export function tokenizeWithTheme(
       tokensWithScopesIndex = 0
     }
 
-    const result = grammar.tokenizeLine2(line, ruleStack, 500)
+    const result = grammar.tokenizeLine2(line, ruleStack, tokenizeTimeLimit)
 
     const tokensLength = result.tokens.length / 2
     for (let j = 0; j < tokensLength; j++) {

--- a/packages/core/src/code-to-tokens-base.ts
+++ b/packages/core/src/code-to-tokens-base.ts
@@ -59,6 +59,19 @@ export function tokenizeWithTheme(
       continue
     }
 
+    // Do not attempt to tokenize if a line is too long
+    const maxTokenizationLineLength = 20000
+    if (line.length >= maxTokenizationLineLength) {
+      actual = []
+      final.push([{
+        content: line,
+        offset: lineOffset,
+        color: '',
+        fontStyle: 0,
+      }])
+      continue
+    }
+
     let resultWithScopes
     let tokensWithScopes
     let tokensWithScopesIndex
@@ -69,7 +82,7 @@ export function tokenizeWithTheme(
       tokensWithScopesIndex = 0
     }
 
-    const result = grammar.tokenizeLine2(line, ruleStack)
+    const result = grammar.tokenizeLine2(line, ruleStack, 500)
 
     const tokensLength = result.tokens.length / 2
     for (let j = 0; j < tokensLength; j++) {

--- a/packages/core/src/code-to-tokens-base.ts
+++ b/packages/core/src/code-to-tokens-base.ts
@@ -59,9 +59,9 @@ export function tokenizeWithTheme(
       continue
     }
 
-    // Do not attempt to tokenize if a line is too long
-    const maxTokenizationLineLength = 20000
-    if (line.length >= maxTokenizationLineLength) {
+    // Do not attempt to tokenize if the line length is longer than the `maxTokenizationLineLength`
+    const maxTokenizationLineLength = options?.maxTokenizationLineLength ?? 0
+    if (maxTokenizationLineLength > 0 && line.length >= maxTokenizationLineLength) {
       actual = []
       final.push([{
         content: line,

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -118,7 +118,7 @@ export interface CodeToHastOptionsCommon<Languages extends string = string>
   extends
   TransformerOptions,
   DecorationOptions,
-  Pick<TokenizeWithThemeOptions, 'colorReplacements' | 'maxTokenizationLineLength'> {
+  Pick<TokenizeWithThemeOptions, 'colorReplacements' | 'tokenizeMaxLineLength' | 'tokenizeTimeLimit'> {
 
   lang: StringLiteralUnion<Languages | SpecialLanguage>
 

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -118,7 +118,7 @@ export interface CodeToHastOptionsCommon<Languages extends string = string>
   extends
   TransformerOptions,
   DecorationOptions,
-  Pick<TokenizeWithThemeOptions, 'colorReplacements'> {
+  Pick<TokenizeWithThemeOptions, 'colorReplacements' | 'maxTokenizationLineLength'> {
 
   lang: StringLiteralUnion<Languages | SpecialLanguage>
 

--- a/packages/core/src/types/tokens.ts
+++ b/packages/core/src/types/tokens.ts
@@ -164,7 +164,14 @@ export interface TokenizeWithThemeOptions {
    *
    * @default 0 (no limit)
    */
-  maxTokenizationLineLength?: number
+  tokenizeMaxLineLength?: number
+
+  /**
+   * Time limit in milliseconds for tokenizing a single line.
+   *
+   * @default 500 (0.5s)
+   */
+  tokenizeTimeLimit?: number
 }
 
 /**

--- a/packages/core/src/types/tokens.ts
+++ b/packages/core/src/types/tokens.ts
@@ -158,6 +158,13 @@ export interface TokenizeWithThemeOptions {
    * This will be merged with theme's `colorReplacements` if any.
    */
   colorReplacements?: Record<string, string>
+
+  /**
+   * Lines above this length will not be tokenized for performance reasons.
+   *
+   * @default 0 (no limit)
+   */
+  maxTokenizationLineLength?: number
 }
 
 /**

--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -76,6 +76,15 @@ export function shikiToMonaco(
           const { colorMap } = state.highlighter.setTheme(currentTheme)
           const theme = themeMap.get(currentTheme)
           const result = grammar.tokenizeLine2(line, state.ruleStack, 500)
+          
+          if (result.stoppedEarly) {
+      			console.warn(`Time limit reached when tokenizing line: ${line.substring(0, 100)}`)
+      			// return the state at the beginning of the line
+      			return {
+              endState: state,
+              tokens: result.tokens,
+            }
+      		}
 
           const colorToScopeMap = new Map<string, string>()
 

--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -73,6 +73,7 @@ export function shikiToMonaco(
         },
         tokenize(line, state: TokenizerState) {
           // Do not attempt to tokenize if a line is too long
+          // default to 20000 (as in monaco-editor-core defaults)
           const maxTokenizationLineLength = 20000
           if (line.length >= maxTokenizationLineLength) {
             return {

--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -78,9 +78,9 @@ export function shikiToMonaco(
           const result = grammar.tokenizeLine2(line, state.ruleStack, 500)
           
           if (result.stoppedEarly) {
-      			console.warn(`Time limit reached when tokenizing line: ${line.substring(0, 100)}`)
-      			// return the state at the beginning of the line
-      			return {
+            console.warn(`Time limit reached when tokenizing line: ${line.substring(0, 100)}`)
+            // return the state at the beginning of the line
+            return {
               endState: state,
               tokens: result.tokens,
             }

--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -72,19 +72,22 @@ export function shikiToMonaco(
           return new TokenizerState(INITIAL, highlighter)
         },
         tokenize(line, state: TokenizerState) {
+          // Do not attempt to tokenize if a line is too long
+          const maxTokenizationLineLength = 20000
+          if (line.length >= maxTokenizationLineLength) {
+            return {
+              endState: state,
+              tokens: [{ startIndex: 0, scopes: '' }],
+            }
+          }
+
           const grammar = state.highlighter.getLanguage(lang)
           const { colorMap } = state.highlighter.setTheme(currentTheme)
           const theme = themeMap.get(currentTheme)
           const result = grammar.tokenizeLine2(line, state.ruleStack, 500)
 
-          if (result.stoppedEarly) {
+          if (result.stoppedEarly)
             console.warn(`Time limit reached when tokenizing line: ${line.substring(0, 100)}`)
-            // return the state at the beginning of the line
-            return {
-              endState: state,
-              tokens: result.tokens,
-            }
-          }
 
           const colorToScopeMap = new Map<string, string>()
 

--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -75,7 +75,7 @@ export function shikiToMonaco(
           const grammar = state.highlighter.getLanguage(lang)
           const { colorMap } = state.highlighter.setTheme(currentTheme)
           const theme = themeMap.get(currentTheme)
-          const result = grammar.tokenizeLine2(line, state.ruleStack)
+          const result = grammar.tokenizeLine2(line, state.ruleStack, 500)
 
           const colorToScopeMap = new Map<string, string>()
 

--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -74,8 +74,10 @@ export function shikiToMonaco(
         tokenize(line, state: TokenizerState) {
           // Do not attempt to tokenize if a line is too long
           // default to 20000 (as in monaco-editor-core defaults)
-          const maxTokenizationLineLength = 20000
-          if (line.length >= maxTokenizationLineLength) {
+          const tokenizeMaxLineLength = 20000
+          const tokenizeTimeLimit = 500
+
+          if (line.length >= tokenizeMaxLineLength) {
             return {
               endState: state,
               tokens: [{ startIndex: 0, scopes: '' }],
@@ -85,7 +87,7 @@ export function shikiToMonaco(
           const grammar = state.highlighter.getLanguage(lang)
           const { colorMap } = state.highlighter.setTheme(currentTheme)
           const theme = themeMap.get(currentTheme)
-          const result = grammar.tokenizeLine2(line, state.ruleStack, 500)
+          const result = grammar.tokenizeLine2(line, state.ruleStack, tokenizeTimeLimit)
 
           if (result.stoppedEarly)
             console.warn(`Time limit reached when tokenizing line: ${line.substring(0, 100)}`)

--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -76,7 +76,7 @@ export function shikiToMonaco(
           const { colorMap } = state.highlighter.setTheme(currentTheme)
           const theme = themeMap.get(currentTheme)
           const result = grammar.tokenizeLine2(line, state.ruleStack, 500)
-          
+
           if (result.stoppedEarly) {
             console.warn(`Time limit reached when tokenizing line: ${line.substring(0, 100)}`)
             // return the state at the beginning of the line
@@ -84,7 +84,7 @@ export function shikiToMonaco(
               endState: state,
               tokens: result.tokens,
             }
-      		}
+          }
 
           const colorToScopeMap = new Map<string, string>()
 

--- a/packages/shiki/test/general.test.ts
+++ b/packages/shiki/test/general.test.ts
@@ -191,7 +191,7 @@ describe('should', () => {
     expect(await codeToHtml(`const short = ""\nconst long = ${longText}`, {
       theme: 'vitesse-light',
       lang: 'javascript',
-      maxTokenizationLineLength: 100,
+      tokenizeMaxLineLength: 100,
     })).toMatchInlineSnapshot(`"<pre class="shiki vitesse-light" style="background-color:#ffffff;color:#393a34" tabindex="0"><code><span class="line"><span style="color:#AB5959">const</span><span style="color:#B07D48"> short</span><span style="color:#999999"> =</span><span style="color:#B5695999"> ""</span></span>\n<span class="line"><span>const long = ${longText}</span></span></code></pre>"`)
   })
 })

--- a/packages/shiki/test/general.test.ts
+++ b/packages/shiki/test/general.test.ts
@@ -179,6 +179,15 @@ describe('should', () => {
       }
     }
   })
+
+  it('skip line tokenizing', async () => {
+    const longText = 'foo'.repeat(50)
+    expect(await codeToHtml(`const short = ""\nconst long = ${longText}`, {
+      theme: 'vitesse-light',
+      lang: 'javascript',
+      maxTokenizationLineLength: 100,
+    })).toMatchInlineSnapshot(`"<pre class="shiki vitesse-light" style="background-color:#ffffff;color:#393a34" tabindex="0"><code><span class="line"><span style="color:#AB5959">const</span><span style="color:#B07D48"> short</span><span style="color:#999999"> =</span><span style="color:#B5695999"> ""</span></span>\n<span class="line"><span>const long = ${longText}</span></span></code></pre>"`)
+  })
 })
 
 describe('errors', () => {

--- a/packages/shiki/test/general.test.ts
+++ b/packages/shiki/test/general.test.ts
@@ -182,6 +182,12 @@ describe('should', () => {
 
   it('skip line tokenizing', async () => {
     const longText = 'foo'.repeat(50)
+
+    expect(await codeToHtml(`const long = ${longText}`, {
+      theme: 'vitesse-light',
+      lang: 'javascript',
+    })).toMatchInlineSnapshot(`"<pre class="shiki vitesse-light" style="background-color:#ffffff;color:#393a34" tabindex="0"><code><span class="line"><span style="color:#AB5959">const</span><span style="color:#B07D48"> long</span><span style="color:#999999"> =</span><span style="color:#B07D48"> ${longText}</span></span></code></pre>"`)
+
     expect(await codeToHtml(`const short = ""\nconst long = ${longText}`, {
       theme: 'vitesse-light',
       lang: 'javascript',


### PR DESCRIPTION
 ### Description

Fix the textmate tokenizer freeze/crash the browser if a line is too long:

- Set the `timeLimit` parameter of `tokenizeLine2` to 500ms (align to vscode)
- Do not attempt to tokenize if a line is too long (enable by adding the `maxTokenizationLineLength` opion)

### Linked Issues

_

### Additional context

_Refs_

`timeLimit`:
https://github.com/microsoft/vscode/blob/3ce7ccff4116da34370cecfb329420f266499ec4/src/vs/workbench/services/textMate/browser/tokenizationSupport/textMateTokenizationSupport.ts#L54

Do not attempt:
https://github.com/microsoft/vscode/blob/6722b81416d8f1ee24209ca4a19792b6e6a55beb/src/vs/workbench/services/textMate/browser/tokenizationSupport/tokenizationSupportWithLineLimit.ts#L38

<!-- e.g. is there anything you'd like reviewers to focus on? -->
