### PR TITLE
feat: introduce `GrammarState`

### DIFF
--- a/packages/core/src/grammar-state.ts
+++ b/packages/core/src/grammar-state.ts
@@ -1,0 +1,54 @@
+import type { StateStackImpl } from '../vendor/vscode-textmate/src/grammar'
+import { ShikiError } from './error'
+import type { StateStack } from './textmate'
+
+/**
+ * GrammarState is a special reference object that holds the state of a grammar.
+ *
+ * It's used to highlight code snippets that are part of the target language.
+ */
+export class GrammarState {
+  constructor(
+    private _stack: StateStack,
+    public lang: string,
+    public theme: string,
+  ) {}
+
+  get scopes() {
+    return getScopes(this._stack as StateStackImpl)
+  }
+
+  toJSON() {
+    return {
+      lang: this.lang,
+      theme: this.theme,
+      scopes: this.scopes,
+    }
+  }
+}
+
+function getScopes(stack: StateStackImpl) {
+  const scopes: string[] = []
+  const visited = new Set<StateStackImpl>()
+
+  function pushScope(stack: StateStackImpl) {
+    if (visited.has(stack))
+      return
+    visited.add(stack)
+    const name = stack?.nameScopesList?.scopeName
+    if (name)
+      scopes.push(name)
+    if (stack.parent)
+      pushScope(stack.parent)
+  }
+
+  pushScope(stack)
+  return scopes
+}
+
+export function getGrammarStack(state: GrammarState) {
+  if (!(state instanceof GrammarState))
+    throw new ShikiError('Invalid grammar state')
+  // @ts-expect-error _stack is private
+  return state._stack
+}

--- a/packages/core/src/highlighter.ts
+++ b/packages/core/src/highlighter.ts
@@ -1,7 +1,7 @@
 import { codeToHast } from './code-to-hast'
 import { codeToHtml } from './code-to-html'
 import { codeToTokens } from './code-to-tokens'
-import { codeToTokensBase } from './code-to-tokens-base'
+import { codeToTokensBase, getLastGrammarState } from './code-to-tokens-base'
 import { codeToTokensWithThemes } from './code-to-tokens-themes'
 import { createShikiInternal } from './internal'
 import type { HighlighterCore, HighlighterCoreOptions } from './types'
@@ -16,6 +16,7 @@ export async function createHighlighterCore(options: HighlighterCoreOptions = {}
   const internal = await createShikiInternal(options)
 
   return {
+    getLastGrammarState: (code, options) => getLastGrammarState(internal, code, options),
     codeToTokensBase: (code, options) => codeToTokensBase(internal, code, options),
     codeToTokensWithThemes: (code, options) => codeToTokensWithThemes(internal, code, options),
     codeToTokens: (code, options) => codeToTokens(internal, code, options),

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1,13 +1,13 @@
-import type { IGrammar, IGrammarConfiguration, IRawTheme } from './textmate'
+import type { IGrammarConfiguration, IRawTheme } from './textmate'
 import { Registry as TextMateRegistry, Theme as TextMateTheme } from './textmate'
-import type { LanguageRegistration, ThemeRegistrationAny, ThemeRegistrationResolved } from './types'
+import type { Grammar, LanguageRegistration, ThemeRegistrationAny, ThemeRegistrationResolved } from './types'
 import type { Resolver } from './resolver'
 import { normalizeTheme } from './normalize'
 import { ShikiError } from './error'
 
 export class Registry extends TextMateRegistry {
   private _resolvedThemes: Map<string, ThemeRegistrationResolved> = new Map()
-  private _resolvedGrammars: Map<string, IGrammar> = new Map()
+  private _resolvedGrammars: Map<string, Grammar> = new Map()
   private _langMap: Map<string, LanguageRegistration> = new Map()
   private _langGraph: Map<string, LanguageRegistration> = new Map()
 
@@ -97,8 +97,9 @@ export class Registry extends TextMateRegistry {
 
     // @ts-expect-error Private members, set this to override the previous grammar (that can be a stub)
     this._syncRegistry._rawGrammars.set(lang.scopeName, lang)
-    const g = await this.loadGrammarWithConfiguration(lang.scopeName, 1, grammarConfig)
-    this._resolvedGrammars.set(lang.name, g!)
+    const g = await this.loadGrammarWithConfiguration(lang.scopeName, 1, grammarConfig) as Grammar
+    g.name = lang.name
+    this._resolvedGrammars.set(lang.name, g)
     if (lang.aliases) {
       lang.aliases.forEach((alias) => {
         this._alias[alias] = lang.name

--- a/packages/core/src/types/highlighter.ts
+++ b/packages/core/src/types/highlighter.ts
@@ -109,7 +109,7 @@ export interface HighlighterGeneric<BundledLangKeys extends string, BundledTheme
    * You can pass the grammar state to `codeToTokens` as `grammarState` to continue tokenizing from an intermediate state.
    */
   getLastGrammarState: (
-    langId: string,
+    code: string,
     options: CodeToTokensBaseOptions<ResolveBundleKey<BundledLangKeys>, ResolveBundleKey<BundledThemeKeys>>
   ) => GrammarState
 

--- a/packages/core/src/types/highlighter.ts
+++ b/packages/core/src/types/highlighter.ts
@@ -2,7 +2,7 @@ import type { Root } from 'hast'
 import type { Grammar } from './textmate'
 import type { LanguageInput, LanguageRegistration, ResolveBundleKey, SpecialLanguage } from './langs'
 import type { SpecialTheme, ThemeInput, ThemeRegistrationAny, ThemeRegistrationResolved } from './themes'
-import type { CodeToTokensBaseOptions, CodeToTokensOptions, CodeToTokensWithThemesOptions, ThemedToken, ThemedTokenWithVariants, TokensResult } from './tokens'
+import type { CodeToTokensBaseOptions, CodeToTokensOptions, CodeToTokensWithThemesOptions, GrammarState, ThemedToken, ThemedTokenWithVariants, TokensResult } from './tokens'
 import type { CodeToHastOptions } from './options'
 
 /**
@@ -104,6 +104,14 @@ export interface HighlighterGeneric<BundledLangKeys extends string, BundledTheme
     code: string,
     options: CodeToTokensWithThemesOptions<ResolveBundleKey<BundledLangKeys>, ResolveBundleKey<BundledThemeKeys>>
   ) => ThemedTokenWithVariants[][]
+  /**
+   * Get the last grammar state of a code snippet.
+   * You can pass the grammar state to `codeToTokens` as `grammarState` to continue tokenizing from an intermediate state.
+   */
+  getLastGrammarState: (
+    langId: string,
+    options: CodeToTokensBaseOptions<ResolveBundleKey<BundledLangKeys>, ResolveBundleKey<BundledThemeKeys>>
+  ) => GrammarState
 
   /**
    * Get internal context object

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -123,7 +123,7 @@ export interface CodeToHastOptionsCommon<Languages extends string = string>
   extends
   TransformerOptions,
   DecorationOptions,
-  Pick<TokenizeWithThemeOptions, 'colorReplacements' | 'tokenizeMaxLineLength' | 'tokenizeTimeLimit'> {
+  Pick<TokenizeWithThemeOptions, 'colorReplacements' | 'tokenizeMaxLineLength' | 'tokenizeTimeLimit' | 'grammarState' | 'grammarContextCode'> {
 
   lang: StringLiteralUnion<Languages | SpecialLanguage>
 

--- a/packages/core/src/types/textmate.ts
+++ b/packages/core/src/types/textmate.ts
@@ -1,13 +1,16 @@
 import type {
-  IGrammar as Grammar,
+  IGrammar,
   IRawGrammar as RawGrammar,
   IRawTheme as RawTheme,
   IRawThemeSetting as RawThemeSetting,
 } from '../textmate'
 
 export type {
-  Grammar,
   RawGrammar,
   RawTheme,
   RawThemeSetting,
+}
+
+export interface Grammar extends IGrammar {
+  name: string
 }

--- a/packages/core/src/types/tokens.ts
+++ b/packages/core/src/types/tokens.ts
@@ -1,6 +1,9 @@
+import type { GrammarState } from '../grammar-state'
 import type { SpecialLanguage } from './langs'
 import type { SpecialTheme, ThemeRegistrationAny } from './themes'
 import type { CodeOptionsThemes } from './options'
+
+export type { GrammarState }
 
 export interface CodeToTokensBaseOptions<Languages extends string = string, Themes extends string = string> extends TokenizeWithThemeOptions {
   lang?: Languages | SpecialLanguage
@@ -172,6 +175,21 @@ export interface TokenizeWithThemeOptions {
    * @default 500 (0.5s)
    */
   tokenizeTimeLimit?: number
+
+  /**
+   * Represent the state of the grammar, allowing to continue tokenizing from a intermediate grammar state.
+   *
+   * You can get the grammar state from `getLastGrammarState`.
+   */
+  grammarState?: GrammarState
+
+  /**
+   * The code context of the grammar.
+   * Consider it a prepended code to the input code, that only participate the grammar inference but not presented in the final output.
+   *
+   * This will be ignored if `grammarState` is provided.
+   */
+  grammarContextCode?: string
 }
 
 /**

--- a/packages/shiki/test/grammar-state.test.ts
+++ b/packages/shiki/test/grammar-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { codeToHtml, createHighlighter } from '../src'
+import { createHighlighter } from '../src'
 
 it('getLastGrammarState', async () => {
   const shiki = await createHighlighter({
@@ -228,5 +228,21 @@ describe('errors', () => {
       theme: 'vitesse-light',
       grammarState: state,
     })
+  })
+
+  it('should throw on wrong themes', async () => {
+    const shiki = await createHighlighter({
+      themes: ['vitesse-light', 'vitesse-dark'],
+      langs: ['typescript', 'javascript'],
+    })
+
+    const state = shiki.getLastGrammarState('let a:', { lang: 'typescript', theme: 'vitesse-light' })
+
+    expect(() => shiki.codeToTokens('string', {
+      lang: 'ts',
+      theme: 'vitesse-dark',
+      grammarState: state,
+    }))
+      .toThrowErrorMatchingInlineSnapshot(`[ShikiError: Grammar state theme "vitesse-light" does not match highlight theme "vitesse-dark"]`)
   })
 })

--- a/packages/shiki/test/grammar-state.test.ts
+++ b/packages/shiki/test/grammar-state.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest'
+import { codeToHtml, createHighlighter } from '../src'
+
+it('getLastGrammarState', async () => {
+  const shiki = await createHighlighter({
+    themes: ['vitesse-light'],
+    langs: ['typescript'],
+  })
+
+  const state = shiki.getLastGrammarState('let a:', { lang: 'typescript', theme: 'vitesse-light' })
+
+  expect.soft(state).toMatchInlineSnapshot(`
+    {
+      "lang": "typescript",
+      "scopes": [
+        "meta.type.annotation.ts",
+        "meta.var-single-variable.expr.ts",
+        "meta.var.expr.ts",
+        "source.ts",
+      ],
+      "theme": "vitesse-light",
+    }
+  `)
+
+  const input = 'Omit<{}, string | number>'
+
+  const highlightedNatural = shiki.codeToTokens(input, {
+    lang: 'typescript',
+    theme: 'vitesse-light',
+  })
+
+  const highlightedContext = shiki.codeToTokens(input, {
+    lang: 'typescript',
+    theme: 'vitesse-light',
+    grammarState: state,
+  })
+
+  const highlightedContext2 = shiki.codeToTokens(input, {
+    lang: 'typescript',
+    theme: 'vitesse-light',
+    grammarState: state,
+  })
+
+  expect.soft(highlightedNatural)
+    .not.toEqual(highlightedContext)
+
+  expect.soft(highlightedContext)
+    .toEqual(highlightedContext2)
+
+  expect.soft(highlightedNatural)
+    .toMatchInlineSnapshot(`
+      {
+        "bg": "#ffffff",
+        "fg": "#393a34",
+        "rootStyle": undefined,
+        "themeName": "vitesse-light",
+        "tokens": [
+          [
+            {
+              "color": "#B07D48",
+              "content": "Omit",
+              "fontStyle": 0,
+              "offset": 0,
+            },
+            {
+              "color": "#999999",
+              "content": "<{},",
+              "fontStyle": 0,
+              "offset": 4,
+            },
+            {
+              "color": "#393A34",
+              "content": " ",
+              "fontStyle": 0,
+              "offset": 8,
+            },
+            {
+              "color": "#B07D48",
+              "content": "string",
+              "fontStyle": 0,
+              "offset": 9,
+            },
+            {
+              "color": "#393A34",
+              "content": " ",
+              "fontStyle": 0,
+              "offset": 15,
+            },
+            {
+              "color": "#AB5959",
+              "content": "|",
+              "fontStyle": 0,
+              "offset": 16,
+            },
+            {
+              "color": "#393A34",
+              "content": " ",
+              "fontStyle": 0,
+              "offset": 17,
+            },
+            {
+              "color": "#B07D48",
+              "content": "number",
+              "fontStyle": 0,
+              "offset": 18,
+            },
+            {
+              "color": "#999999",
+              "content": ">",
+              "fontStyle": 0,
+              "offset": 24,
+            },
+          ],
+        ],
+      }
+    `)
+
+  expect.soft(highlightedContext)
+    .toMatchInlineSnapshot(`
+      {
+        "bg": "#ffffff",
+        "fg": "#393a34",
+        "rootStyle": undefined,
+        "themeName": "vitesse-light",
+        "tokens": [
+          [
+            {
+              "color": "#2E8F82",
+              "content": "Omit",
+              "fontStyle": 0,
+              "offset": 0,
+            },
+            {
+              "color": "#999999",
+              "content": "<{}, ",
+              "fontStyle": 0,
+              "offset": 4,
+            },
+            {
+              "color": "#2E8F82",
+              "content": "string",
+              "fontStyle": 0,
+              "offset": 9,
+            },
+            {
+              "color": "#999999",
+              "content": " | ",
+              "fontStyle": 0,
+              "offset": 15,
+            },
+            {
+              "color": "#2E8F82",
+              "content": "number",
+              "fontStyle": 0,
+              "offset": 18,
+            },
+            {
+              "color": "#999999",
+              "content": ">",
+              "fontStyle": 0,
+              "offset": 24,
+            },
+          ],
+        ],
+      }
+    `)
+})
+
+it('grammarContextCode', async () => {
+  const shiki = await createHighlighter({
+    themes: ['vitesse-light'],
+    langs: ['typescript', 'vue', 'html'],
+  })
+
+  const input = '<div :value="1 + 2"><button /></div>'
+
+  const highlightedHtml = shiki.codeToHtml(input, {
+    lang: 'html',
+    theme: 'vitesse-light',
+    structure: 'inline',
+  })
+
+  const highlightedVueTemplate = shiki.codeToHtml(input, {
+    lang: 'vue',
+    theme: 'vitesse-light',
+    structure: 'inline',
+    grammarContextCode: '<template>',
+  })
+
+  const highlightedVueBare = shiki.codeToHtml(input, {
+    lang: 'vue',
+    theme: 'vitesse-light',
+    structure: 'inline',
+  })
+
+  expect(highlightedHtml)
+    .toMatchInlineSnapshot(`"<span style="color:#999999">&#x3C;</span><span style="color:#1E754F">div</span><span style="color:#B07D48"> :value</span><span style="color:#999999">=</span><span style="color:#B5695999">"</span><span style="color:#B56959">1 + 2</span><span style="color:#B5695999">"</span><span style="color:#999999">>&#x3C;</span><span style="color:#1E754F">button</span><span style="color:#999999;font-style:italic"> /</span><span style="color:#999999">>&#x3C;/</span><span style="color:#1E754F">div</span><span style="color:#999999">></span>"`)
+
+  expect(highlightedVueTemplate)
+    .toMatchInlineSnapshot(`"<span style="color:#999999">&#x3C;</span><span style="color:#1E754F">div</span><span style="color:#999999"> :</span><span style="color:#59873A">value</span><span style="color:#999999">=</span><span style="color:#B5695999">"</span><span style="color:#2F798A">1</span><span style="color:#AB5959"> +</span><span style="color:#2F798A"> 2</span><span style="color:#B5695999">"</span><span style="color:#999999">>&#x3C;</span><span style="color:#1E754F">button</span><span style="color:#999999;font-style:italic"> /</span><span style="color:#999999">>&#x3C;/</span><span style="color:#1E754F">div</span><span style="color:#999999">></span>"`)
+
+  expect(highlightedVueBare)
+    .toMatchInlineSnapshot(`"<span style="color:#999999">&#x3C;</span><span style="color:#1E754F">div</span><span style="color:#999999"> :</span><span style="color:#59873A">value</span><span style="color:#999999">=</span><span style="color:#B5695999">"</span><span style="color:#2F798A">1</span><span style="color:#AB5959"> +</span><span style="color:#2F798A"> 2</span><span style="color:#B5695999">"</span><span style="color:#999999">></span><span style="color:#393A34">&#x3C;button /></span><span style="color:#999999">&#x3C;/</span><span style="color:#1E754F">div</span><span style="color:#999999">></span>"`)
+
+  expect(highlightedVueTemplate)
+    .not.toEqual(highlightedVueBare)
+})
+
+describe('errors', () => {
+  it('should throw on wrong language', async () => {
+    const shiki = await createHighlighter({
+      themes: ['vitesse-light'],
+      langs: ['typescript', 'javascript'],
+    })
+
+    const state = shiki.getLastGrammarState('let a:', { lang: 'typescript', theme: 'vitesse-light' })
+
+    expect(() => shiki.codeToTokens('string', {
+      lang: 'js',
+      theme: 'vitesse-light',
+      grammarState: state,
+    }))
+      .toThrowErrorMatchingInlineSnapshot(`[ShikiError: Grammar state language "typescript" does not match highlight language "javascript"]`)
+
+    // Alias "ts" should not throw
+    shiki.codeToTokens('string', {
+      lang: 'ts',
+      theme: 'vitesse-light',
+      grammarState: state,
+    })
+  })
+})


### PR DESCRIPTION
### Motivations 

Sometimes, we might want to highlight a partial of the code snippet, which might not necessarily be a full language statement. 

For example, if we want to highlight a TypeScript type annotation `Pick<MyObject, string>[]` we might do:

```ts
import { codeToHtml } from 'shiki'

const highlighted = await codeToHtml('Pick<MyObject, string>[]', { lang: 'ts', theme: 'github-dark' })
```


We will get the result like this:

<img width="266" alt="image" src="https://github.com/shikijs/shiki/assets/11247099/0d086384-28ec-45fa-8b78-21b0411fd5a5">

This isn't accurate. This is because from the grammar, Shiki doesn't know it's a type annotation already.

Instead, we could append `let a: ` to our code to hint that:

```ts
import { codeToHtml } from 'shiki'

const highlighted = await codeToHtml('let a: Pick<MyObject, string>[]', { lang: 'ts', theme: 'github-dark' })
```

Which will now render:

<img width="295" alt="Screenshot 2024-06-27 at 18 25 47" src="https://github.com/shikijs/shiki/assets/11247099/f16aed94-5813-4e85-858a-99f7653d7a7d">

While the highlighting is now correct, we have another challenge: removing the "temporary snippet" we just added from the highlighted HTML.

### Solutions

This PR introduces a new concept, `GrammarState`, with a few APIs around it. `GrammarState` is a special token that holds the grammar context and allows you to highlight from an intermediate grammar state, making it easier to highlight code snippets.

For example, you can get the grammar state with the `getLastGrammarState` method, and pass into the `grammarState` option:

```ts
import { createHighlighter } from 'shiki'

const shiki = await createHighlighter({ langs: ['ts'], themes: ['github-dark'] })

const stateTypeAnnotation = shiki.getLastGrammarState('let a:', { lang: 'ts', theme: 'github-dark' })

const highlightedType = shiki.codeToHtml(
  'Pick<MyObject, string>[]',
  {
     lang: 'ts', 
     theme: 'github-dark',
     grammarState: stateTypeAnnotation // <--- this
  }
)
```

Now Shiki would highlight correctly as it knows to start as the type annotation. You can keep that grammar state object for multiple uses as well.

<img width="223" alt="image" src="https://github.com/shikijs/shiki/assets/11247099/c896c2ae-2a88-428b-9d06-2d2552eaae8b">

---

For one-off grammar context shifting, we also provide a shorthand by the `grammarContextCode` option:

```ts
const highlightedType = shiki.codeToHtml(
  'Pick<MyObject, string>[]',
  {
     lang: 'ts', 
     theme: 'github-dark',
     grammarContextCode: 'let a:' // same as above, a temporary grammar state is created internally
  }
)
```

### Credits

Thanks to @benjamincanac for the idea and discussions