### PR TITLE
feat(perf): wrap json data with `JSON.parse` to speed up rebundling

### DIFF
--- a/packages/shiki/scripts/prepare/langs.ts
+++ b/packages/shiki/scripts/prepare/langs.ts
@@ -52,7 +52,7 @@ export async function prepareLangs() {
       `${COMMENT_HEAD}
 ${deps.map(i => `import ${i.replace(/\W/g, '_')} from './${i}'`).join('\n')}
 
-const lang = Object.freeze(${JSON.stringify(json)})
+const lang = Object.freeze(JSON.parse(${JSON.stringify(JSON.stringify(json))}))
 
 export default [
 ${[

--- a/packages/shiki/scripts/prepare/themes.ts
+++ b/packages/shiki/scripts/prepare/themes.ts
@@ -10,7 +10,7 @@ export async function prepareTheme(): Promise<void> {
       await fs.writeFile(
         `./src/assets/themes/${t.name}.js`,
         `${COMMENT_HEAD}
-export default Object.freeze(${JSON.stringify(theme, null, 2)})
+export default Object.freeze(JSON.parse(${JSON.stringify(JSON.stringify(theme))}))
 `,
         'utf-8',
       )


### PR DESCRIPTION
This PR changes the bundled grammars and themes to use `JSON.parse("{...}")` instead of plain JS object `{...}`. This would hugely improve the re-bundling speed and memory usage as the compiler don't need to create many unused AST for the data inside.

This should have no effects to the end user usage