### PR TITLE
docs: change Chinese translation site link to make China Mainland accessible

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -204,7 +204,7 @@ export default withMermaid(defineConfig({
     },
     zh: {
       label: '简体中文 (Community)',
-      link: 'https://shiki-zh-docs.vercel.app',
+      link: 'https://shiki.tmrs.site',
     },
   },
 


### PR DESCRIPTION
### Description

Because the *.vercel.app domain was blocked by China Mainland firewall policy, I changed the link to another domain, thus enhanced the reading experience for Simplified Chinese users.

Thank you.