### PR TITLE
feat(core): pass raw token to `transformer.span` api

### DIFF
--- a/packages/core/src/highlight/code-to-hast.ts
+++ b/packages/core/src/highlight/code-to-hast.ts
@@ -180,7 +180,7 @@ export function tokensToHast(
         tokenNode.properties.style = style
 
       for (const transformer of transformers)
-        tokenNode = transformer?.span?.call(context, tokenNode, idx + 1, col, lineNode) || tokenNode
+        tokenNode = transformer?.span?.call(context, tokenNode, idx + 1, col, lineNode, token) || tokenNode
 
       if (structure === 'inline')
         root.children.push(tokenNode)

--- a/packages/types/src/transformers.ts
+++ b/packages/types/src/transformers.ts
@@ -81,7 +81,7 @@ export interface ShikiTransformer {
   /**
    * Transform each token `<span>` element.
    */
-  span?: (this: ShikiTransformerContext, hast: Element, line: number, col: number, lineElement: Element) => Element | void
+  span?: (this: ShikiTransformerContext, hast: Element, line: number, col: number, lineElement: Element, token: ThemedToken) => Element | void
   /**
    * Transform the generated HTML string before returning.
    * This hook will only be called with `codeToHtml`.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Sometimes, we need to process some information in `transformer.tokens` and then record some additional information in the `token`, which will later be processed into the tokenNode in the `transformer.span` for rendering in HTML.

For example, I need to add a background color to tokens within a specific range. I need to split the tokens in `transformer.tokens` and add special markers, but I can't easily render these markers in `transformer.span`.

Now I am using the modified `tokenNode.htmlStyle` field to workaround, but I feel that exposing it in `transformer.span` would be better.



### Linked Issues
No linked issue

### Additional context
If you feel that this PR does not align with Shiki's design philosophy, you can close it, thanks
<!-- e.g. is there anything you'd like reviewers to focus on? -->
