### PR TITLE
feat: store grammar state in weakmap

### DIFF
--- a/packages/core/src/constructors/bundle-factory.ts
+++ b/packages/core/src/constructors/bundle-factory.ts
@@ -190,7 +190,9 @@ export interface ShorthandsBundle<L extends string, T extends string> {
    * Shorthand for `getLastGrammarState` with auto-loaded theme and language.
    * A singleton highlighter it maintained internally.
    */
-  getLastGrammarState: (code: string, options: CodeToTokensBaseOptions<L, T>) => Promise<GrammarState>
+  getLastGrammarState:
+    | ((element: ThemedToken[][] | Root) => GrammarState)
+    | ((code: string, options: CodeToTokensBaseOptions<L, T>) => Promise<GrammarState>)
 }
 
 export function makeSingletonHighlighter<L extends string, T extends string>(

--- a/packages/core/src/constructors/highlighter.ts
+++ b/packages/core/src/constructors/highlighter.ts
@@ -20,7 +20,7 @@ export async function createHighlighterCore(options: HighlighterCoreOptions = {}
   const internal = await createShikiInternal(options)
 
   return {
-    getLastGrammarState: (code, options) => getLastGrammarState(internal, code, options),
+    getLastGrammarState: (...args: any[]) => getLastGrammarState(internal, ...args as [any])!,
     codeToTokensBase: (code, options) => codeToTokensBase(internal, code, options),
     codeToTokensWithThemes: (code, options) => codeToTokensWithThemes(internal, code, options),
     codeToTokens: (code, options) => codeToTokens(internal, code, options),
@@ -43,7 +43,7 @@ export function createHighlighterCoreSync(options: HighlighterCoreOptions<true> 
   const internal = createShikiInternalSync(options)
 
   return {
-    getLastGrammarState: (code, options) => getLastGrammarState(internal, code, options),
+    getLastGrammarState: (...args: any[]) => getLastGrammarState(internal, ...args as [any, any]),
     codeToTokensBase: (code, options) => codeToTokensBase(internal, code, options),
     codeToTokensWithThemes: (code, options) => codeToTokensWithThemes(internal, code, options),
     codeToTokens: (code, options) => codeToTokens(internal, code, options),

--- a/packages/core/src/highlight/code-to-hast.ts
+++ b/packages/core/src/highlight/code-to-hast.ts
@@ -1,6 +1,7 @@
 import type {
   CodeToHastOptions,
   CodeToHastRenderOptions,
+  GrammarState,
   ShikiInternal,
   ShikiTransformerContext,
   ShikiTransformerContextCommon,
@@ -14,7 +15,7 @@ import type {
 } from 'hast'
 
 import { FontStyle } from '@shikijs/vscode-textmate'
-
+import { getLastGrammarStateFromMap, setLastGrammarStateToMap } from '../textmate/grammar-state'
 import { addClassToHast, getTokenStyleObject, stringifyTokenStyle } from '../utils'
 import { warnDeprecated } from '../warn'
 import { getTransformers } from './_get-transformers'
@@ -42,6 +43,7 @@ export function codeToHast(
     bg,
     themeName,
     rootStyle,
+    grammarState,
   } = codeToTokens(internal, input, options)
 
   const {
@@ -73,6 +75,7 @@ export function codeToHast(
       rootStyle,
     },
     contextSource,
+    grammarState,
   )
 }
 
@@ -80,6 +83,7 @@ export function tokensToHast(
   tokens: ThemedToken[][],
   options: CodeToHastRenderOptions,
   transformerContext: ShikiTransformerContextSource,
+  grammarState: GrammarState | undefined = getLastGrammarStateFromMap(tokens),
 ): Root {
   const transformers = getTransformers(options)
 
@@ -219,6 +223,9 @@ export function tokensToHast(
   let result = root
   for (const transformer of transformers)
     result = transformer?.root?.call(context, result) || result
+
+  if (grammarState)
+    setLastGrammarStateToMap(result, grammarState)
 
   return result
 }

--- a/packages/engine-javascript/test/__records__/html-basic.json
+++ b/packages/engine-javascript/test/__records__/html-basic.json
@@ -202,6 +202,88 @@
       },
       {
         "args": [
+          "<div class=\"foo\">bar</div>\n",
+          0
+        ],
+        "result": {
+          "index": 35,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 0,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 1,
+              "end": 4,
+              "length": 3
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4,
+              "end": 5,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4,
+              "end": 5,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          0
+        ],
+        "result": {
+          "index": 77,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
           "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
           0
         ],
@@ -226,6 +308,118 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          0
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 0,
+              "length": 0
+            },
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 1,
+              "end": 4,
+              "length": 3
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4,
+              "end": 5,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4,
+              "end": 5,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          26
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 26,
+              "end": 26,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
       {
         "args": [
           "<div class=\"foo\">bar</div>\n",
@@ -476,6 +670,134 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          0
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 4,
+              "length": 4
+            },
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 1,
+              "end": 4,
+              "length": 3
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4,
+              "end": 5,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4,
+              "end": 5,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          16
+        ],
+        "result": {
+          "index": 2,
+          "captureIndices": [
+            {
+              "start": 16,
+              "end": 17,
+              "length": 1
+            },
+            {
+              "start": 16,
+              "end": 17,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          20
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 20,
+              "end": 26,
+              "length": 6
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 20,
+              "end": 22,
+              "length": 2
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 22,
+              "end": 25,
+              "length": 3
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 25,
+              "end": 26,
+              "length": 1
+            }
+          ]
+        }
       }
     ]
   },
@@ -491,6 +813,38 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          4
+        ],
+        "result": {
+          "index": 5,
+          "captureIndices": [
+            {
+              "start": 4,
+              "end": 5,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          16
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 16,
+              "end": 16,
+              "length": 0
+            }
+          ]
+        }
+      },
       {
         "args": [
           "<div class=\"foo\">bar</div>\n",
@@ -619,6 +973,85 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          5
+        ],
+        "result": {
+          "index": 4,
+          "captureIndices": [
+            {
+              "start": 5,
+              "end": 10,
+              "length": 5
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 5,
+              "end": 10,
+              "length": 5
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          10
+        ],
+        "result": {
+          "index": 5,
+          "captureIndices": [
+            {
+              "start": 10,
+              "end": 11,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          11
+        ],
+        "result": {
+          "index": 6,
+          "captureIndices": [
+            {
+              "start": 11,
+              "end": 12,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          16
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 16,
+              "end": 16,
+              "length": 0
+            }
+          ]
+        }
       }
     ]
   },
@@ -630,6 +1063,22 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          12
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 15,
+              "end": 16,
+              "length": 1
+            }
+          ]
+        }
+      },
       {
         "args": [
           "<div class=\"foo\">bar</div>\n",
@@ -659,6 +1108,22 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          17
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 20,
+              "end": 20,
+              "length": 0
+            }
+          ]
+        }
+      },
       {
         "args": [
           "<div class=\"foo\">bar</div>\n",
@@ -816,6 +1281,135 @@
         "args": [
           "<div class=\"foo\">bar</div>\n",
           26
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "<div class=\"foo\">bar</div>\n",
+          26
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          1
+        ],
+        "result": {
+          "index": 79,
+          "captureIndices": [
+            {
+              "start": 1,
+              "end": 2,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          2
+        ],
+        "result": {
+          "index": 115,
+          "captureIndices": [
+            {
+              "start": 2,
+              "end": 9,
+              "length": 7
+            },
+            {
+              "start": 2,
+              "end": 9,
+              "length": 7
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          9
+        ],
+        "result": {
+          "index": 116,
+          "captureIndices": [
+            {
+              "start": 10,
+              "end": 14,
+              "length": 4
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          14
+        ],
+        "result": {
+          "index": 77,
+          "captureIndices": [
+            {
+              "start": 14,
+              "end": 15,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          15
+        ],
+        "result": {
+          "index": 34,
+          "captureIndices": [
+            {
+              "start": 15,
+              "end": 15,
+              "length": 0
+            },
+            {
+              "start": 15,
+              "end": 16,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 16,
+              "end": 20,
+              "length": 4
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 20,
+              "end": 21,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          75
         ],
         "result": null
       },
@@ -1042,6 +1636,98 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          15
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 15,
+              "end": 21,
+              "length": 6
+            },
+            {
+              "start": 15,
+              "end": 16,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 16,
+              "end": 20,
+              "length": 4
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 20,
+              "end": 21,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          75
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 75,
+              "end": 75,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
       }
     ]
   },
@@ -1056,6 +1742,328 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          21
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 21,
+              "end": 27,
+              "length": 6
+            },
+            {
+              "start": 21,
+              "end": 22,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 22,
+              "end": 26,
+              "length": 4
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 26,
+              "end": 27,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          27
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 27,
+              "end": 34,
+              "length": 7
+            },
+            {
+              "start": 27,
+              "end": 28,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 28,
+              "end": 33,
+              "length": 5
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 33,
+              "end": 34,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          34
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 37,
+              "end": 45,
+              "length": 8
+            },
+            {
+              "start": 37,
+              "end": 39,
+              "length": 2
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 39,
+              "end": 44,
+              "length": 5
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 44,
+              "end": 45,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          45
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 45,
+              "end": 52,
+              "length": 7
+            },
+            {
+              "start": 45,
+              "end": 47,
+              "length": 2
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 47,
+              "end": 51,
+              "length": 4
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 51,
+              "end": 52,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          52
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 52,
+              "end": 58,
+              "length": 6
+            },
+            {
+              "start": 52,
+              "end": 53,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 53,
+              "end": 57,
+              "length": 4
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 57,
+              "end": 58,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          58
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 61,
+              "end": 68,
+              "length": 7
+            },
+            {
+              "start": 61,
+              "end": 63,
+              "length": 2
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 63,
+              "end": 67,
+              "length": 4
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 67,
+              "end": 68,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",
+          68
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 68,
+              "end": 75,
+              "length": 7
+            },
+            {
+              "start": 68,
+              "end": 70,
+              "length": 2
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 70,
+              "end": 74,
+              "length": 4
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 74,
+              "end": 75,
+              "length": 1
+            }
+          ]
+        }
+      },
       {
         "args": [
           "<!DOCTYPE html><html><head><title>foo</title></head><body>bar</body></html>\n",

--- a/packages/engine-javascript/test/__records__/json-basic.json
+++ b/packages/engine-javascript/test/__records__/json-basic.json
@@ -38,6 +38,52 @@
       },
       {
         "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          0
+        ],
+        "result": {
+          "index": 4,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          17
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          0
+        ],
+        "result": {
+          "index": 3,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          56
+        ],
+        "result": null
+      },
+      {
+        "args": [
           "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
           0
         ],
@@ -172,6 +218,118 @@
       },
       {
         "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          1
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 1,
+              "end": 2,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          6
+        ],
+        "result": {
+          "index": 5,
+          "captureIndices": [
+            {
+              "start": 6,
+              "end": 7,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          8
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 8,
+              "end": 9,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          13
+        ],
+        "result": {
+          "index": 5,
+          "captureIndices": [
+            {
+              "start": 13,
+              "end": 14,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          15
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 15,
+              "end": 16,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          16
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 16,
+              "end": 17,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          54
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 54,
+              "end": 55,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
           "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
           54
         ],
@@ -228,6 +386,38 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          2
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 5,
+              "end": 6,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          9
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 12,
+              "end": 13,
+              "length": 1
+            }
+          ]
+        }
       }
     ]
   },
@@ -247,6 +437,80 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          7
+        ],
+        "result": {
+          "index": 5,
+          "captureIndices": [
+            {
+              "start": 7,
+              "end": 8,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          14
+        ],
+        "result": {
+          "index": 2,
+          "captureIndices": [
+            {
+              "start": 14,
+              "end": 15,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          15
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 15,
+              "end": 15,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":{\"bar\":1}}\n",
+          16
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 16,
+              "end": 16,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
       {
         "args": [
           "{\"foo\":{\"bar\":1}}\n",
@@ -803,6 +1067,470 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          1
+        ],
+        "result": {
+          "index": 10,
+          "captureIndices": [
+            {
+              "start": 1,
+              "end": 2,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          2
+        ],
+        "result": {
+          "index": 10,
+          "captureIndices": [
+            {
+              "start": 2,
+              "end": 3,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          3
+        ],
+        "result": {
+          "index": 10,
+          "captureIndices": [
+            {
+              "start": 3,
+              "end": 4,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          4
+        ],
+        "result": {
+          "index": 10,
+          "captureIndices": [
+            {
+              "start": 4,
+              "end": 5,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          5
+        ],
+        "result": {
+          "index": 10,
+          "captureIndices": [
+            {
+              "start": 5,
+              "end": 6,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          6
+        ],
+        "result": {
+          "index": 10,
+          "captureIndices": [
+            {
+              "start": 6,
+              "end": 7,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          7
+        ],
+        "result": {
+          "index": 10,
+          "captureIndices": [
+            {
+              "start": 7,
+              "end": 8,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          8
+        ],
+        "result": {
+          "index": 10,
+          "captureIndices": [
+            {
+              "start": 8,
+              "end": 9,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          9
+        ],
+        "result": {
+          "index": 10,
+          "captureIndices": [
+            {
+              "start": 9,
+              "end": 10,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          10
+        ],
+        "result": {
+          "index": 9,
+          "captureIndices": [
+            {
+              "start": 10,
+              "end": 11,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          11
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 12,
+              "end": 16,
+              "length": 4
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          16
+        ],
+        "result": {
+          "index": 9,
+          "captureIndices": [
+            {
+              "start": 16,
+              "end": 17,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          17
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 18,
+              "end": 22,
+              "length": 4
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          22
+        ],
+        "result": {
+          "index": 9,
+          "captureIndices": [
+            {
+              "start": 22,
+              "end": 23,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          23
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 24,
+              "end": 29,
+              "length": 5
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          29
+        ],
+        "result": {
+          "index": 9,
+          "captureIndices": [
+            {
+              "start": 29,
+              "end": 30,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          30
+        ],
+        "result": {
+          "index": 2,
+          "captureIndices": [
+            {
+              "start": 31,
+              "end": 32,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          32
+        ],
+        "result": {
+          "index": 9,
+          "captureIndices": [
+            {
+              "start": 32,
+              "end": 33,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          33
+        ],
+        "result": {
+          "index": 2,
+          "captureIndices": [
+            {
+              "start": 34,
+              "end": 35,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          35
+        ],
+        "result": {
+          "index": 9,
+          "captureIndices": [
+            {
+              "start": 35,
+              "end": 36,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          36
+        ],
+        "result": {
+          "index": 2,
+          "captureIndices": [
+            {
+              "start": 37,
+              "end": 40,
+              "length": 3
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          40
+        ],
+        "result": {
+          "index": 9,
+          "captureIndices": [
+            {
+              "start": 40,
+              "end": 41,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          41
+        ],
+        "result": {
+          "index": 3,
+          "captureIndices": [
+            {
+              "start": 42,
+              "end": 43,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          47
+        ],
+        "result": {
+          "index": 9,
+          "captureIndices": [
+            {
+              "start": 47,
+              "end": 48,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          48
+        ],
+        "result": {
+          "index": 4,
+          "captureIndices": [
+            {
+              "start": 49,
+              "end": 50,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          50
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 50,
+              "end": 51,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          51
+        ],
+        "result": {
+          "index": 9,
+          "captureIndices": [
+            {
+              "start": 51,
+              "end": 52,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          52
+        ],
+        "result": {
+          "index": 5,
+          "captureIndices": [
+            {
+              "start": 53,
+              "end": 54,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          55
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 55,
+              "end": 56,
+              "length": 1
+            }
+          ]
+        }
       }
     ]
   },
@@ -815,6 +1543,22 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",
+          43
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 46,
+              "end": 47,
+              "length": 1
+            }
+          ]
+        }
+      },
       {
         "args": [
           "[undefined, null, true, false, 0, 1, 1.1, \"foo\", [], {}]\n",

--- a/packages/engine-javascript/test/__records__/jsonc.json
+++ b/packages/engine-javascript/test/__records__/jsonc.json
@@ -63,6 +63,57 @@
           13
         ],
         "result": null
+      },
+      {
+        "args": [
+          "// comment\n",
+          0
+        ],
+        "result": {
+          "index": 7,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 11,
+              "length": 11
+            },
+            {
+              "start": 0,
+              "end": 2,
+              "length": 2
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "// comment\n",
+          11
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "{\"foo\":\"bar\"}\n",
+          0
+        ],
+        "result": {
+          "index": 4,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":\"bar\"}\n",
+          13
+        ],
+        "result": null
       }
     ]
   },
@@ -79,6 +130,54 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "{\"foo\":\"bar\"}\n",
+          1
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 1,
+              "end": 2,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":\"bar\"}\n",
+          6
+        ],
+        "result": {
+          "index": 5,
+          "captureIndices": [
+            {
+              "start": 6,
+              "end": 7,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":\"bar\"}\n",
+          12
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 12,
+              "end": 13,
+              "length": 1
+            }
+          ]
+        }
+      },
       {
         "args": [
           "{\"foo\":\"bar\"}\n",
@@ -153,6 +252,22 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "{\"foo\":\"bar\"}\n",
+          2
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 5,
+              "end": 6,
+              "length": 1
+            }
+          ]
+        }
       }
     ]
   },
@@ -208,6 +323,43 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "{\"foo\":\"bar\"}\n",
+          7
+        ],
+        "result": {
+          "index": 3,
+          "captureIndices": [
+            {
+              "start": 7,
+              "end": 8,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "{\"foo\":\"bar\"}\n",
+          12
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 12,
+              "end": 12,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
       }
     ]
   },
@@ -220,6 +372,22 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "{\"foo\":\"bar\"}\n",
+          8
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 11,
+              "end": 12,
+              "length": 1
+            }
+          ]
+        }
+      },
       {
         "args": [
           "{\"foo\":\"bar\"}\n",

--- a/packages/engine-javascript/test/__records__/sql.json
+++ b/packages/engine-javascript/test/__records__/sql.json
@@ -240,6 +240,513 @@
       },
       {
         "args": [
+          "SELECT * FROM foo\n",
+          0
+        ],
+        "result": {
+          "index": 12,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 6,
+              "length": 6
+            },
+            {
+              "start": 0,
+              "end": 6,
+              "length": 6
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "SELECT * FROM foo\n",
+          6
+        ],
+        "result": {
+          "index": 21,
+          "captureIndices": [
+            {
+              "start": 7,
+              "end": 8,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "SELECT * FROM foo\n",
+          8
+        ],
+        "result": {
+          "index": 12,
+          "captureIndices": [
+            {
+              "start": 9,
+              "end": 13,
+              "length": 4
+            },
+            {
+              "start": 9,
+              "end": 13,
+              "length": 4
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "SELECT * FROM foo\n",
+          13
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "USE AdventureWorks2022;\n",
+          0
+        ],
+        "result": {
+          "index": 56,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 3,
+              "length": 3
+            },
+            {
+              "start": 0,
+              "end": 3,
+              "length": 3
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "USE AdventureWorks2022;\n",
+          3
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "GO\n",
+          0
+        ],
+        "result": {
+          "index": 56,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 2,
+              "length": 2
+            },
+            {
+              "start": 0,
+              "end": 2,
+              "length": 2
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "GO\n",
+          2
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "IF OBJECT_ID('dbo.NewProducts', 'U') IS NOT NULL\n",
+          0
+        ],
+        "result": {
+          "index": 56,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 2,
+              "length": 2
+            },
+            {
+              "start": 0,
+              "end": 2,
+              "length": 2
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "IF OBJECT_ID('dbo.NewProducts', 'U') IS NOT NULL\n",
+          2
+        ],
+        "result": {
+          "index": 39,
+          "captureIndices": [
+            {
+              "start": 3,
+              "end": 13,
+              "length": 10
+            },
+            {
+              "start": 3,
+              "end": 12,
+              "length": 9
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "IF OBJECT_ID('dbo.NewProducts', 'U') IS NOT NULL\n",
+          13
+        ],
+        "result": {
+          "index": 47,
+          "captureIndices": [
+            {
+              "start": 13,
+              "end": 30,
+              "length": 17
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 13,
+              "end": 14,
+              "length": 1
+            },
+            {
+              "start": 29,
+              "end": 30,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "IF OBJECT_ID('dbo.NewProducts', 'U') IS NOT NULL\n",
+          30
+        ],
+        "result": {
+          "index": 47,
+          "captureIndices": [
+            {
+              "start": 32,
+              "end": 35,
+              "length": 3
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 32,
+              "end": 33,
+              "length": 1
+            },
+            {
+              "start": 34,
+              "end": 35,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "IF OBJECT_ID('dbo.NewProducts', 'U') IS NOT NULL\n",
+          35
+        ],
+        "result": {
+          "index": 13,
+          "captureIndices": [
+            {
+              "start": 37,
+              "end": 48,
+              "length": 11
+            },
+            {
+              "start": 37,
+              "end": 48,
+              "length": 11
+            },
+            {
+              "start": 37,
+              "end": 44,
+              "length": 7
+            },
+            {
+              "start": 37,
+              "end": 40,
+              "length": 3
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "IF OBJECT_ID('dbo.NewProducts', 'U') IS NOT NULL\n",
+          48
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "DROP TABLE dbo.NewProducts;\n",
+          0
+        ],
+        "result": {
+          "index": 6,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 10,
+              "length": 10
+            },
+            {
+              "start": 0,
+              "end": 4,
+              "length": 4
+            },
+            {
+              "start": 5,
+              "end": 10,
+              "length": 5
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "DROP TABLE dbo.NewProducts;\n",
+          10
+        ],
+        "result": {
+          "index": 46,
+          "captureIndices": [
+            {
+              "start": 11,
+              "end": 26,
+              "length": 15
+            },
+            {
+              "start": 11,
+              "end": 14,
+              "length": 3
+            },
+            {
+              "start": 15,
+              "end": 26,
+              "length": 11
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "DROP TABLE dbo.NewProducts;\n",
+          26
+        ],
+        "result": null
+      },
+      {
+        "args": [
           "USE AdventureWorks2022;\n",
           0
         ],

--- a/packages/engine-javascript/test/__records__/toml.json
+++ b/packages/engine-javascript/test/__records__/toml.json
@@ -144,6 +144,138 @@
           27
         ],
         "result": null
+      },
+      {
+        "args": [
+          "# This is a TOML document\n",
+          0
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 0,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "# This is a TOML document\n",
+          26
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "title = \"TOML Example\"\n",
+          0
+        ],
+        "result": {
+          "index": 3,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 8,
+              "length": 8
+            },
+            {
+              "start": 0,
+              "end": 5,
+              "length": 5
+            },
+            {
+              "start": 6,
+              "end": 7,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "title = \"TOML Example\"\n",
+          22
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "[owner]\n",
+          0
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 7,
+              "length": 7
+            },
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            },
+            {
+              "start": 1,
+              "end": 6,
+              "length": 5
+            },
+            {
+              "start": 6,
+              "end": 7,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[owner]\n",
+          7
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "name = \"Tom Preston-Werner\"\n",
+          0
+        ],
+        "result": {
+          "index": 3,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 7,
+              "length": 7
+            },
+            {
+              "start": 0,
+              "end": 4,
+              "length": 4
+            },
+            {
+              "start": 5,
+              "end": 6,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "name = \"Tom Preston-Werner\"\n",
+          27
+        ],
+        "result": null
       }
     ]
   },
@@ -155,6 +287,22 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "# This is a TOML document\n",
+          0
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            }
+          ]
+        }
+      },
       {
         "args": [
           "# This is a TOML document\n",
@@ -195,6 +343,22 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "# This is a TOML document\n",
+          1
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 25,
+              "end": 26,
+              "length": 1
+            }
+          ]
+        }
       }
     ]
   },
@@ -206,6 +370,22 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "# This is a TOML document\n",
+          26
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 26,
+              "end": 26,
+              "length": 0
+            }
+          ]
+        }
+      },
       {
         "args": [
           "# This is a TOML document\n",
@@ -277,6 +457,38 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "title = \"TOML Example\"\n",
+          8
+        ],
+        "result": {
+          "index": 2,
+          "captureIndices": [
+            {
+              "start": 8,
+              "end": 9,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "name = \"Tom Preston-Werner\"\n",
+          7
+        ],
+        "result": {
+          "index": 2,
+          "captureIndices": [
+            {
+              "start": 7,
+              "end": 8,
+              "length": 1
+            }
+          ]
+        }
       }
     ]
   },
@@ -289,6 +501,38 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "title = \"TOML Example\"\n",
+          9
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 21,
+              "end": 22,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "name = \"Tom Preston-Werner\"\n",
+          8
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 26,
+              "end": 27,
+              "length": 1
+            }
+          ]
+        }
+      },
       {
         "args": [
           "title = \"TOML Example\"\n",
@@ -376,6 +620,38 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "title = \"TOML Example\"\n",
+          22
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 22,
+              "end": 22,
+              "length": 0
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "name = \"Tom Preston-Werner\"\n",
+          27
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 27,
+              "end": 27,
+              "length": 0
+            }
+          ]
+        }
       }
     ]
   },
@@ -386,6 +662,29 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "[owner",
+          1
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 1,
+              "end": 6,
+              "length": 5
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "[owner",
+          6
+        ],
+        "result": null
+      },
       {
         "args": [
           "[owner",

--- a/packages/engine-javascript/test/__records__/ts-basic.json
+++ b/packages/engine-javascript/test/__records__/ts-basic.json
@@ -163,6 +163,37 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          0
+        ],
+        "result": {
+          "index": 3,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 0,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 0,
+              "end": 5,
+              "length": 5
+            }
+          ]
+        }
       }
     ]
   },
@@ -185,6 +216,130 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          0
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 6,
+              "length": 6
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 0,
+              "end": 5,
+              "length": 5
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          6
+        ],
+        "result": {
+          "index": 5,
+          "captureIndices": [
+            {
+              "start": 6,
+              "end": 9,
+              "length": 3
+            },
+            {
+              "start": 6,
+              "end": 9,
+              "length": 3
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          18
+        ],
+        "result": {
+          "index": 6,
+          "captureIndices": [
+            {
+              "start": 18,
+              "end": 19,
+              "length": 1
+            },
+            {
+              "start": 18,
+              "end": 19,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          25
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 25,
+              "end": 25,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 25,
+              "end": 25,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 25,
+              "end": 25,
+              "length": 0
+            }
+          ]
+        }
+      },
       {
         "args": [
           "const foo: string = \"bar\"\n",
@@ -333,6 +488,22 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          6
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 6,
+              "end": 6,
+              "length": 0
+            }
+          ]
+        }
       }
     ]
   },
@@ -353,6 +524,58 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          9
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 9,
+              "end": 10,
+              "length": 1
+            },
+            {
+              "start": 9,
+              "end": 10,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          18
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 18,
+              "end": 18,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
       {
         "args": [
           "const foo: string = \"bar\"\n",
@@ -450,6 +673,53 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          10
+        ],
+        "result": {
+          "index": 13,
+          "captureIndices": [
+            {
+              "start": 11,
+              "end": 17,
+              "length": 6
+            },
+            {
+              "start": 11,
+              "end": 17,
+              "length": 6
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          17
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 18,
+              "end": 18,
+              "length": 0
+            },
+            {
+              "start": 18,
+              "end": 18,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
       {
         "args": [
           "const foo: string = \"bar\"\n",
@@ -631,6 +901,48 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          19
+        ],
+        "result": {
+          "index": 2,
+          "captureIndices": [
+            {
+              "start": 20,
+              "end": 21,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          25
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 25,
+              "end": 25,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
       }
     ]
   },
@@ -642,6 +954,32 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          21
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 24,
+              "end": 25,
+              "length": 1
+            },
+            {
+              "start": 24,
+              "end": 25,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
       {
         "args": [
           "const foo: string = \"bar\"\n",
@@ -804,6 +1142,13 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "const foo: string = \"bar\"\n",
+          25
+        ],
+        "result": null
+      },
       {
         "args": [
           "const foo: string = \"bar\"\n",

--- a/packages/engine-javascript/test/__records__/vue.json
+++ b/packages/engine-javascript/test/__records__/vue.json
@@ -202,6 +202,118 @@
       },
       {
         "args": [
+          "<script setup>\n",
+          0
+        ],
+        "result": {
+          "index": 35,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 0,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 1,
+              "end": 7,
+              "length": 6
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 7,
+              "end": 8,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 7,
+              "end": 8,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<template>\n",
+          0
+        ],
+        "result": {
+          "index": 34,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 0,
+              "length": 0
+            },
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 1,
+              "end": 9,
+              "length": 8
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 9,
+              "end": 10,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
           "<template>\n",
           0
         ],
@@ -256,6 +368,118 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "<script setup>\n",
+          0
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 0,
+              "length": 0
+            },
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 1,
+              "end": 7,
+              "length": 6
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 7,
+              "end": 8,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 7,
+              "end": 8,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "</script>\n",
+          9
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 9,
+              "end": 9,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
       {
         "args": [
           "<script setup>\n",
@@ -506,6 +730,134 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "<script setup>\n",
+          0
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 7,
+              "length": 7
+            },
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 1,
+              "end": 7,
+              "length": 6
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 7,
+              "end": 8,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 7,
+              "end": 8,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<script setup>\n",
+          13
+        ],
+        "result": {
+          "index": 2,
+          "captureIndices": [
+            {
+              "start": 13,
+              "end": 14,
+              "length": 1
+            },
+            {
+              "start": 13,
+              "end": 14,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "</script>\n",
+          0
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 9,
+              "length": 9
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 0,
+              "end": 2,
+              "length": 2
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 2,
+              "end": 8,
+              "length": 6
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 8,
+              "end": 9,
+              "length": 1
+            }
+          ]
+        }
       }
     ]
   },
@@ -521,6 +873,38 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "<script setup>\n",
+          7
+        ],
+        "result": {
+          "index": 5,
+          "captureIndices": [
+            {
+              "start": 7,
+              "end": 8,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<script setup>\n",
+          13
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 13,
+              "end": 13,
+              "length": 0
+            }
+          ]
+        }
+      },
       {
         "args": [
           "<script setup>\n",
@@ -617,6 +1001,53 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "<script setup>\n",
+          8
+        ],
+        "result": {
+          "index": 4,
+          "captureIndices": [
+            {
+              "start": 8,
+              "end": 13,
+              "length": 5
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 8,
+              "end": 13,
+              "length": 5
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<script setup>\n",
+          13
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 13,
+              "end": 13,
+              "length": 0
+            }
+          ]
+        }
       }
     ]
   },
@@ -631,6 +1062,52 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "<script setup>\n",
+          14
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "import { ref } from 'vue'\n",
+          0
+        ],
+        "result": {
+          "index": 3,
+          "captureIndices": [
+            {
+              "start": 7,
+              "end": 8,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "import { ref } from 'vue'\n",
+          14
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "</script>\n",
+          0
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 0,
+              "length": 0
+            }
+          ]
+        }
+      },
       {
         "args": [
           "<script setup>\n",
@@ -791,6 +1268,70 @@
         "args": [
           "import { ref } from 'vue'\n",
           12
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 13,
+              "end": 14,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "import { ref } from 'vue'\n",
+          8
+        ],
+        "result": {
+          "index": 83,
+          "captureIndices": [
+            {
+              "start": 9,
+              "end": 12,
+              "length": 3
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "import { ref } from 'vue'\n",
+          12
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 13,
+              "end": 14,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<div>{{ foo }}</div>\n",
+          6
+        ],
+        "result": {
+          "index": 26,
+          "captureIndices": [
+            {
+              "start": 6,
+              "end": 7,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<div>{{ foo }}</div>\n",
+          13
         ],
         "result": {
           "index": 0,
@@ -981,6 +1522,20 @@
       },
       {
         "args": [
+          "</script>\n",
+          9
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "</template>\n",
+          11
+        ],
+        "result": null
+      },
+      {
+        "args": [
           "</template>\n",
           11
         ],
@@ -996,6 +1551,98 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "<template>\n",
+          0
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 10,
+              "length": 10
+            },
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 1,
+              "end": 9,
+              "length": 8
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 9,
+              "end": 10,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "</template>\n",
+          11
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 11,
+              "end": 11,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            }
+          ]
+        }
+      },
       {
         "args": [
           "<template>\n",
@@ -1268,6 +1915,174 @@
             }
           ]
         }
+      },
+      {
+        "args": [
+          "<template>\n",
+          10
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "<div>{{ foo }}</div>\n",
+          0
+        ],
+        "result": {
+          "index": 1,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 5,
+              "length": 5
+            },
+            {
+              "start": 0,
+              "end": 1,
+              "length": 1
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 1,
+              "end": 4,
+              "length": 3
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4,
+              "end": 5,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<div>{{ foo }}</div>\n",
+          5
+        ],
+        "result": {
+          "index": 3,
+          "captureIndices": [
+            {
+              "start": 5,
+              "end": 6,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<div>{{ foo }}</div>\n",
+          14
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 14,
+              "end": 20,
+              "length": 6
+            },
+            {
+              "start": 14,
+              "end": 16,
+              "length": 2
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 16,
+              "end": 19,
+              "length": 3
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 19,
+              "end": 20,
+              "length": 1
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<div>{{ foo }}</div>\n",
+          20
+        ],
+        "result": null
+      },
+      {
+        "args": [
+          "</template>\n",
+          0
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 0,
+              "end": 11,
+              "length": 11
+            },
+            {
+              "start": 0,
+              "end": 2,
+              "length": 2
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 2,
+              "end": 10,
+              "length": 8
+            },
+            {
+              "start": 4294967295,
+              "end": 4294967295,
+              "length": 0
+            },
+            {
+              "start": 10,
+              "end": 11,
+              "length": 1
+            }
+          ]
+        }
       }
     ]
   },
@@ -1297,6 +2112,43 @@
       ]
     ],
     "executions": [
+      {
+        "args": [
+          "<div>{{ foo }}</div>\n",
+          7
+        ],
+        "result": {
+          "index": 13,
+          "captureIndices": [
+            {
+              "start": 8,
+              "end": 12,
+              "length": 4
+            },
+            {
+              "start": 8,
+              "end": 11,
+              "length": 3
+            }
+          ]
+        }
+      },
+      {
+        "args": [
+          "<div>{{ foo }}</div>\n",
+          12
+        ],
+        "result": {
+          "index": 0,
+          "captureIndices": [
+            {
+              "start": 12,
+              "end": 13,
+              "length": 1
+            }
+          ]
+        }
+      },
       {
         "args": [
           "<div>{{ foo }}</div>\n",

--- a/packages/types/src/highlighter.ts
+++ b/packages/types/src/highlighter.ts
@@ -16,6 +16,11 @@ import type {
 import type { Awaitable, MaybeArray } from './utils'
 
 /**
+ * Type of object that can be bound to a grammar state
+ */
+export type GrammarStateMapKey = Root | ThemedToken[][]
+
+/**
  * Internal context of Shiki, core textmate logic
  */
 export interface ShikiInternal<BundledLangKeys extends string = never, BundledThemeKeys extends string = never> {
@@ -127,10 +132,10 @@ export interface HighlighterGeneric<BundledLangKeys extends string, BundledTheme
    * Get the last grammar state of a code snippet.
    * You can pass the grammar state to `codeToTokens` as `grammarState` to continue tokenizing from an intermediate state.
    */
-  getLastGrammarState: (
-    code: string,
-    options: CodeToTokensBaseOptions<ResolveBundleKey<BundledLangKeys>, ResolveBundleKey<BundledThemeKeys>>
-  ) => GrammarState
+  getLastGrammarState: {
+    (element: GrammarStateMapKey, options?: never): GrammarState | undefined
+    (code: string, options: CodeToTokensBaseOptions<ResolveBundleKey<BundledLangKeys>, ResolveBundleKey<BundledThemeKeys>>): GrammarState
+  }
 
   /**
    * Get internal context object

--- a/packages/types/src/tokens.ts
+++ b/packages/types/src/tokens.ts
@@ -1,4 +1,4 @@
-import type { FontStyle, IRawThemeSetting } from '@shikijs/vscode-textmate'
+import type { FontStyle, IRawThemeSetting, StateStack } from '@shikijs/vscode-textmate'
 import type { SpecialLanguage } from './langs'
 import type { CodeOptionsThemes } from './options'
 import type { SpecialTheme, ThemeRegistrationAny } from './themes'
@@ -11,6 +11,15 @@ import type { SpecialTheme, ThemeRegistrationAny } from './themes'
 export interface GrammarState {
   readonly lang: string
   readonly theme: string
+  readonly themes: string[]
+  /**
+   * @internal
+   */
+  getInternalStack: (theme?: string) => StateStack | undefined
+  getScopes: (theme?: string) => string[] | undefined
+  /**
+   * @deprecated Use `getScopes` instead.
+   */
   get scopes(): string[]
 }
 
@@ -238,4 +247,9 @@ export interface TokensResult {
    * When specified, `fg` and `bg` will be ignored.
    */
   rootStyle?: string
+
+  /**
+   * The last grammar state of the code snippet.
+   */
+  grammarState?: GrammarState
 }


### PR DESCRIPTION
In https://github.com/shikijs/shiki/pull/712, we introduced GrammarState to resume the highlighting from the middle way. It solves the problem of customizing grammar context, but wasn't very useful for passable highlighting (for example, in a text editor, instead of highlighting the full context again over again, we can reuse the result from the previously highlighted lines) - because users need to run the parsing twice to get the `GrammarState` object. The existing API wasn't designed to be able to return extra property, making it hard to return the `GrammarState` in one-go, without breaking changes.

This PR overcharges the `shiki.getLastGrammarState()` function to be able to accept the return Hast `Root` or `ThemedToken[][]` to retrieve the `GrammarState` stored in a internal WeakMap. Make the usage more performent.

Along the way, we also made `GrammarState` work with multiple themes by storing multiple internal state for each theme.

The usage would be like:

```ts
const shiki = await getHighlighter(/*...*/)

const hast = shiki.codeToHast(/* ... */)

const grammarState = shiki.getLastGrammarState(hash) // pass the hast instead of code
```

close #803