### PR TITLE
test: transformer empty line fixtures

### DIFF
--- a/packages/transformers/test/fixtures/focus/empty-line-comment.js
+++ b/packages/transformers/test/fixtures/focus/empty-line-comment.js
@@ -1,0 +1,9 @@
+export function transformerNotationFocus(
+  // [!code focus:5]
+  options = {},
+) {
+  const {
+    classFocused = 'focused',
+    classActivePre = 'has-focused',
+  } = options
+}

--- a/packages/transformers/test/fixtures/focus/empty-line-comment.js.output.html
+++ b/packages/transformers/test/fixtures/focus/empty-line-comment.js.output.html
@@ -1,0 +1,7 @@
+<pre class="shiki github-dark has-focused" style="background-color:#24292e;color:#e1e4e8" tabindex="0"><code><span class="line"><span style="color:#F97583">export</span><span style="color:#F97583"> function</span><span style="color:#B392F0"> transformerNotationFocus</span><span style="color:#E1E4E8">(</span></span><span class="line focused"><span style="color:#FFAB70">  options</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> {},</span></span><span class="line focused"><span style="color:#E1E4E8">) {</span></span><span class="line focused"><span style="color:#F97583">  const</span><span style="color:#E1E4E8"> {</span></span><span class="line focused"><span style="color:#79B8FF">    classFocused</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> 'focused'</span><span style="color:#E1E4E8">,</span></span><span class="line"><span style="color:#79B8FF">    classActivePre</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> 'has-focused'</span><span style="color:#E1E4E8">,</span></span><span class="line"><span style="color:#E1E4E8">  } </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> options</span></span><span class="line"><span style="color:#E1E4E8">}</span></span><span class="line"></span></code></pre>
+<style>
+body { margin: 0; }
+.shiki { padding: 1em; }
+.line { display: block; width: 100%; height: 1.2em; }
+.has-focused .focused { background-color: #8805; }
+</style>

--- a/packages/transformers/test/fixtures/highlight/empty-line-comment.js
+++ b/packages/transformers/test/fixtures/highlight/empty-line-comment.js
@@ -1,0 +1,9 @@
+export function transformerNotationFocus(
+  // [!code highlight:5]
+  options = {},
+) {
+  const {
+    classFocused = 'focused',
+    classActivePre = 'has-focused',
+  } = options
+}

--- a/packages/transformers/test/fixtures/highlight/empty-line-comment.js.output.html
+++ b/packages/transformers/test/fixtures/highlight/empty-line-comment.js.output.html
@@ -1,0 +1,7 @@
+<pre class="shiki github-dark has-highlighted" style="background-color:#24292e;color:#e1e4e8" tabindex="0"><code><span class="line"><span style="color:#F97583">export</span><span style="color:#F97583"> function</span><span style="color:#B392F0"> transformerNotationFocus</span><span style="color:#E1E4E8">(</span></span><span class="line highlighted"><span style="color:#FFAB70">  options</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> {},</span></span><span class="line highlighted"><span style="color:#E1E4E8">) {</span></span><span class="line highlighted"><span style="color:#F97583">  const</span><span style="color:#E1E4E8"> {</span></span><span class="line highlighted"><span style="color:#79B8FF">    classFocused</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> 'focused'</span><span style="color:#E1E4E8">,</span></span><span class="line"><span style="color:#79B8FF">    classActivePre</span><span style="color:#F97583"> =</span><span style="color:#9ECBFF"> 'has-focused'</span><span style="color:#E1E4E8">,</span></span><span class="line"><span style="color:#E1E4E8">  } </span><span style="color:#F97583">=</span><span style="color:#E1E4E8"> options</span></span><span class="line"><span style="color:#E1E4E8">}</span></span><span class="line"></span></code></pre>
+<style>
+body { margin: 0; }
+.shiki { padding: 1em; }
+.line { display: block; width: 100%; height: 1.2em; }
+.highlighted { background-color: #8885; }
+</style>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Shiki's focus and highlight transformers remove the `<span>` entirely if the comment line is otherwise empty.

This PR adds a fixture which tests this behavior.

### Linked Issues

This behavior is discussed in https://github.com/shikijs/shiki/issues/589

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
