### PR TITLE
refactor: cache getLoadedThemes and getLoadedLanguages

### DIFF
--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -55,8 +55,7 @@ export async function getShikiInternal(options: HighlighterCoreOptions = {}): Pr
     langs,
   )
 
-  const _registry = new Registry(resolver, themes, langs)
-  Object.assign(_registry.alias, options.langAlias)
+  const _registry = new Registry(resolver, themes, langs, options.langAlias)
   await _registry.init()
 
   let _lastTheme: string | ThemeRegistrationAny


### PR DESCRIPTION
### Description

This PR caches `getLoadedThemes()` and `getLoadedLanguages()` so they're only re-computed when needed.

`getLoadedThemes()` and `getLoadedLanguages()` are often hot APIs as they're used to check if themes or languages are loaded for lazy-loading additional themes and languages. This means that for every highlight, these functions could be called, and `Object.keys()` + fresh arrays are always constructed, which is taxing.



### Linked Issues

n/a

### Additional context

Examples of hot APIs:

- https://github.com/expressive-code/expressive-code/blob/b6e7167ac4014ab12d60a87c843379a3df87b5cc/packages/%40expressive-code/plugin-shiki/src/index.ts#L71
- https://github.com/expressive-code/expressive-code/blob/b6e7167ac4014ab12d60a87c843379a3df87b5cc/packages/%40expressive-code/plugin-shiki/src/index.ts#L85
- https://github.com/withastro/astro/blob/260f4fa1912ba78299c587a7cad1101354ebbb48/packages/markdown/remark/src/shiki.ts#L57

In my profiling for a 2m30s Rollup build, I find both `getLoadedThemes()` and `getLoadedLanguages()` took around 3s altogether. Not much, but I think it's worth shaving off where possible. After this PR, both took around 0.2s altogether.

---

Initially, I wanted to create both a separate `themeNames`/`languageNames` array where they're long-living, but I find `getLoadedLanguages()` a bit hard to do so as its `_resolvedGrammar` and `alias` can change often, so I opted for caching instead.

---

I also refactored `_themes`, `_langs`, and `_alias` to be private, so it's easier to control when they're mutated and reset the cache accordingly.


