### PR TITLE
fix(core): simplify cloudflare wasm loading

### DIFF
--- a/packages/core/src/oniguruma/index.ts
+++ b/packages/core/src/oniguruma/index.ts
@@ -426,6 +426,14 @@ export function loadWasm(options: LoadWasmOptions): Promise<void> {
         else if (isArrayBuffer(instance)) {
           instance = await _makeArrayBufferLoader(instance)(info)
         }
+        // cloudflare's import("xxx.wasm") returns `{ default: WebAssembly.Module }`
+        // https://developers.cloudflare.com/workers/wrangler/bundling/
+        else if (instance instanceof WebAssembly.Module) {
+          instance = await _makeArrayBufferLoader(instance)(info)
+        }
+        else if ('default' in instance && instance.default instanceof WebAssembly.Module) {
+          instance = await _makeArrayBufferLoader(instance.default)(info)
+        }
       }
 
       if ('instance' in instance)
@@ -440,7 +448,7 @@ export function loadWasm(options: LoadWasmOptions): Promise<void> {
   return initPromise
 }
 
-function _makeArrayBufferLoader(data: ArrayBufferView | ArrayBuffer): WebAssemblyInstantiator {
+function _makeArrayBufferLoader(data: ArrayBufferView | ArrayBuffer | WebAssembly.Module): WebAssemblyInstantiator {
   return importObject => WebAssembly.instantiate(data, importObject)
 }
 function _makeResponseStreamingLoader(data: Response): WebAssemblyInstantiator {

--- a/packages/core/src/oniguruma/index.ts
+++ b/packages/core/src/oniguruma/index.ts
@@ -426,7 +426,7 @@ export function loadWasm(options: LoadWasmOptions): Promise<void> {
         else if (isArrayBuffer(instance)) {
           instance = await _makeArrayBufferLoader(instance)(info)
         }
-        // cloudflare's import("xxx.wasm") returns `{ default: WebAssembly.Module }`
+        // import("shiki/onig.wasm") returns `{ default: WebAssembly.Module }` on cloudflare workers
         // https://developers.cloudflare.com/workers/wrangler/bundling/
         else if (instance instanceof WebAssembly.Module) {
           instance = await _makeArrayBufferLoader(instance)(info)

--- a/packages/shiki/test/cf.ts
+++ b/packages/shiki/test/cf.ts
@@ -8,7 +8,10 @@ import js from 'shiki/langs/javascript.mjs'
 // eslint-disable-next-line antfu/no-import-dist
 import wasm from '../dist/onig.wasm'
 
-await loadWasm(obj => WebAssembly.instantiate(wasm, obj))
+await loadWasm(wasm)
+
+// cloudflare also supports dynamic import
+// await loadWasm(import('../dist/onig.wasm'))
 
 export default {
   async fetch() {

--- a/packages/shiki/test/wasm5.test.ts
+++ b/packages/shiki/test/wasm5.test.ts
@@ -1,0 +1,19 @@
+import { expect, it } from 'vitest'
+import { getHighlighterCore } from '../src/core'
+
+import js from '../src/assets/langs/javascript'
+import nord from '../src/assets/themes/nord'
+
+// eslint-disable-next-line antfu/no-import-dist
+import { wasmBinary } from '../../core/dist/wasm-inlined.mjs'
+
+it('loadWasm: WebAssembly.Module', async () => {
+  const shiki = await getHighlighterCore({
+    themes: [nord],
+    langs: [js as any],
+    loadWasm: WebAssembly.compile(wasmBinary) as any,
+  })
+
+  expect(shiki.codeToHtml('1 + 1', { lang: 'javascript', theme: 'nord' }))
+    .toMatchInlineSnapshot(`"<pre class="shiki nord" style="background-color:#2e3440ff;color:#d8dee9ff" tabindex="0"><code><span class="line"><span style="color:#B48EAD">1</span><span style="color:#81A1C1"> +</span><span style="color:#B48EAD"> 1</span></span></code></pre>"`)
+})

--- a/packages/shiki/test/wasm6.test.ts
+++ b/packages/shiki/test/wasm6.test.ts
@@ -1,0 +1,19 @@
+import { expect, it } from 'vitest'
+import { getHighlighterCore } from '../src/core'
+
+import js from '../src/assets/langs/javascript'
+import nord from '../src/assets/themes/nord'
+
+// eslint-disable-next-line antfu/no-import-dist
+import { wasmBinary } from '../../core/dist/wasm-inlined.mjs'
+
+it('loadWasm: { default: WebAssembly.Module }', async () => {
+  const shiki = await getHighlighterCore({
+    themes: [nord],
+    langs: [js as any],
+    loadWasm: Promise.resolve({ default: await WebAssembly.compile(wasmBinary) }) as any,
+  })
+
+  expect(shiki.codeToHtml('1 + 1', { lang: 'javascript', theme: 'nord' }))
+    .toMatchInlineSnapshot(`"<pre class="shiki nord" style="background-color:#2e3440ff;color:#d8dee9ff" tabindex="0"><code><span class="line"><span style="color:#B48EAD">1</span><span style="color:#81A1C1"> +</span><span style="color:#B48EAD"> 1</span></span></code></pre>"`)
+})


### PR DESCRIPTION


### Description

- Closes https://github.com/shikijs/shiki/issues/604

It looks like the exact usage of `loadWasm(import('shiki/onig.wasm'))`  shown in the documentation doesn't work currently https://shiki.style/guide/install#cloudflare-workers.

There is actually a different way to load wasm directly `WebAssembly.instantiate` as demonstrated in `packages/shiki/test/cf.ts` and it works. However, this usage seems a little more convoluted, so I'm suggesting to improve `loadWasm` utility to support `loadWasm(import('shiki/onig.wasm')` usage like in the documentation. 

https://github.com/shikijs/shiki/blob/044181dfd536f693dc0b7309db60837834182f89/packages/shiki/test/cf.ts#L11

I tested locally with `pnpm -C packages/shiki test:cf`, but It looks like this is not checked on CI.
Please let me know if it's desired to have some integration test for cloudflare usage.

### Linked Issues

https://github.com/shikijs/shiki/issues/604

### Additional context

I was experimenting with shiki on Vite SSR demo https://github.com/hi-ogawa/reproductions/tree/main/shiki-604-cloudflare and currently my `loadWasm` looks like a following since I need to switch to `import("shiki/onig.wasm")` only on cloudflare build:

```ts
	await loadWasm(async (info) => {
		if (import.meta.env.VITE_BUILD_CF) {
			const mod = await import("shiki/onig.wasm" as string);
			return WebAssembly.instantiate(mod.default, info);
		} else {
			return import("shiki/wasm");
		}
	});
```

With this PR's patch, I would be able to always write `await loadWasm(import("shiki/wasm"))` then setup `alias` or custom resolution to switch to `"shiki/onig.wasm` https://github.com/hi-ogawa/reproductions/pull/7.
