### PR TITLE
fix: add `jl` alias for Julia

### DIFF
--- a/packages/shiki/src/assets/langs-bundle-full.ts
+++ b/packages/shiki/src/assets/langs-bundle-full.ts
@@ -504,6 +504,9 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
   {
     'id': 'julia',
     'name': 'Julia',
+    'aliases': [
+      'jl',
+    ],
     'import': (() => import('./langs/julia')) as DynamicImportLanguageRegistration
   },
   {
@@ -1197,6 +1200,7 @@ export type BundledLanguage =
   | 'jssm'
   | 'jsx'
   | 'julia'
+  | 'jl'
   | 'kotlin'
   | 'kql'
   | 'kt'

--- a/packages/shiki/src/assets/langs-bundle-web.ts
+++ b/packages/shiki/src/assets/langs-bundle-web.ts
@@ -145,6 +145,9 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
   {
     'id': 'julia',
     'name': 'Julia',
+    'aliases': [
+      'jl',
+    ],
     'import': (() => import('./langs/julia')) as DynamicImportLanguageRegistration
   },
   {
@@ -349,6 +352,7 @@ export type BundledLanguage =
   | 'jsonl'
   | 'jsx'
   | 'julia'
+  | 'jl'
   | 'less'
   | 'lua'
   | 'markdown'


### PR DESCRIPTION


<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Julia files have a `.jl` extension, so it would be a good idea to add a `jl` alias for the language.

This is useful for me because I'm working on a project where I want to highlight dynamically based on the file extension, and I suspect this is hardly uncommon. 

This could be done manually today by consumers of the library with `langAlias` but I think it's reasonable to include the main file extension for Julia. 

### Linked Issues

N/A

### Additional context

No tests are provided because as far as I can tell languages aliases aren't tested. Besides, I think it's a very simple change so it's easy to tell if it's correct or not. 

Thanks!
