### PR TITLE
fix(rehype): fix type issues

### DIFF
--- a/packages/rehype/src/core.ts
+++ b/packages/rehype/src/core.ts
@@ -58,15 +58,6 @@ export type RehypeShikiCoreOptions =
   & CodeOptionsMeta
   & RehypeShikiExtraOptions
 
-declare module 'hast' {
-  interface Data {
-    meta?: string
-  }
-  interface Properties {
-    metastring?: string
-  }
-}
-
 const languagePrefix = 'language-'
 
 function rehypeShikiFromHighlighter(
@@ -123,7 +114,7 @@ function rehypeShikiFromHighlighter(
         return
       }
 
-      const metaString = head.data?.meta ?? head.properties.metastring ?? ''
+      const metaString = head.data?.meta ?? head.properties.metastring?.toString() ?? ''
       const meta = parseMetaString?.(metaString, node, tree) || {}
 
       const codeOptions: CodeToHastOptions = {

--- a/packages/rehype/src/index.ts
+++ b/packages/rehype/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference types="mdast-util-to-hast" />
 import type { LanguageInput } from 'shiki/core'
 import type { BuiltinLanguage, BuiltinTheme } from 'shiki'
 import { bundledLanguages, getHighlighter } from 'shiki'


### PR DESCRIPTION
### Description

The augmented hast `Data` interface conflicts with `ElementData` from `mdast-util-to-hast`. The augmentation is redundant, so it’s removed entirely.

The augmented hast `Properties` interface was redundant and invalid. Instead, the value is now converted to string in the place it is used.

### Linked Issues

https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69775

### Additional context

You should only augment interfaces if you define something, not if you consume it.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
