### PR TITLE
fix(rehype): add the misssing `CodeToHastOptionsCommon` to `RehypeShikiCoreOptions` for `rehype` plugin

### DIFF
--- a/docs/packages/rehype.md
+++ b/docs/packages/rehype.md
@@ -10,6 +10,8 @@ outline: deep
 
 ## Install
 
+Install via npm, or see [CDN](https://esm.sh/@shikijs/rehype@1.11.1).
+
 ```bash
 npm i -D @shikijs/rehype
 ```

--- a/docs/packages/rehype.md
+++ b/docs/packages/rehype.md
@@ -10,8 +10,6 @@ outline: deep
 
 ## Install
 
-Install via npm, or see [CDN](https://esm.sh/@shikijs/rehype@1.11.1).
-
 ```bash
 npm i -D @shikijs/rehype
 ```

--- a/packages/rehype/src/core.ts
+++ b/packages/rehype/src/core.ts
@@ -1,4 +1,4 @@
-import type { CodeOptionsMeta, CodeOptionsThemes, CodeToHastOptions, HighlighterGeneric, TransformerOptions } from 'shiki/core'
+import type { CodeOptionsMeta, CodeOptionsThemes, CodeToHastOptions, CodeToHastOptionsCommon, HighlighterGeneric, TransformerOptions } from 'shiki/core'
 import type { Element, Root } from 'hast'
 import type { BuiltinTheme } from 'shiki'
 import type { Transformer } from 'unified'
@@ -57,6 +57,7 @@ export type RehypeShikiCoreOptions =
   & TransformerOptions
   & CodeOptionsMeta
   & RehypeShikiExtraOptions
+  & Omit<CodeToHastOptionsCommon, 'lang'>
 
 const languagePrefix = 'language-'
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

See: #724 and #723

Uable to prompt properties in the `CodeToHastOptionsCommon` type when I use `RehypeShikiOptions` options.

As mentioned in PR #724, it conforms to the `CodeToHastOptions` type, we should add it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
