### PR TITLE
fix: typo STANDALONG -> STANDALONE in prepare script

### DIFF
--- a/packages/shiki/scripts/prepare/langs.ts
+++ b/packages/shiki/scripts/prepare/langs.ts
@@ -31,7 +31,7 @@ const LANGS_LAZY_EMBEDDED_PARTIAL = [
 /**
  * Languages to be excluded from SFC langs
  */
-const STANDALONG_LANGS_EMBEDDED = [
+const STANDALONE_LANGS_EMBEDDED = [
   'pug',
   'stylus',
   'sass',
@@ -85,8 +85,8 @@ export async function prepareLangs() {
       json.embeddedLangs = includes
     }
     else if (LANGS_LAZY_EMBEDDED_PARTIAL.includes(lang.name)) {
-      json.embeddedLangsLazy = (json.embeddedLangs || []).filter(i => STANDALONG_LANGS_EMBEDDED.includes(i)) || []
-      json.embeddedLangs = (json.embeddedLangs || []).filter(i => !STANDALONG_LANGS_EMBEDDED.includes(i)) || []
+      json.embeddedLangsLazy = (json.embeddedLangs || []).filter(i => STANDALONE_LANGS_EMBEDDED.includes(i)) || []
+      json.embeddedLangs = (json.embeddedLangs || []).filter(i => !STANDALONE_LANGS_EMBEDDED.includes(i)) || []
     }
 
     const deps: string[] = json.embeddedLangs || []


### PR DESCRIPTION
### Description

Fixes a typo in the language preparation script where `STANDALONG_LANGS_EMBEDDED` was misspelled. The constant is used to identify languages that should be kept standalone in the language bundling process.

Changed `STANDALONG` -> `STANDALONE` in the variable name to improve code readability and maintain consistent naming conventions.

### Linked Issues
N/A

### Additional context
This is a simple typo fix in the prepare script variable name. The functionality remains unchanged as this only affects the variable naming.