### PR TITLE
feat(core): codeToHast supports generating lang-xx on code element

### DIFF
--- a/packages/core/src/highlight/code-to-hast.ts
+++ b/packages/core/src/highlight/code-to-hast.ts
@@ -34,7 +34,9 @@ export function codeToHast(
 ): Root {
   let input = code
 
-  for (const transformer of getTransformers(options))
+  const transformers = getTransformers(options)
+
+  for (const transformer of transformers)
     input = transformer.preprocess?.call(transformerContext, input, options) || input
 
   let {
@@ -62,7 +64,7 @@ export function codeToHast(
     },
   }
 
-  for (const transformer of getTransformers(options))
+  for (const transformer of transformers)
     tokens = transformer.tokens?.call(contextSource, tokens) || tokens
 
   return tokensToHast(
@@ -96,14 +98,23 @@ export function tokensToHast(
   const {
     structure = 'classic',
     tabindex = '0',
+    themeName,
+    lang,
+    rootStyle,
+    bg,
+    fg,
+    meta = {},
+    addLanguageClass,
   } = options
+
+  const classes = `shiki ${themeName || ''}`
 
   let preNode: Element = {
     type: 'element',
     tagName: 'pre',
     properties: {
-      class: `shiki ${options.themeName || ''}`,
-      style: options.rootStyle || `background-color:${options.bg};color:${options.fg}`,
+      class: classes,
+      style: rootStyle || `background-color:${bg};color:${fg}`,
       ...(tabindex !== false && tabindex != null)
         ? {
             tabindex: tabindex.toString(),
@@ -111,7 +122,7 @@ export function tokensToHast(
         : {},
       ...Object.fromEntries(
         Array.from(
-          Object.entries(options.meta || {}),
+          Object.entries(meta),
         )
           .filter(([key]) => !key.startsWith('_')),
       ),
@@ -122,7 +133,11 @@ export function tokensToHast(
   let codeNode: Element = {
     type: 'element',
     tagName: 'code',
-    properties: {},
+    properties: addLanguageClass
+      ? {
+          class: `${options.lang ? `language-${lang}` : ''}`,
+        }
+      : {},
     children: lines,
   }
 

--- a/packages/shiki/test/hast.test.ts
+++ b/packages/shiki/test/hast.test.ts
@@ -94,3 +94,26 @@ it('render whitespace', async () => {
       <span class="line"><span style="color:#59873A">		tab</span><span style="color:#999999">()</span></span></code></pre>"
     `)
 })
+
+it('render-lang-class', async () => {
+  const snippet = `
+    \`\`\`js
+    console.log('hello')
+    \`\`\`
+  `
+
+  const code = await codeToHtml(snippet, {
+    lang: 'js',
+    theme: 'vitesse-light',
+    addLanguageClass: true,
+  })
+
+  expect(code)
+    .toMatchInlineSnapshot(`
+      "<pre class="shiki vitesse-light" style="background-color:#ffffff;color:#393a34" tabindex="0"><code class="language-js"><span class="line"></span>
+      <span class="line"><span style="color:#B5695977">    \`\`\`</span><span style="color:#B56959">js</span></span>
+      <span class="line"><span style="color:#B56959">    console.log('hello')</span></span>
+      <span class="line"><span style="color:#B5695977">    \`\`\`</span></span>
+      <span class="line"><span style="color:#393A34">  </span></span></code></pre>"
+    `)
+})

--- a/packages/shiki/test/hast.test.ts
+++ b/packages/shiki/test/hast.test.ts
@@ -95,7 +95,7 @@ it('render whitespace', async () => {
     `)
 })
 
-it('render-lang-class', async () => {
+it('render lang class', async () => {
   const snippet = `
     \`\`\`js
     console.log('hello')

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -163,6 +163,13 @@ export interface CodeToHastOptionsCommon<Languages extends string = string>
    * @default 0
    */
   tabindex?: number | string | false
+
+  /**
+   * Add `language-*` class to code element
+   *
+   * @default false
+   */
+  addLanguageClass?: boolean
 }
 
 export interface CodeOptionsMeta {


### PR DESCRIPTION

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`codeToHast` supports generating language class on `code` element

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

#629 

### Additional context

In this #629 , he also hopes to support `meta data`. I found that there are already relevant data in `codeToHast`, but I observed that the relevant data has been filtered out, so I don't know how to deal with it appropriately. Therefore, there is no relevant logic for now in this PR.

![image](https://github.com/user-attachments/assets/5c4ca2d0-6780-4a6b-8daa-836f4931110e)

https://github.com/shikijs/shiki/blob/f76a371dbc2752cba341023df00ebfe9b66cb3f6/packages/core/src/highlight/code-to-hast.ts#L113-L116
<!-- e.g. is there anything you'd like reviewers to focus on? -->
