### PR TITLE
feat(rehype): Add fallback language support for lazy loading in rehype-shiki

### DIFF
--- a/packages/rehype/src/core.ts
+++ b/packages/rehype/src/core.ts
@@ -6,6 +6,7 @@ import type { Root } from 'hast'
 import type { Transformer } from 'unified'
 import type { RehypeShikiHandler } from './handlers'
 import type { RehypeShikiCoreOptions } from './types'
+import { bundledLanguages } from 'shiki'
 import { isSpecialLang } from 'shiki/core'
 import { visit } from 'unist-util-visit'
 import { InlineCodeHandlers, PreHandler } from './handlers'
@@ -97,6 +98,9 @@ function rehypeShikiFromHighlighter(
         return lang
 
       if (lazy) {
+        if (fallbackLanguage && !(Object.keys(bundledLanguages) as string[]).includes(lang)) {
+          lang = fallbackLanguage as string
+        }
         languageQueue.push(lang)
         return lang
       }

--- a/packages/rehype/src/core.ts
+++ b/packages/rehype/src/core.ts
@@ -94,11 +94,16 @@ function rehypeShikiFromHighlighter(
       if (!lang)
         return defaultLanguage
 
-      if (highlighter.getLoadedLanguages().includes(lang) || isSpecialLang(lang))
+      const isLoadedLanguage = highlighter.getLoadedLanguages().includes(lang)
+      if (isLoadedLanguage || isSpecialLang(lang))
         return lang
 
       if (lazy) {
-        if (fallbackLanguage && !(Object.keys(bundledLanguages) as string[]).includes(lang)) {
+        const isBundledLanguage = (Object.keys(bundledLanguages) as string[]).includes(lang)
+
+        if (fallbackLanguage
+          && !isLoadedLanguage
+          && !isBundledLanguage) {
           lang = fallbackLanguage as string
         }
         languageQueue.push(lang)

--- a/packages/rehype/src/types.ts
+++ b/packages/rehype/src/types.ts
@@ -26,7 +26,7 @@ export interface RehypeShikiExtraOptions {
   defaultLanguage?: string
 
   /**
-   * The fallback language to use when specified language is not loaded
+   * The fallback language to use when specified language is not loaded or unavailable
    *
    */
   fallbackLanguage?: string

--- a/packages/rehype/src/types.ts
+++ b/packages/rehype/src/types.ts
@@ -28,7 +28,6 @@ export interface RehypeShikiExtraOptions {
   /**
    * The fallback language to use when specified language is not loaded
    *
-   * Ignored if `lazy` is enabled
    */
   fallbackLanguage?: string
 

--- a/packages/rehype/test/core.test.ts
+++ b/packages/rehype/test/core.test.ts
@@ -63,6 +63,30 @@ it('run with lazy', async () => {
   expect(file.toString()).toMatchFileSnapshot('./fixtures/a.core.out.html')
 })
 
+it('run with lazy and fallback', async () => {
+  const highlighter = await createHighlighter({
+    themes: [
+      'vitesse-light',
+    ],
+    langs: [],
+  })
+
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkRehype)
+    .use(rehypeShikiFromHighlighter, highlighter, {
+      lazy: true,
+      theme: 'vitesse-light',
+      fallbackLanguage: 'text',
+      transformers: [
+        transformerMetaHighlight(),
+      ],
+    })
+    .use(rehypeStringify)
+    .process(await fs.readFile(new URL('./fixtures/d.md', import.meta.url)))
+
+  expect(file.toString()).toMatchFileSnapshot('./fixtures/d.core.out.html')
+})
 it('run with rehype-raw', async () => {
   const highlighter = await createHighlighter({
     themes: [

--- a/packages/rehype/test/fixtures/d.core.out.html
+++ b/packages/rehype/test/fixtures/d.core.out.html
@@ -1,0 +1,1 @@
+<pre class="shiki vitesse-light" style="background-color:#ffffff;color:#393a34" tabindex="0"><code><span class="line"><span>Should fallback to text</span></span></code></pre>

--- a/packages/rehype/test/fixtures/d.md
+++ b/packages/rehype/test/fixtures/d.md
@@ -1,0 +1,3 @@
+```x-text
+Should fallback to text
+```


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
```ts
 /**
   * The fallback language to use when specified language is not loaded
   *
   * Ignored if `lazy` is enabled
   */
  fallbackLanguage?: string
```
Previously, unsupported languages were ignored if `lazy` was enabled. 

This update assigns a fallback language when the requested language isn’t found, 
ensuring the fallback language is enabled.
 


### Linked Issues
N/A
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
