### PR TITLE
feat(twoslash): support `@includes`

### DIFF
--- a/packages/twoslash/src/core.ts
+++ b/packages/twoslash/src/core.ts
@@ -9,7 +9,7 @@ import type { Element, ElementContent, Text } from 'hast'
 import { splitTokens } from '@shikijs/core'
 import type { TransformerTwoslashOptions, TwoslashRenderer, TwoslashShikiFunction, TwoslashShikiReturn } from './types'
 import { ShikiTwoslashError } from './error'
-import { addIncludes, parseIncludeMeta, replaceIncludesInCode } from './includes'
+import { TwoslashIncludesManager, parseIncludeMeta } from './includes'
 
 export * from './types'
 export * from './renderer-rich'
@@ -73,7 +73,7 @@ export function createTransformerFactory(
      *
      * @TODO: where/when to initialize includes?
      */
-    const includes = new Map<string, string>()
+    const includes = new TwoslashIncludesManager()
 
     return {
       preprocess(code) {
@@ -86,9 +86,9 @@ export function createTransformerFactory(
             const include = parseIncludeMeta(this.options.meta?.__raw)
 
             if (include)
-              addIncludes(includes, include, code)
+              includes.add(include, code)
 
-            const codeWithIncludes = replaceIncludesInCode(includes, code)
+            const codeWithIncludes = includes.applyInclude(code)
 
             const twoslash = (twoslasher as TwoslashShikiFunction)(codeWithIncludes, lang, twoslashOptions)
             map.set(this.meta, twoslash)

--- a/packages/twoslash/src/core.ts
+++ b/packages/twoslash/src/core.ts
@@ -9,6 +9,7 @@ import type { Element, ElementContent, Text } from 'hast'
 import { splitTokens } from '@shikijs/core'
 import type { TransformerTwoslashOptions, TwoslashRenderer, TwoslashShikiFunction, TwoslashShikiReturn } from './types'
 import { ShikiTwoslashError } from './error'
+import { addIncludes, parseIncludeMeta, replaceIncludesInCode } from './includes'
 
 export * from './types'
 export * from './renderer-rich'
@@ -66,6 +67,14 @@ export function createTransformerFactory(
     const map = new WeakMap<ShikiTransformerContextMeta, TwoslashShikiReturn>()
 
     const filter = options.filter || ((lang, _, options) => langs.includes(lang) && (!explicitTrigger || trigger.test(options.meta?.__raw || '')))
+
+    /**
+     * A set of includes which can be pulled via a set ID.
+     *
+     * @TODO: where/when to initialize includes?
+     */
+    const includes = new Map<string, string>()
+
     return {
       preprocess(code) {
         let lang = this.options.lang
@@ -74,7 +83,14 @@ export function createTransformerFactory(
 
         if (filter(lang, code, this.options)) {
           try {
-            const twoslash = (twoslasher as TwoslashShikiFunction)(code, lang, twoslashOptions)
+            const include = parseIncludeMeta(this.options.meta?.__raw)
+
+            if (include)
+              addIncludes(includes, include, code)
+
+            const codeWithIncludes = replaceIncludesInCode(includes, code)
+
+            const twoslash = (twoslasher as TwoslashShikiFunction)(codeWithIncludes, lang, twoslashOptions)
             map.set(this.meta, twoslash)
             this.meta.twoslash = twoslash
             this.options.lang = twoslash.meta?.extension || lang

--- a/packages/twoslash/src/core.ts
+++ b/packages/twoslash/src/core.ts
@@ -40,6 +40,7 @@ export function createTransformerFactory(
       explicitTrigger = false,
       renderer = defaultRenderer,
       throws = true,
+      includesMap = new Map(),
     } = options
 
     const onTwoslashError = options.onTwoslashError || (
@@ -68,12 +69,7 @@ export function createTransformerFactory(
 
     const filter = options.filter || ((lang, _, options) => langs.includes(lang) && (!explicitTrigger || trigger.test(options.meta?.__raw || '')))
 
-    /**
-     * A set of includes which can be pulled via a set ID.
-     *
-     * @TODO: where/when to initialize includes?
-     */
-    const includes = new TwoslashIncludesManager()
+    const includes = new TwoslashIncludesManager(includesMap)
 
     return {
       preprocess(code) {

--- a/packages/twoslash/src/includes.ts
+++ b/packages/twoslash/src/includes.ts
@@ -36,8 +36,12 @@ export function replaceIncludesInCode(_map: Map<string, string>, code: string, s
 
     if (!replaceWith) {
       const msg = `Could not find an include with the key: '${key}'.\nThere is: ${Array.from(_map.keys())}.`
-      if (shouldThrow)
+      if (shouldThrow) {
         throw new Error(msg)
+      }
+      else {
+        console.error(msg)
+      }
     }
     else {
       toReplace.push([match.index, match[0].length, replaceWith])

--- a/packages/twoslash/src/includes.ts
+++ b/packages/twoslash/src/includes.ts
@@ -1,4 +1,8 @@
-export class TwoslashIncludesManager extends Map<string, string> {
+export class TwoslashIncludesManager {
+  constructor(
+    public map: Map<string, string> = new Map(),
+  ) {}
+
   add(name: string, code: string) {
     const lines: string[] = []
 
@@ -7,13 +11,13 @@ export class TwoslashIncludesManager extends Map<string, string> {
 
       if (trimmed.startsWith('// - ')) {
         const key = trimmed.split('// - ')[1].split(' ')[0]
-        this.set(`${name}-${key}`, lines.join('\n'))
+        this.map.set(`${name}-${key}`, lines.join('\n'))
       }
       else {
         lines.push(l)
       }
     })
-    this.set(name, lines.join('\n'))
+    this.map.set(name, lines.join('\n'))
   }
 
   applyInclude(code: string) {
@@ -27,10 +31,10 @@ export class TwoslashIncludesManager extends Map<string, string> {
 
     for (const match of code.matchAll(reMarker)) {
       const key = match[1]
-      const replaceWith = this.get(key)
+      const replaceWith = this.map.get(key)
 
       if (!replaceWith) {
-        const msg = `Could not find an include with the key: '${key}'.\nThere is: ${Array.from(this.keys())}.`
+        const msg = `Could not find an include with the key: '${key}'.\nThere is: ${Array.from(this.map.keys())}.`
         throw new Error(msg)
       }
       else {
@@ -65,6 +69,5 @@ export function parseIncludeMeta(meta?: string): string | null {
     return null
 
   const match = meta.match(INCLUDE_META_REGEX)
-
   return match?.[1] ?? null
 }

--- a/packages/twoslash/src/includes.ts
+++ b/packages/twoslash/src/includes.ts
@@ -51,19 +51,15 @@ export function replaceIncludesInCode(_map: Map<string, string>, code: string) {
 }
 
 /**
- * @example
- *
- * 'typescript twoslash include main meta=miscellaneous'
- *
- * We want to capture the "main", since that's the name of this reusable block.
- * Ignore anything before and after this segment.
- *
- * The name should be captured in the first capturing group, i.e. match[1].
+ * An "include [name]" segment in a raw meta string is a sequence of words,
+ * possibly connected by dashes, following "include " and ending at a word boundary.
  */
 const INCLUDE_META_REGEX = /include\s+(\w+)\b.*?/
 
 /**
- * Given the raw meta, try to parse the include name.
+ * Given a raw meta string for code block like 'twoslash include main-hello-world meta=miscellaneous',
+ * capture the name of the reusable code block as "main-hello-world", and ignore anything
+ * before and after this segment.
  */
 export function parseIncludeMeta(meta?: string): string | null {
   if (!meta)

--- a/packages/twoslash/src/includes.ts
+++ b/packages/twoslash/src/includes.ts
@@ -49,3 +49,27 @@ export function replaceIncludesInCode(_map: Map<string, string>, code: string) {
   })
   return newCode
 }
+
+/**
+ * @example
+ *
+ * 'typescript twoslash include main meta=miscellaneous'
+ *
+ * We want to capture the "main", since that's the name of this reusable block.
+ * Ignore anything before and after this segment.
+ *
+ * The name should be captured in the first capturing group, i.e. match[1].
+ */
+const INCLUDE_META_REGEX = /include\s+(\w+)\b.*?/
+
+/**
+ * Given the raw meta, try to parse the include name.
+ */
+export function parseIncludeMeta(meta?: string): string | null {
+  if (!meta)
+    return null
+
+  const match = meta.match(INCLUDE_META_REGEX)
+
+  return match?.[1] ?? null
+}

--- a/packages/twoslash/src/includes.ts
+++ b/packages/twoslash/src/includes.ts
@@ -56,7 +56,7 @@ export function replaceIncludesInCode(_map: Map<string, string>, code: string, s
  * An "include [name]" segment in a raw meta string is a sequence of words,
  * possibly connected by dashes, following "include " and ending at a word boundary.
  */
-const INCLUDE_META_REGEX = /include\s+(\w+)\b.*?/
+const INCLUDE_META_REGEX = /include\s+([\w-]+)\b.*?/
 
 /**
  * Given a raw meta string for code block like 'twoslash include main-hello-world meta=miscellaneous',

--- a/packages/twoslash/src/includes.ts
+++ b/packages/twoslash/src/includes.ts
@@ -1,0 +1,51 @@
+export function addIncludes(map: Map<string, string>, name: string, code: string) {
+  const lines: string[] = []
+
+  code.split('\n').forEach((l, _i) => {
+    const trimmed = l.trim()
+
+    if (trimmed.startsWith('// - ')) {
+      const key = trimmed.split('// - ')[1].split(' ')[0]
+      map.set(`${name}-${key}`, lines.join('\n'))
+    }
+    else {
+      lines.push(l)
+    }
+  })
+  map.set(name, lines.join('\n'))
+}
+
+export function replaceIncludesInCode(_map: Map<string, string>, code: string) {
+  const includes = /\/\/ @include: (.*)$/gm
+
+  // Basically run a regex over the code replacing any // @include: thing with
+  // 'thing' from the map
+
+  // const toReplace: [index:number, length: number, str: string][] = []
+  const toReplace: [number, number, string][] = []
+
+  let match
+  // eslint-disable-next-line no-cond-assign
+  while ((match = includes.exec(code)) !== null) {
+    // This is necessary to avoid infinite loops with zero-width matches
+    if (match.index === includes.lastIndex) {
+      includes.lastIndex++
+    }
+    const key = match[1]
+    const replaceWith = _map.get(key)
+
+    if (!replaceWith) {
+      const msg = `Could not find an include with the key: '${key}'.\nThere is: ${Array.from(_map.keys())}.`
+      throw new Error(msg)
+    }
+
+    toReplace.push([match.index, match[0].length, replaceWith])
+  }
+
+  let newCode = code.toString()
+  // Go backwards through the found changes so that we can retain index position
+  toReplace.reverse().forEach((r) => {
+    newCode = newCode.substring(0, r[0]) + r[2] + newCode.substring(r[0] + r[1])
+  })
+  return newCode
+}

--- a/packages/twoslash/src/includes.ts
+++ b/packages/twoslash/src/includes.ts
@@ -15,7 +15,7 @@ export function addIncludes(map: Map<string, string>, name: string, code: string
   map.set(name, lines.join('\n'))
 }
 
-export function replaceIncludesInCode(_map: Map<string, string>, code: string) {
+export function replaceIncludesInCode(_map: Map<string, string>, code: string, shouldThrow = true) {
   const includes = /\/\/ @include: (.*)$/gm
 
   // Basically run a regex over the code replacing any // @include: thing with
@@ -36,10 +36,12 @@ export function replaceIncludesInCode(_map: Map<string, string>, code: string) {
 
     if (!replaceWith) {
       const msg = `Could not find an include with the key: '${key}'.\nThere is: ${Array.from(_map.keys())}.`
-      throw new Error(msg)
+      if (shouldThrow)
+        throw new Error(msg)
     }
-
-    toReplace.push([match.index, match[0].length, replaceWith])
+    else {
+      toReplace.push([match.index, match[0].length, replaceWith])
+    }
   }
 
   let newCode = code.toString()

--- a/packages/twoslash/src/types.ts
+++ b/packages/twoslash/src/types.ts
@@ -49,6 +49,11 @@ export interface TransformerTwoslashOptions {
    */
   renderer?: TwoslashRenderer
   /**
+   * A map to store code for `@include` directive
+   * Provide your own instance if you want to clear the map between each transformation
+   */
+  includesMap?: Map<string, string>
+  /**
    * Strictly throw when there is an error
    * @default true
    */

--- a/packages/twoslash/test/includes.test.ts
+++ b/packages/twoslash/test/includes.test.ts
@@ -31,22 +31,22 @@ const c = 3
 `
 
 it('creates a set of examples', () => {
-  const map = new TwoslashIncludesManager()
-  map.add('main', multiExample)
-  expect(map.size === 3)
+  const manager = new TwoslashIncludesManager()
+  manager.add('main', multiExample)
+  expect(manager.map.size === 3)
 
-  expect(map.get('main')).toContain('const c')
-  expect(map.get('main-1')).toContain('const a = 1')
-  expect(map.get('main-2')).toContain('const b = 2')
+  expect(manager.map.get('main')).toContain('const c')
+  expect(manager.map.get('main-1')).toContain('const a = 1')
+  expect(manager.map.get('main-2')).toContain('const b = 2')
 })
 
 it('replaces the code', () => {
-  const map = new TwoslashIncludesManager()
-  map.add('main', multiExample)
-  expect(map.size === 3)
+  const manager = new TwoslashIncludesManager()
+  manager.add('main', multiExample)
+  expect(manager.map.size === 3)
 
   const sample = `// @include: main`
-  const replaced = map.applyInclude(sample)
+  const replaced = manager.applyInclude(sample)
   expect(replaced).toMatchInlineSnapshot(`
     "
     const a = 1
@@ -57,10 +57,10 @@ it('replaces the code', () => {
 })
 
 it('throws an error if key not found', () => {
-  const map = new TwoslashIncludesManager()
+  const manager = new TwoslashIncludesManager()
 
   const sample = `// @include: main`
-  expect(() => map.applyInclude(sample)).toThrow()
+  expect(() => manager.applyInclude(sample)).toThrow()
 })
 
 it('replaces @include directives with previously transformed code blocks', async () => {

--- a/packages/twoslash/test/includes.test.ts
+++ b/packages/twoslash/test/includes.test.ts
@@ -1,0 +1,108 @@
+import { expect, it } from 'vitest'
+import { codeToHtml } from 'shiki'
+import { addIncludes, replaceIncludesInCode } from '../src/includes'
+import { rendererRich, transformerTwoslash } from '../src'
+
+const styleTag = `
+<link rel="stylesheet" href="../../../style-rich.css" />
+<style>
+.dark .shiki,
+.dark .shiki span {
+  color: var(--shiki-dark, inherit);
+  background-color: var(--shiki-dark-bg, inherit);
+  --twoslash-popup-bg: var(--shiki-dark-bg, inherit);
+}
+
+html:not(.dark) .shiki,
+html:not(.dark) .shiki span {
+  color: var(--shiki-light, inherit);
+  background-color: var(--shiki-light-bg, inherit);
+  --twoslash-popup-bg: var(--shiki-light-bg, inherit);
+}
+</style>
+`
+
+const multiExample = `
+const a = 1
+// - 1
+const b = 2
+// - 2
+const c = 3
+`
+
+it('creates a set of examples', () => {
+  const map = new Map()
+  addIncludes(map, 'main', multiExample)
+  expect(map.size === 3)
+
+  expect(map.get('main')).toContain('const c')
+  expect(map.get('main-1')).toContain('const a = 1')
+  expect(map.get('main-2')).toContain('const b = 2')
+})
+
+it('replaces the code', () => {
+  const map = new Map()
+  addIncludes(map, 'main', multiExample)
+  expect(map.size === 3)
+
+  const sample = `// @include: main`
+  const replaced = replaceIncludesInCode(map, sample)
+  expect(replaced).toMatchInlineSnapshot(`
+    "
+    const a = 1
+    const b = 2
+    const c = 3
+    "
+  `)
+})
+
+it('replaces @include directives with previously transformed code blocks', async () => {
+  const main = `
+export const hello = { str: "world" };
+`.trim()
+
+  /**
+   * The @noErrors directive allows the code above the ^| to be invalid,
+   * i.e. so it can demonstrate what a partial autocomplete looks like.
+   */
+  const code = `
+// @include: main
+// @noErrors
+
+hello.
+//    ^|
+`.trim()
+
+  /**
+   * Replacing @include directives only renders nicely rendererRich?
+   */
+  const transformer = transformerTwoslash({
+    renderer: rendererRich(),
+  })
+
+  const htmlMain = await codeToHtml(main, {
+    lang: 'ts',
+    themes: {
+      dark: 'vitesse-dark',
+      light: 'vitesse-light',
+    },
+    defaultColor: false,
+    transformers: [transformer],
+    meta: {
+      __raw: 'include main',
+    },
+  })
+
+  expect(styleTag + htmlMain).toMatchFileSnapshot('./out/includes/main.html')
+
+  const html = await codeToHtml(code, {
+    lang: 'ts',
+    themes: {
+      dark: 'vitesse-dark',
+      light: 'vitesse-light',
+    },
+    transformers: [transformer],
+  })
+
+  expect(styleTag + html).toMatchFileSnapshot('./out/includes/replaced_directives.html')
+})

--- a/packages/twoslash/test/includes.test.ts
+++ b/packages/twoslash/test/includes.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from 'vitest'
 import { codeToHtml } from 'shiki'
-import { addIncludes, replaceIncludesInCode } from '../src/includes'
+import { TwoslashIncludesManager } from '../src/includes'
 import { rendererRich, transformerTwoslash } from '../src'
 
 const styleTag = `
@@ -31,8 +31,8 @@ const c = 3
 `
 
 it('creates a set of examples', () => {
-  const map = new Map()
-  addIncludes(map, 'main', multiExample)
+  const map = new TwoslashIncludesManager()
+  map.add('main', multiExample)
   expect(map.size === 3)
 
   expect(map.get('main')).toContain('const c')
@@ -41,12 +41,12 @@ it('creates a set of examples', () => {
 })
 
 it('replaces the code', () => {
-  const map = new Map()
-  addIncludes(map, 'main', multiExample)
+  const map = new TwoslashIncludesManager()
+  map.add('main', multiExample)
   expect(map.size === 3)
 
   const sample = `// @include: main`
-  const replaced = replaceIncludesInCode(map, sample)
+  const replaced = map.applyInclude(sample)
   expect(replaced).toMatchInlineSnapshot(`
     "
     const a = 1
@@ -57,17 +57,10 @@ it('replaces the code', () => {
 })
 
 it('throws an error if key not found', () => {
-  const map = new Map()
+  const map = new TwoslashIncludesManager()
 
   const sample = `// @include: main`
-  expect(() => replaceIncludesInCode(map, sample)).toThrow()
-})
-
-it('does not throw an error if key not found but shouldThrow is false', () => {
-  const map = new Map()
-
-  const sample = `// @include: main`
-  expect(() => replaceIncludesInCode(map, sample, false)).not.toThrow()
+  expect(() => map.applyInclude(sample)).toThrow()
 })
 
 it('replaces @include directives with previously transformed code blocks', async () => {

--- a/packages/twoslash/test/includes.test.ts
+++ b/packages/twoslash/test/includes.test.ts
@@ -56,6 +56,20 @@ it('replaces the code', () => {
   `)
 })
 
+it('throws an error if key not found', () => {
+  const map = new Map()
+
+  const sample = `// @include: main`
+  expect(() => replaceIncludesInCode(map, sample)).toThrow()
+})
+
+it('does not throw an error if key not found but shouldThrow is false', () => {
+  const map = new Map()
+
+  const sample = `// @include: main`
+  expect(() => replaceIncludesInCode(map, sample, false)).not.toThrow()
+})
+
 it('replaces @include directives with previously transformed code blocks', async () => {
   const main = `
 export const hello = { str: "world" };
@@ -104,5 +118,7 @@ hello.
     transformers: [transformer],
   })
 
-  expect(styleTag + html).toMatchFileSnapshot('./out/includes/replaced_directives.html')
+  expect(styleTag + html).toMatchFileSnapshot(
+    './out/includes/replaced_directives.html',
+  )
 })

--- a/packages/twoslash/test/out/includes/main.html
+++ b/packages/twoslash/test/out/includes/main.html
@@ -1,0 +1,20 @@
+
+<link rel="stylesheet" href="../../../style-rich.css" />
+<style>
+.dark .shiki,
+.dark .shiki span {
+  color: var(--shiki-dark, inherit);
+  background-color: var(--shiki-dark-bg, inherit);
+  --twoslash-popup-bg: var(--shiki-dark-bg, inherit);
+}
+
+html:not(.dark) .shiki,
+html:not(.dark) .shiki span {
+  color: var(--shiki-light, inherit);
+  background-color: var(--shiki-light-bg, inherit);
+  --twoslash-popup-bg: var(--shiki-light-bg, inherit);
+}
+</style>
+<pre class="shiki shiki-themes vitesse-dark vitesse-light twoslash lsp" style="--shiki-dark:#dbd7caee;--shiki-light:#393a34;--shiki-dark-bg:#121212;--shiki-light-bg:#ffffff" tabindex="0"><code><span class="line"><span style="--shiki-dark:#4D9375;--shiki-light:#1E754F">export</span><span style="--shiki-dark:#CB7676;--shiki-light:#AB5959"> const </span><span style="--shiki-dark:#BD976A;--shiki-light:#B07D48"><span class="twoslash-hover"><span class="twoslash-popup-container"><code class="twoslash-popup-code"><pre class="shiki shiki-themes vitesse-dark vitesse-light" style="--shiki-dark:#dbd7caee;--shiki-light:#393a34;--shiki-dark-bg:#121212;--shiki-light-bg:#ffffff" tabindex="0"><code><span class="line"><span style="--shiki-dark:#CB7676;--shiki-light:#AB5959">const </span><span style="--shiki-dark:#BD976A;--shiki-light:#B07D48">hello</span><span style="--shiki-dark:#666666;--shiki-light:#999999">: {</span></span>
+<span class="line"><span style="--shiki-dark:#BD976A;--shiki-light:#B07D48">    str</span><span style="--shiki-dark:#666666;--shiki-light:#999999">: </span><span style="--shiki-dark:#5DA994;--shiki-light:#2E8F82">string</span><span style="--shiki-dark:#666666;--shiki-light:#999999">;</span></span>
+<span class="line"><span style="--shiki-dark:#666666;--shiki-light:#999999">}</span></span></code></pre></code></span>hello</span></span><span style="--shiki-dark:#666666;--shiki-light:#999999"> =</span><span style="--shiki-dark:#666666;--shiki-light:#999999"> { </span><span style="--shiki-dark:#B8A965;--shiki-light:#998418"><span class="twoslash-hover"><span class="twoslash-popup-container"><code class="twoslash-popup-code"><span style="--shiki-dark:#80A665;--shiki-light:#59873A">str</span><span style="--shiki-dark:#666666;--shiki-light:#999999">:</span><span style="--shiki-dark:#BD976A;--shiki-light:#B07D48"> string</span></code></span>str</span></span><span style="--shiki-dark:#666666;--shiki-light:#999999">: </span><span style="--shiki-dark:#C98A7D77;--shiki-light:#B5695977">"</span><span style="--shiki-dark:#C98A7D;--shiki-light:#B56959">world</span><span style="--shiki-dark:#C98A7D77;--shiki-light:#B5695977">"</span><span style="--shiki-dark:#666666;--shiki-light:#999999"> };</span></span></code></pre>

--- a/packages/twoslash/test/out/includes/replaced_directives.html
+++ b/packages/twoslash/test/out/includes/replaced_directives.html
@@ -1,0 +1,25 @@
+
+<link rel="stylesheet" href="../../../style-rich.css" />
+<style>
+.dark .shiki,
+.dark .shiki span {
+  color: var(--shiki-dark, inherit);
+  background-color: var(--shiki-dark-bg, inherit);
+  --twoslash-popup-bg: var(--shiki-dark-bg, inherit);
+}
+
+html:not(.dark) .shiki,
+html:not(.dark) .shiki span {
+  color: var(--shiki-light, inherit);
+  background-color: var(--shiki-light-bg, inherit);
+  --twoslash-popup-bg: var(--shiki-light-bg, inherit);
+}
+</style>
+<pre class="shiki shiki-themes vitesse-light vitesse-dark twoslash lsp" style="background-color:#ffffff;--shiki-dark-bg:#121212;color:#393a34;--shiki-dark:#dbd7caee" tabindex="0"><code><span class="line"><span style="color:#1E754F;--shiki-dark:#4D9375">export</span><span style="color:#AB5959;--shiki-dark:#CB7676"> const </span><span style="color:#B07D48;--shiki-dark:#BD976A"><span class="twoslash-hover"><span class="twoslash-popup-container"><code class="twoslash-popup-code"><pre class="shiki shiki-themes vitesse-light vitesse-dark" style="background-color:#ffffff;--shiki-dark-bg:#121212;color:#393a34;--shiki-dark:#dbd7caee" tabindex="0"><code><span class="line"><span style="color:#AB5959;--shiki-dark:#CB7676">const </span><span style="color:#B07D48;--shiki-dark:#BD976A">hello</span><span style="color:#999999;--shiki-dark:#666666">: {</span></span>
+<span class="line"><span style="color:#B07D48;--shiki-dark:#BD976A">    str</span><span style="color:#999999;--shiki-dark:#666666">: </span><span style="color:#2E8F82;--shiki-dark:#5DA994">string</span><span style="color:#999999;--shiki-dark:#666666">;</span></span>
+<span class="line"><span style="color:#999999;--shiki-dark:#666666">}</span></span></code></pre></code></span>hello</span></span><span style="color:#999999;--shiki-dark:#666666"> =</span><span style="color:#999999;--shiki-dark:#666666"> { </span><span style="color:#998418;--shiki-dark:#B8A965"><span class="twoslash-hover"><span class="twoslash-popup-container"><code class="twoslash-popup-code"><span style="color:#59873A;--shiki-dark:#80A665">str</span><span style="color:#999999;--shiki-dark:#666666">:</span><span style="color:#B07D48;--shiki-dark:#BD976A"> string</span></code></span>str</span></span><span style="color:#999999;--shiki-dark:#666666">: </span><span style="color:#B5695977;--shiki-dark:#C98A7D77">"</span><span style="color:#B56959;--shiki-dark:#C98A7D">world</span><span style="color:#B5695977;--shiki-dark:#C98A7D77">"</span><span style="color:#999999;--shiki-dark:#666666"> };</span></span>
+<span class="line"></span>
+<span class="line"><span style="color:#B07D48;--shiki-dark:#BD976A"><span class="twoslash-hover"><span class="twoslash-popup-container"><code class="twoslash-popup-code"><pre class="shiki shiki-themes vitesse-light vitesse-dark" style="background-color:#ffffff;--shiki-dark-bg:#121212;color:#393a34;--shiki-dark:#dbd7caee" tabindex="0"><code><span class="line"><span style="color:#AB5959;--shiki-dark:#CB7676">const </span><span style="color:#B07D48;--shiki-dark:#BD976A">hello</span><span style="color:#999999;--shiki-dark:#666666">: {</span></span>
+<span class="line"><span style="color:#B07D48;--shiki-dark:#BD976A">    str</span><span style="color:#999999;--shiki-dark:#666666">: </span><span style="color:#2E8F82;--shiki-dark:#5DA994">string</span><span style="color:#999999;--shiki-dark:#666666">;</span></span>
+<span class="line"><span style="color:#999999;--shiki-dark:#666666">}</span></span></code></pre></code></span>hello</span></span><span style="color:#999999;--shiki-dark:#666666"><span>.<span class="twoslash-completion-cursor"><ul class="twoslash-completion-list"><li><span class="twoslash-completions-icon completions-property"><svg viewBox="0 0 32 32"><path fill="currentColor" d="M12.1 2a9.8 9.8 0 0 0-5.4 1.6l6.4 6.4a2.1 2.1 0 0 1 .2 3a2.1 2.1 0 0 1-3-.2L3.7 6.4A9.84 9.84 0 0 0 2 12.1a10.14 10.14 0 0 0 10.1 10.1a10.9 10.9 0 0 0 2.6-.3l6.7 6.7a5 5 0 0 0 7.1-7.1l-6.7-6.7a10.9 10.9 0 0 0 .3-2.6A10 10 0 0 0 12.1 2m8 10.1a7.61 7.61 0 0 1-.3 2.1l-.3 1.1l.8.8l6.7 6.7a2.88 2.88 0 0 1 .9 2.1A2.72 2.72 0 0 1 27 27a2.9 2.9 0 0 1-4.2 0l-6.7-6.7l-.8-.8l-1.1.3a7.61 7.61 0 0 1-2.1.3a8.27 8.27 0 0 1-5.7-2.3A7.63 7.63 0 0 1 4 12.1a8.33 8.33 0 0 1 .3-2.2l4.4 4.4a4.14 4.14 0 0 0 5.9.2a4.14 4.14 0 0 0-.2-5.9L10 4.2a6.45 6.45 0 0 1 2-.3a8.27 8.27 0 0 1 5.7 2.3a8.49 8.49 0 0 1 2.4 5.9"></path></svg></span><span><span class="twoslash-completions-matched"></span><span class="twoslash-completions-unmatched">str</span></span></li></ul></span></span></span></span>
+<span class="line"></span></code></pre>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The `@include` feature that was demonstrated on the documentation for shiki-twoslash-v0 doesn't work with the newer version.

This is because remark-shiki-twoslash (which was used on the old documentation website) would handle the caching and replacement of code with this feature prior to passing the transformed result to twoslash. [See here](https://github.com/shikijs/twoslash/blob/42015c138b41f1618f0df74d72e8f3ecc8f844ef/packages/remark-shiki-twoslash/src/index.ts#L73).

### Solution
- Port the utilities for `includes` from [remark-shiki-twoslash](https://github.com/shikijs/twoslash/blob/42015c138b41f1618f0df74d72e8f3ecc8f844ef/packages/remark-shiki-twoslash/src/includes.ts) to `@shikijs/twoslash`
- Add a string parser utility to identify `include [name]` in raw meta tags.
- Initialize a new map somewhere `const includes = new Map<string, string>()`
- Add relevant code blocks to the includes cache, and replace any `@include` directives prior to twoslash .
- Write tests

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

twoslashes/twoslash#47

### Additional context

TODO: 
Figure out the best place to initialize the `includes` Map...
remark-shiki-twoslash initializes it globally 🤔 

#### References

- [old documentation source markdown](https://github.com/shikijs/twoslash/blob/42015c138b41f1618f0df74d72e8f3ecc8f844ef/site/examples/includes.md?plain=1#L16)
- [old documentation](https://shikijs.github.io/twoslash/)
- [remark-shiki-twoslash includes utilities](https://github.com/shikijs/twoslash/blob/42015c138b41f1618f0df74d72e8f3ecc8f844ef/packages/remark-shiki-twoslash/src/includes.ts)
- [remark-shiki-twoslash adding code to the includes cache](https://github.com/shikijs/twoslash/blob/42015c138b41f1618f0df74d72e8f3ecc8f844ef/packages/remark-shiki-twoslash/src/index.ts#L44)
- [remark-shiki-twoslash replacing @include directives](https://github.com/shikijs/twoslash/blob/42015c138b41f1618f0df74d72e8f3ecc8f844ef/packages/remark-shiki-twoslash/src/index.ts#L73)

<!-- e.g. is there anything you'd like reviewers to focus on? -->
