### PR TITLE
fix(rehype): support special languages

### DIFF
--- a/packages/rehype/src/core.ts
+++ b/packages/rehype/src/core.ts
@@ -6,6 +6,7 @@ import type { Root } from 'hast'
 import type { Transformer } from 'unified'
 import type { RehypeShikiHandler } from './handlers'
 import type { RehypeShikiCoreOptions } from './types'
+import { isSpecialLang } from 'shiki/core'
 import { visit } from 'unist-util-visit'
 import { InlineCodeHandlers, PreHandler } from './handlers'
 
@@ -92,7 +93,7 @@ function rehypeShikiFromHighlighter(
       if (!lang)
         return defaultLanguage
 
-      if (highlighter.getLoadedLanguages().includes(lang))
+      if (highlighter.getLoadedLanguages().includes(lang) || isSpecialLang(lang))
         return lang
 
       if (lazy) {

--- a/packages/rehype/test/fixtures/a.core.out.html
+++ b/packages/rehype/test/fixtures/a.core.out.html
@@ -5,3 +5,4 @@
 <span class="line highlighted"><span style="color:#AB5959">const</span><span style="color:#B07D48"> a</span><span style="color:#999999"> =</span><span style="color:#2F798A"> 1</span></span>
 <span class="line highlighted"><span style="color:#B07D48">console</span><span style="color:#999999">.</span><span style="color:#59873A">log</span><span style="color:#999999">(</span><span style="color:#B07D48">a</span><span style="color:#999999">)</span></span></code></pre>
 <pre class="shiki vitesse-light" style="background-color:#ffffff;color:#393a34" tabindex="0"><code><span class="line"><span>Should fallback to default language</span></span></code></pre>
+<pre class="shiki vitesse-light" style="background-color:#ffffff;color:#393a34" tabindex="0"><code><span class="line"><span>Special languages should be styled</span></span></code></pre>

--- a/packages/rehype/test/fixtures/a.md
+++ b/packages/rehype/test/fixtures/a.md
@@ -12,3 +12,7 @@ console.log(a)
 ```
 Should fallback to default language
 ```
+
+```plaintext
+Special languages should be styled
+```

--- a/packages/rehype/test/fixtures/a.out.html
+++ b/packages/rehype/test/fixtures/a.out.html
@@ -5,3 +5,4 @@
 <span class="line highlighted"><span style="color:#AB5959">const</span><span style="color:#B07D48"> </span><span style="color:#B07D48" class="highlighted-word">a</span><span style="color:#999999"> =</span><span style="color:#2F798A"> 1</span></span>
 <span class="line highlighted"><span style="color:#B07D48">console</span><span style="color:#999999">.</span><span style="color:#59873A">log</span><span style="color:#999999">(</span><span style="color:#B07D48" class="highlighted-word">a</span><span style="color:#999999">)</span></span></code></pre>
 <pre class="shiki vitesse-light" style="background-color:#ffffff;color:#393a34" tabindex="0"><code><span class="line"><span>Should fallback to default language</span></span></code></pre>
+<pre class="shiki vitesse-light" style="background-color:#ffffff;color:#393a34" tabindex="0"><code><span class="line"><span>Special languages should be styled</span></span></code></pre>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Currently, special languages like `plaintext` and `txt` are treated as normal languages.

When `lazy` is not enabled, codeblocks with special languages will be ignored because `highlighter.getLoadedLanguages()` will never contain these languages.

This PR adds a check for `isSpecialLang` to allow styling codeblocks with special languages.

### Linked Issues

#805 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
