### PR TITLE
refactor: cache setTheme createFromRawTheme

### DIFF
--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1,5 +1,5 @@
-import type { IGrammar, IGrammarConfiguration } from './textmate'
-import { Registry as TextMateRegistry } from './textmate'
+import type { IGrammar, IGrammarConfiguration, IRawTheme } from './textmate'
+import { Registry as TextMateRegistry, Theme as TextMateTheme } from './textmate'
 import type { LanguageRegistration, ThemeRegistrationAny, ThemeRegistrationResolved } from './types'
 import type { Resolver } from './resolver'
 import { normalizeTheme } from './normalize'
@@ -10,6 +10,7 @@ export class Registry extends TextMateRegistry {
   private _resolvedGrammars: Record<string, IGrammar> = {}
   private _langMap: Record<string, LanguageRegistration> = {}
   private _langGraph: Map<string, LanguageRegistration> = new Map()
+  private _textmateThemeCache = new WeakMap<IRawTheme, TextMateTheme>()
 
   alias: Record<string, string> = {}
 
@@ -40,6 +41,22 @@ export class Registry extends TextMateRegistry {
 
   public getLoadedThemes() {
     return Object.keys(this._resolvedThemes) as string[]
+  }
+
+  // Override and re-implement this method to cache the textmate themes as `TextMateTheme.createFromRawTheme`
+  // is expensive. Themes can switch often especially for dual-theme support.
+  //
+  // The parent class also accepts `colorMap` as the second parameter, but since we don't use that,
+  // we omit here so it's easier to cache the themes.
+  public override setTheme(theme: IRawTheme): void {
+    let textmateTheme = this._textmateThemeCache.get(theme)
+    if (!textmateTheme) {
+      textmateTheme = TextMateTheme.createFromRawTheme(theme)
+      this._textmateThemeCache.set(theme, textmateTheme)
+    }
+
+    // @ts-expect-error Access private `_syncRegistry`, but should work in runtime
+    this._syncRegistry.setTheme(textmateTheme)
   }
 
   public getGrammar(name: string) {

--- a/packages/core/src/textmate.ts
+++ b/packages/core/src/textmate.ts
@@ -1,6 +1,7 @@
 // We re-bundled vscode-textmate from source to have ESM support.
 // This file re-exports some runtime values we need.
 export { Registry, INITIAL, StateStack } from '../vendor/vscode-textmate/src/main'
+export { Theme } from '../vendor/vscode-textmate/src/theme'
 export type {
   IRawTheme,
   IRawGrammar,


### PR DESCRIPTION
### Description

This PR caches `createFromRawTheme` within `setTheme` to improve dual-theme support perf.

For dual-theme support, `registry.setTheme` is used to switch to a theme before processing a code. When this switch occurs, `Theme.createFromRawTheme` (from `vscode-textmate`) is used to transform the theme to its format and this function can be expensive when called many times.

Theme switches happen often here (following the stack down):

https://github.com/shikijs/shiki/blob/8653f88639ca50b77d03d73ea8e3ceb59cdd94a5/packages/core/src/code-to-tokens-themes.ts#L21-L26

https://github.com/shikijs/shiki/blob/8653f88639ca50b77d03d73ea8e3ceb59cdd94a5/packages/core/src/code-to-tokens-base.ts#L27

https://github.com/shikijs/shiki/blob/8653f88639ca50b77d03d73ea8e3ceb59cdd94a5/packages/core/src/internal.ts#L80-L83

https://github.com/microsoft/vscode-textmate/blob/09effd8b7429b71010e0fa34ea2e16e622692946/src/main.ts#L72-L77

### Linked Issues

n/a

### Additional context

This also helps for those implementing multi-theme support manually: https://github.com/expressive-code/expressive-code/blob/b6e7167ac4014ab12d60a87c843379a3df87b5cc/packages/%40expressive-code/plugin-shiki/src/index.ts#L81-L96

In my profiling for a 2m30s Rollup build, I find `setTheme()` to take 11.7s. With this PR, it's now 0.018s.