### PR TITLE
feat(shiki-monaco): add `langMappings` option

### DIFF
--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -18,6 +18,12 @@ export interface ShikiToMonacoOptions {
    * @default 500
    */
   tokenizeTimeLimit?: number
+  /**
+   * Mappings from Shiki language identifiers to Monaco language identifiers.
+   *
+   * @default {}
+   */
+  langMappings?: Record<string, string>
 }
 
 export function textmateThemeToMonacoTheme(theme: ThemeRegistrationResolved): MonacoTheme {
@@ -103,12 +109,14 @@ export function shikiToMonaco(
   const {
     tokenizeMaxLineLength = 20000,
     tokenizeTimeLimit = 500,
+    langMappings = {},
   } = options
 
   const monacoLanguageIds = new Set(monaco.languages.getLanguages().map(l => l.id))
   for (const lang of highlighter.getLoadedLanguages()) {
-    if (monacoLanguageIds.has(lang)) {
-      monaco.languages.setTokensProvider(lang, {
+    const monacoLang = langMappings[lang] || lang
+    if (monacoLanguageIds.has(monacoLang)) {
+      monaco.languages.setTokensProvider(monacoLang, {
         getInitialState() {
           return new TokenizerState(INITIAL)
         },


### PR DESCRIPTION
### Description

There is currently no way to apply tsx syntax highlighting from shiki without losing the built-in IntelliSense for the typescript language in monaco. There is no `tsx` language in monaco - tsx is covered by `typescript` language. The guide (https://shiki.style/packages/monaco) suggests doing `monaco.languages.register({ id: ... })`, but by doing so for `id: 'tsx'`, we will lack the built-in IntelliSense for typescript.

So I added an option to map between shiki and monaco languages. For tsx it looks like this:

```
 const shikiHighlighter = await createHighlighter({
   themes,
   langs: ['tsx'],
 })

 shikiToMonaco(shikiHighlighter, monaco, {
   langMappings: { tsx: 'typescript' }
 })
```

We can then use the built-in typescript language in monaco, with TSX syntax highlighting from shiki:

```
monaco.editor.createModel(
   ...,
   'typescript',
   monaco.Uri.parse('file:///index.tsx')
 )
```

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
