### PR TITLE
docs: fix the size of the home demo text area on firefox

### DIFF
--- a/docs/.vitepress/components/ShikiMiniPlayground.vue
+++ b/docs/.vitepress/components/ShikiMiniPlayground.vue
@@ -67,7 +67,7 @@ function onInput() {
       <textarea
         ref="textAreaRef"
         v-model="play.input"
-        whitespace-pre overflow-auto
+        whitespace-pre overflow-auto w-full h-full
         font-mono bg-transparent absolute inset-0 py-20px px-24px
         text-transparent caret-gray tab-4 resize-none z-10
         class="line-height-$vp-code-line-height font-$vp-font-family-mono text-size-$vp-code-font-size"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Currently, the demo on the home page of the docs is not displaying properly on Firefox, because the `textarea` that should allows visitors to edit the displayed code has the wrong dimensions :
<img width="771" alt="image" src="https://github.com/shikijs/shiki/assets/24679993/73d640ac-b3b2-4108-a83f-2b927b60cfa5">

This PR fixes this problem by setting explicitly the width and the height of the textarea to be 100% of its parent, which is the expected size.
<img width="1040" alt="image" src="https://github.com/shikijs/shiki/assets/24679993/31e2d302-e626-4595-88f3-89679ba8836d">

I have checked in Chrome and Safari if this change had any unexpected consequences there, but as far as I can tell it looks exactly the same before and after it.

### Linked Issues

Fixes #613

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
