### PR TITLE
fix(transformers): allow SQL comment syntax in notation transformer, fix #654

### DIFF
--- a/packages/transformers/src/transformers/notation-map.ts
+++ b/packages/transformers/src/transformers/notation-map.ts
@@ -24,7 +24,7 @@ export function transformerNotationMap(
 
   return createCommentNotationTransformer(
     name,
-    new RegExp(`\\s*(?://|/\\*|<!--|#)\\s+\\[!code (${Object.keys(classMap).map(escapeRegExp).join('|')})(:\\d+)?\\]\\s*(?:\\*/|-->)?`),
+    new RegExp(`\\s*(?://|/\\*|<!--|#|--)\\s+\\[!code (${Object.keys(classMap).map(escapeRegExp).join('|')})(:\\d+)?\\]\\s*(?:\\*/|-->)?`),
     function ([_, match, range = ':1'], _line, _comment, lines, index) {
       const lineNum = Number.parseInt(range.slice(1), 10)
       lines

--- a/packages/transformers/test/fixtures/highlight/query.sql
+++ b/packages/transformers/test/fixtures/highlight/query.sql
@@ -1,0 +1,5 @@
+CREATE TABLE foo 
+(
+	`id` INT AUTO_INCREMENT NOT NULL, -- [!code highlight]
+	PRIMARY KEY (`id`)
+);

--- a/packages/transformers/test/fixtures/highlight/query.sql.output.html
+++ b/packages/transformers/test/fixtures/highlight/query.sql.output.html
@@ -1,0 +1,7 @@
+<pre class="shiki github-dark has-highlighted" style="background-color:#24292e;color:#e1e4e8" tabindex="0"><code><span class="line"><span style="color:#F97583">CREATE</span><span style="color:#F97583"> TABLE</span><span style="color:#B392F0"> foo</span><span style="color:#E1E4E8"> </span></span><span class="line"><span style="color:#E1E4E8">(</span></span><span class="line highlighted"><span style="color:#9ECBFF">	`id`</span><span style="color:#F97583"> INT</span><span style="color:#E1E4E8"> AUTO_INCREMENT </span><span style="color:#F97583">NOT NULL</span><span style="color:#E1E4E8">, </span></span><span class="line"><span style="color:#F97583">	PRIMARY KEY</span><span style="color:#E1E4E8"> (</span><span style="color:#9ECBFF">`id`</span><span style="color:#E1E4E8">)</span></span><span class="line"><span style="color:#E1E4E8">);</span></span></code></pre>
+<style>
+body { margin: 0; }
+.shiki { padding: 1em; }
+.line { display: block; width: 100%; height: 1.2em; }
+.highlighted { background-color: #8885; }
+</style>


### PR DESCRIPTION
…shikijs/shiki#654)

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

It was not possible to highlight a line in SQL using `-- [!code highlight]`.
I have added SQL comment notation (`--`) to the comment notation transformer.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
https://github.com/shikijs/shiki/issues/654

<!-- e.g. is there anything you'd like reviewers to focus on? -->
