### PR TITLE
docs: update Slidev & Nuxt links

### DIFF
--- a/docs/packages/twoslash.md
+++ b/docs/packages/twoslash.md
@@ -159,7 +159,7 @@ In markdown, you can use the following syntax to trigger Twoslash:
 While you can set up Twoslash with Shiki on your own with the instructions above, you can also find high-level integrations with frameworks and tools here:
 
 - [VitePress](/packages/vitepress#twoslash) - A plugin to enable Twoslash support in VitePress.
-- [Nuxt](/packages/nuxt#twoslash) - A module to enable Twoslash for Nuxt Content.
+- [Nuxt](/packages/nuxt#twoslash-integration) - A module to enable Twoslash for Nuxt Content.
 - [Vocs](https://vocs.dev/docs/guides/twoslash) - Vocs has TwoSlash support built-in.
 - [Slidev](https://sli.dev/features/twoslash#twoslash-integration) - Slidev has TwoSlash support built-in.
 

--- a/docs/packages/twoslash.md
+++ b/docs/packages/twoslash.md
@@ -161,7 +161,7 @@ While you can set up Twoslash with Shiki on your own with the instructions above
 - [VitePress](/packages/vitepress#twoslash) - A plugin to enable Twoslash support in VitePress.
 - [Nuxt](/packages/nuxt#twoslash) - A module to enable Twoslash for Nuxt Content.
 - [Vocs](https://vocs.dev/docs/guides/twoslash) - Vocs has TwoSlash support built-in.
-- [Slidev](https://sli.dev/custom/highlighters.html#twoslash-integration) - Slidev has TwoSlash support built-in.
+- [Slidev](https://sli.dev/features/twoslash#twoslash-integration) - Slidev has TwoSlash support built-in.
 
 ## Recipes
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Update the links to integrations from  from https://shiki.style/packages/twoslash#integrations:
- Updated the link to Slidev integration
- Updated the link to Nuxt integration


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

None

### Additional context

When I was at https://shiki.style/packages/twoslash#integrations

1. The Slidev link pointed to the 404 page. The TwoSlash Integration has been moved to https://sli.dev/features/twoslash#twoslash-integration therefore updating it in docs.

2. The Nuxt link pointed to non-existing hash (i.e. `#twoslash`) while the correct one was `#twoslash-integration`

<!-- e.g. is there anything you'd like reviewers to focus on? -->
