### PR TITLE
docs(transformers): clarify that shiki does not parse meta

### DIFF
--- a/docs/guide/transformers.md
+++ b/docs/guide/transformers.md
@@ -62,7 +62,7 @@ Transformers can also access markdown 'meta' strings in [supported integrations]
 
 ````markdown
 <!-- [!code word:meta=here] -->
-```html meta=here
+```html foo=bar baz-qux="qu ux"
 ````
 
 You can access the raw meta using:
@@ -71,5 +71,5 @@ You can access the raw meta using:
 
 ```ts
 options.meta
-// => { meta: 'here', __raw: 'meta=here' }
+// => { __raw: 'foo=bar baz-qux="qu ux"' }
 ```


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Currently the docs imply that Shiki provides a parsed meta object. This change removes that implication. This change also provides an example of dashcased meta attribute keys and quoted meta attribute values.

### Linked Issues

- #792

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
