### PR TITLE
fix: codeToTokens's includeExplanation option

### DIFF
--- a/packages/core/src/code-to-tokens-themes.ts
+++ b/packages/core/src/code-to-tokens-themes.ts
@@ -34,6 +34,10 @@ export function codeToTokensWithThemes(
           offset: _token.offset,
         }
 
+        if ('includeExplanation' in options) {
+          mergedToken.explanation = _token.explanation
+        }
+
         tokens.forEach((t, themeIdx) => {
           const {
             content: _,

--- a/packages/core/src/code-to-tokens-themes.ts
+++ b/packages/core/src/code-to-tokens-themes.ts
@@ -34,7 +34,7 @@ export function codeToTokensWithThemes(
           offset: _token.offset,
         }
 
-        if ('includeExplanation' in options) {
+        if ('includeExplanation' in options && options.includeExplanation) {
           mergedToken.explanation = _token.explanation
         }
 


### PR DESCRIPTION
## Description

The options's `includeExplanation` field in `codeToTokens` doesn't work!
