### PR TITLE
fix: allow nullish color for colorReplacement, fix ansi highlighting with dark-plus, fix #597

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -147,7 +147,7 @@ export function splitTokens<
 }
 
 export function applyColorReplacements(color: string, replacements?: Record<string, string>): string {
-  return replacements?.[color.toLowerCase()] || color
+  return replacements?.[color?.toLowerCase()] || color
 }
 
 export function getTokenStyleObject(token: TokenStyles) {

--- a/packages/shiki/test/ansi.test.ts
+++ b/packages/shiki/test/ansi.test.ts
@@ -31,3 +31,16 @@ Packages: [0;32m+1038[0m[0m
 
   expect(out).toMatchFileSnapshot('./out/ansi-background.html')
 })
+
+// https://github.com/shikijs/shiki/issues/597
+it('renders ansi to html with theme dark-plus', async () => {
+  const out = await codeToHtml(`[0;30;43m WARN [0m using --force I sure hope you know what you are doing
+Scope: all 6 workspace projects
+Lockfile is up to date, resolution step is skipped
+Packages: [0;32m+952[0m
+[0;32m++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++[0m
+Progress: resolved [0;104m952[0m, reused [0;104m910[0m, downloaded [0;104m42[0m, added [0;104m952[0m, done
+Done in 15.7s`, { theme: 'dark-plus', lang: 'ansi' })
+
+  expect(out).toMatchFileSnapshot('./out/ansi-dark-plus.html')
+})

--- a/packages/shiki/test/out/ansi-dark-plus.html
+++ b/packages/shiki/test/out/ansi-dark-plus.html
@@ -1,0 +1,7 @@
+<pre class="shiki dark-plus" style="background-color:#1E1E1E;color:#D4D4D4" tabindex="0"><code><span class="line"><span> WARN </span><span style="color:#D4D4D4"> using --force I sure hope you know what you are doing</span></span>
+<span class="line"><span style="color:#D4D4D4">Scope: all 6 workspace projects</span></span>
+<span class="line"><span style="color:#D4D4D4">Lockfile is up to date, resolution step is skipped</span></span>
+<span class="line"><span style="color:#D4D4D4">Packages: </span><span>+952</span></span>
+<span class="line"><span>++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++</span></span>
+<span class="line"><span style="color:#D4D4D4">Progress: resolved </span><span style="color:#D4D4D4">952</span><span style="color:#D4D4D4">, reused </span><span style="color:#D4D4D4">910</span><span style="color:#D4D4D4">, downloaded </span><span style="color:#D4D4D4">42</span><span style="color:#D4D4D4">, added </span><span style="color:#D4D4D4">952</span><span style="color:#D4D4D4">, done</span></span>
+<span class="line"><span style="color:#D4D4D4">Done in 15.7s</span></span></code></pre>


### PR DESCRIPTION
### Description

This PR fixes highlighting ansi with other themes than `monokai` (see #597).

### Linked Issues

#597

### Additional context

I've implemented an test for ansi with dark-plus. Which fails when removing the change to `packages/core/src/utils.ts`  Other themes didn't work either, but I didn't test them. Although they should be fine with this fix.
