### PR TITLE
fix(core): `createdBundledHighlighter` cause wasm engine to be loaded

### DIFF
--- a/packages/core/src/constructors/bundle-factory.ts
+++ b/packages/core/src/constructors/bundle-factory.ts
@@ -120,7 +120,7 @@ export function createdBundledHighlighter<BundledLangs extends string, BundledTh
       .map(i => resolveLang(i as BundledLangs))
 
     const core = await createHighlighterCore({
-      engine: engine(),
+      engine: options.engine ?? engine(),
       ...options,
       themes: _themes,
       langs,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

While playing with JavaScript Regex engine and `getSingletonHighlighter`, I noticed that the WASM engine was loaded regardless of my `engine` option, and it is indeed using the JavaScript engine.

After looking into the codebase, I found:

```ts
    const core = await createHighlighterCore({
      engine: engine(),
```

In the code of `createdBundledHighlighter` (highlighter factory), this causes `engine` to be called and hence the WASM engine is loaded with lazy import, even if it is unused.

### Linked Issues

N/A

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
