### PR TITLE
Add CSS variables for markup diff tokens

### DIFF
--- a/packages/shiki/src/theme-css-variables.ts
+++ b/packages/shiki/src/theme-css-variables.ts
@@ -231,6 +231,36 @@ export function createCssVariablesTheme(options: CssVariablesThemeOptions = {}):
           foreground: variable('token-keyword'),
         },
       },
+      {
+        // [Custom] Diff
+        scope: [
+          'markup.inserted',
+          'meta.diff.header.to-file',
+          'punctuation.definition.inserted',
+        ],
+        settings: {
+          foreground: variable('token-inserted'),
+        },
+      },
+      {
+        scope: [
+          'markup.deleted',
+          'meta.diff.header.from-file',
+          'punctuation.definition.deleted',
+        ],
+        settings: {
+          foreground: variable('token-deleted'),
+        },
+      },
+      {
+        scope: [
+          'markup.changed',
+          'punctuation.definition.changed',
+        ],
+        settings: {
+          foreground: variable('token-changed'),
+        },
+      },
     ],
   }
 


### PR DESCRIPTION
This PR fixes #697. The CSS variables theme had no definition for these tokens.

### Description

This PR introduces a set of new CSS variables:
- `--shiki-token-inserted`
- `--shiki-token-deleted`
- `--shiki-token-changed`

### Linked Issues

#697

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
