### PR TITLE
feat: bump Oniguruma-To-ES dep to support more grammars and simplify

### DIFF
--- a/docs/guide/regex-engines.md
+++ b/docs/guide/regex-engines.md
@@ -77,11 +77,11 @@ The JavaScript engine is best when running in the browser and in cases when you 
 
 ### JavaScript Runtime Target
 
-For the most accurate result, [Oniguruma-To-ES](https://github.com/slevithan/oniguruma-to-es) requires the [RegExp `v` flag support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets), which is available in Node.js v20+ and ES2024 ([Browser compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets#browser_compatibility)).
+For the best result, [Oniguruma-To-ES](https://github.com/slevithan/oniguruma-to-es) uses the [RegExp `v` flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets), which is available in Node.js v20+ and ES2024 ([Browser compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets#browser_compatibility)).
 
-For older environments, it can simulate the behavior but `u` flag but might yield less accurate results.
+For older environments, it can use the `u` flag but somewhat fewer grammars are supported.
 
-By default, it automatically detects the runtime target and uses the appropriate behavior. You can override this behavior by setting the `target` option:
+By default, the runtime target is automatically detected. You can override this behavior by setting the `target` option:
 
 ```ts
 const jsEngine = createJavaScriptRegexEngine({

--- a/docs/references/engine-js-compat.md
+++ b/docs/references/engine-js-compat.md
@@ -2,20 +2,20 @@
 
 Compatibility reference of all built-in grammars with the [JavaScript RegExp engine](/guide/regex-engines#javascript-regexp-engine-experimental).
 
-> Genreated on Friday, November 15, 2024
+> Generated on Sunday, November 17, 2024
 >
 > Version `1.23.0`
 >
-> Runtime: Node.js v20.18.0
+> Runtime: Node.js v22.11.0
 
 ## Report Summary
 
 |                 |                        Count |
 | :-------------- | ---------------------------: |
-| Total Languages |                          214 |
-| Supported       |  [178](#supported-languages) |
-| Mismatched      |  [18](#mismatched-languages) |
-| Unsupported     | [18](#unsupported-languages) |
+| Total Languages |                          215 |
+| Supported       |  [192](#supported-languages) |
+| Mismatched      |  [10](#mismatched-languages) |
+| Unsupported     | [13](#unsupported-languages) |
 
 ## Supported Languages
 
@@ -37,21 +37,26 @@ In some edge cases, it's not guaranteed that the the highlighting will be 100% t
 | astro              | ✅ OK           |               613 |               - |      |
 | awk                | ✅ OK           |                36 |               - |      |
 | ballerina          | ✅ OK           |               230 |               - |      |
+| bash               | ✅ OK           |               148 |               - |      |
 | bat                | ✅ OK           |                58 |               - |      |
 | berry              | ✅ OK           |                18 |               - |      |
 | bibtex             | ✅ OK           |                19 |               - |      |
 | bicep              | ✅ OK           |                27 |               - |      |
+| blade              | ✅ OK           |              1126 |               - |      |
+| c                  | ✅ OK           |               177 |               - |      |
 | cadence            | ✅ OK           |                71 |               - |      |
+| cairo              | ✅ OK           |                80 |               - |      |
 | clarity            | ✅ OK           |                43 |               - |      |
 | clj                | ✅ OK           |                38 |               - |      |
 | clojure            | ✅ OK           |                38 |               - |      |
 | cmake              | ✅ OK           |                23 |               - |      |
-| cobol              | ✅ OK           |               864 |               - |      |
+| cobol              | ✅ OK           |               863 |               - |      |
 | codeowners         | ✅ OK           |                 4 |               - |      |
 | codeql             | ✅ OK           |               151 |               - |      |
 | coffee             | ✅ OK           |               469 |               - |      |
 | common-lisp        | ✅ OK           |                60 |               - |      |
 | coq                | ✅ OK           |                25 |               - |      |
+| crystal            | ✅ OK           |              1067 |               - |      |
 | css                | ✅ OK           |               141 |               - |      |
 | csv                | ✅ OK           |                 1 |               - |      |
 | cue                | ✅ OK           |                85 |               - |      |
@@ -65,9 +70,11 @@ In some edge cases, it's not guaranteed that the the highlighting will be 100% t
 | dotenv             | ✅ OK           |                 9 |               - |      |
 | dream-maker        | ✅ OK           |                56 |               - |      |
 | edge               | ✅ OK           |               632 |               - |      |
+| elixir             | ✅ OK           |               708 |               - |      |
 | elm                | ✅ OK           |               244 |               - |      |
 | emacs-lisp         | ✅ OK           |               153 |               - |   22 |
 | erb                | ✅ OK           |              1312 |               - |      |
+| erlang             | ✅ OK           |               147 |               - |      |
 | fennel             | ✅ OK           |                31 |               - |      |
 | fish               | ✅ OK           |                25 |               - |      |
 | fluent             | ✅ OK           |                23 |               - |      |
@@ -82,6 +89,7 @@ In some edge cases, it's not guaranteed that the the highlighting will be 100% t
 | gleam              | ✅ OK           |                26 |               - |      |
 | glimmer-js         | ✅ OK           |               676 |               - |      |
 | glimmer-ts         | ✅ OK           |               676 |               - |      |
+| glsl               | ✅ OK           |               186 |               - |      |
 | gnuplot            | ✅ OK           |                82 |               - |      |
 | go                 | ✅ OK           |               123 |               - |      |
 | graphql            | ✅ OK           |               448 |               - |      |
@@ -120,15 +128,16 @@ In some edge cases, it's not guaranteed that the the highlighting will be 100% t
 | make               | ✅ OK           |                51 |               - |      |
 | marko              | ✅ OK           |               926 |               - |      |
 | matlab             | ✅ OK           |                88 |               - |      |
+| mdx                | ✅ OK           |               197 |               - |      |
 | mipsasm            | ✅ OK           |                17 |               - |      |
 | mojo               | ✅ OK           |               213 |               - |      |
 | move               | ✅ OK           |               120 |               - |      |
 | narrat             | ✅ OK           |                34 |               - |      |
-| nextflow           | ✅ OK           |                17 |               - |      |
-| nginx              | ✅ OK           |               378 |               - |      |
+| nextflow           | ✅ OK           |                32 |               - |      |
 | nix                | ✅ OK           |                80 |               - |      |
 | nushell            | ✅ OK           |                81 |               - |      |
 | objective-c        | ✅ OK           |               223 |               - |      |
+| objective-cpp      | ✅ OK           |               309 |               - |      |
 | ocaml              | ✅ OK           |               178 |               - |      |
 | pascal             | ✅ OK           |                23 |               - |      |
 | perl               | ✅ OK           |               941 |               - |      |
@@ -145,12 +154,13 @@ In some edge cases, it's not guaranteed that the the highlighting will be 100% t
 | qmldir             | ✅ OK           |                 7 |               - |      |
 | qss                | ✅ OK           |                31 |               - |      |
 | r                  | ✅ OK           |                71 |               - |      |
-| racket             | ✅ OK           |                69 |               - |      |
+| racket             | ✅ OK           |                69 |               - |    8 |
 | raku               | ✅ OK           |                52 |               - |      |
 | reg                | ✅ OK           |                 9 |               - |      |
 | regexp             | ✅ OK           |                34 |               - |      |
 | rel                | ✅ OK           |                17 |               - |      |
 | riscv              | ✅ OK           |                36 |               - |      |
+| ruby               | ✅ OK           |              1307 |               - |      |
 | rust               | ✅ OK           |                89 |               - |      |
 | sas                | ✅ OK           |               101 |               - |      |
 | sass               | ✅ OK           |                69 |               - |      |
@@ -158,7 +168,9 @@ In some edge cases, it's not guaranteed that the the highlighting will be 100% t
 | scheme             | ✅ OK           |                34 |               - |      |
 | scss               | ✅ OK           |               234 |               - |      |
 | shaderlab          | ✅ OK           |                87 |               - |      |
+| shellscript        | ✅ OK           |               148 |               - |      |
 | shellsession       | ✅ OK           |               150 |               - |      |
+| smalltalk          | ✅ OK           |                35 |               - |      |
 | solidity           | ✅ OK           |               102 |               - |      |
 | soy                | ✅ OK           |               649 |               - |      |
 | sparql             | ✅ OK           |                19 |               - |      |
@@ -167,7 +179,7 @@ In some edge cases, it's not guaranteed that the the highlighting will be 100% t
 | ssh-config         | ✅ OK           |                12 |               - |      |
 | stata              | ✅ OK           |               253 |               - |      |
 | stylus             | ✅ OK           |               107 |               - |      |
-| svelte             | ✅ OK           |               636 |               - |      |
+| svelte             | ✅ OK           |               637 |               - |      |
 | system-verilog     | ✅ OK           |               102 |               - |      |
 | systemd            | ✅ OK           |                32 |               - |      |
 | tasl               | ✅ OK           |                23 |               - |      |
@@ -197,11 +209,13 @@ In some edge cases, it's not guaranteed that the the highlighting will be 100% t
 | wenyan             | ✅ OK           |                18 |               - |      |
 | wgsl               | ✅ OK           |                44 |               - |      |
 | wikitext           | ✅ OK           |               104 |               - |      |
+| wolfram            | ✅ OK           |               501 |               - |      |
 | xml                | ✅ OK           |               169 |               - |      |
 | xsl                | ✅ OK           |               171 |               - |      |
 | yaml               | ✅ OK           |                48 |               - |      |
 | zenscript          | ✅ OK           |                21 |               - |      |
 | zig                | ✅ OK           |                51 |               - |      |
+| zsh                | ✅ OK           |               148 |               - |      |
 
 ###### Table Field Explanations
 
@@ -214,26 +228,18 @@ In some edge cases, it's not guaranteed that the the highlighting will be 100% t
 
 Languages that do not throw with the JavaScript RegExp engine, but will produce different results than the WASM engine. Please use with caution.
 
-| Language      | Highlight Match                                                                    | Patterns Parsable | Patterns Failed | Diff |
-| ------------- | :--------------------------------------------------------------------------------- | ----------------: | --------------: | ---: |
-| bash          | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=bash)          |               148 |               - |   56 |
-| beancount     | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=beancount)     |                39 |               - |  171 |
-| c             | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=c)             |               177 |               - |  209 |
-| crystal       | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=crystal)       |              1067 |               - |   40 |
-| elixir        | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=elixir)        |               708 |               - |  179 |
-| erlang        | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=erlang)        |               147 |               - |  470 |
-| glsl          | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=glsl)          |               186 |               - |  306 |
-| kotlin        | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=kotlin)        |                58 |               - | 1953 |
-| kusto         | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=kusto)         |                60 |               - |   40 |
-| mermaid       | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=mermaid)       |               129 |               - |   38 |
-| objective-cpp | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=objective-cpp) |               309 |               - |  172 |
-| php           | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=php)           |              1131 |               - |  605 |
-| po            | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=po)            |                23 |               - |  423 |
-| pug           | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=pug)           |               686 |               - |  164 |
-| ruby          | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=ruby)          |              1307 |               - |    1 |
-| shellscript   | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=shellscript)   |               148 |               - |   56 |
-| smalltalk     | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=smalltalk)     |                35 |               - |   40 |
-| zsh           | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=zsh)           |               148 |               - |  117 |
+| Language  | Highlight Match                                                                | Patterns Parsable | Patterns Failed | Diff |
+| --------- | :----------------------------------------------------------------------------- | ----------------: | --------------: | ---: |
+| apex      | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=apex)      |               187 |               - |  236 |
+| beancount | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=beancount) |                39 |               - |  171 |
+| haskell   | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=haskell)   |               157 |               - |   39 |
+| kotlin    | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=kotlin)    |                58 |               - | 1953 |
+| kusto     | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=kusto)     |                60 |               - |   40 |
+| mermaid   | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=mermaid)   |               129 |               - |   38 |
+| nginx     | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=nginx)     |               378 |               - |    4 |
+| php       | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=php)       |              1131 |               - |  605 |
+| po        | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=po)        |                23 |               - |  423 |
+| pug       | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=pug)       |               686 |               - |  164 |
 
 ## Unsupported Languages
 
@@ -242,20 +248,15 @@ Languages that throw with the JavaScript RegExp engine, either because they cont
 | Language   | Highlight Match                                                          | Patterns Parsable | Patterns Failed | Diff |
 | ---------- | :----------------------------------------------------------------------- | ----------------: | --------------: | ---: |
 | ada        | ✅ OK                                                                    |               201 |               1 |      |
-| blade      | ✅ OK                                                                    |              1125 |               1 |      |
-| fsharp     | ✅ OK                                                                    |               234 |               5 |      |
-| nim        | ✅ OK                                                                    |              1121 |               5 |      |
-| julia      | ✅ OK                                                                    |              1147 |              21 |      |
-| rst        | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=rst) |              1836 |              21 |   62 |
+| julia      | ✅ OK                                                                    |              1166 |               2 |      |
+| fsharp     | ✅ OK                                                                    |               236 |               3 |      |
+| nim        | ✅ OK                                                                    |              1123 |               3 |      |
+| rst        | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=rst) |              1855 |               2 |   62 |
 | hack       | ❌ Error                                                                 |               947 |               1 |  114 |
-| haskell    | ❌ Error                                                                 |               156 |               1 |  143 |
-| wolfram    | ❌ Error                                                                 |               500 |               1 |   12 |
-| purescript | ❌ Error                                                                 |                71 |               2 |   36 |
+| purescript | ❌ Error                                                                 |                72 |               1 |   42 |
+| cpp        | ❌ Error                                                                 |               510 |               2 |    8 |
+| csharp     | ❌ Error                                                                 |               306 |               3 |  204 |
+| markdown   | ❌ Error                                                                 |               115 |               3 |  857 |
 | swift      | ❌ Error                                                                 |               326 |               3 |   40 |
-| mdx        | ❌ Error                                                                 |               193 |               4 |      |
-| markdown   | ❌ Error                                                                 |               113 |               5 |  193 |
-| mdc        | ❌ Error                                                                 |               778 |               6 |  389 |
-| apex       | ❌ Error                                                                 |               175 |              12 |  269 |
-| cpp        | ❌ Error                                                                 |               491 |              21 |   25 |
-| csharp     | ❌ Error                                                                 |               281 |              28 |  207 |
-| razor      | ❌ Error                                                                 |               927 |              30 |   26 |
+| mdc        | ❌ Error                                                                 |               779 |               4 |      |
+| razor      | ❌ Error                                                                 |               952 |               5 |   22 |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ catalogs:
       specifier: ^1.4.1
       version: 1.4.1
     oniguruma-to-es:
-      specifier: 0.1.2
-      version: 0.1.2
+      specifier: 0.4.1
+      version: 0.4.1
     picocolors:
       specifier: ^1.1.1
       version: 1.1.1
@@ -553,7 +553,7 @@ importers:
         version: 9.3.0
       oniguruma-to-es:
         specifier: 'catalog:'
-        version: 0.1.2
+        version: 0.4.1
 
   packages/engine-oniguruma:
     dependencies:
@@ -4250,8 +4250,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  oniguruma-to-es@0.1.2:
-    resolution: {integrity: sha512-sBYKVJlIMB0WPO+tSu/NNB1ytSFeHyyJZ3Ayxfx3f/QUuXu0lvZk0VB4K7npmdlHSC0ldqanzh/sUSlAbgCTfw==}
+  oniguruma-to-es@0.4.1:
+    resolution: {integrity: sha512-rNcEohFz095QKGRovP/yqPIKc+nP+Sjs4YTHMv33nMePGKrq/r2eu9Yh4646M5XluGJsUnmwoXuiXE69KDs+fQ==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -4639,14 +4639,14 @@ packages:
     resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  regex-recursion@4.1.0:
-    resolution: {integrity: sha512-HZATaE4VEmNarD27CNferql3tYivhYAFfo/jLzvd2+eXIwjJp3VCp11uf2isTcuc4WpuaQtYISMXkiPi8G+xdg==}
+  regex-recursion@4.2.1:
+    resolution: {integrity: sha512-QHNZyZAeKdndD1G3bKAbBEKOSSK4KOHQrAJ01N1LJeb0SoH4DJIeFhp0uUpETgONifS4+P3sOgoA1dhzgrQvhA==}
 
   regex-utilities@2.3.0:
     resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
 
-  regex@4.4.0:
-    resolution: {integrity: sha512-uCUSuobNVeqUupowbdZub6ggI5/JZkYyJdDogddJr60L764oxC2pMZov1fQ3wM9bdyzUILDG+Sqx6NAKAz9rKQ==}
+  regex@5.0.0:
+    resolution: {integrity: sha512-LO5oiSc2Kgbw1qlSQIkzeqapoPeOP3y4DxNoxjTDpuECk6xNcADfN2rJhmOxJSgrv8vQOcgbKSFuyfyPfMmlxw==}
 
   regexp-ast-analysis@0.7.1:
     resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
@@ -9502,11 +9502,11 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  oniguruma-to-es@0.1.2:
+  oniguruma-to-es@0.4.1:
     dependencies:
       emoji-regex-xs: 1.0.0
-      regex: 4.4.0
-      regex-recursion: 4.1.0
+      regex: 5.0.0
+      regex-recursion: 4.2.1
 
   optionator@0.9.4:
     dependencies:
@@ -9849,13 +9849,13 @@ snapshots:
     dependencies:
       '@eslint-community/regexpp': 4.12.1
 
-  regex-recursion@4.1.0:
+  regex-recursion@4.2.1:
     dependencies:
       regex-utilities: 2.3.0
 
   regex-utilities@2.3.0: {}
 
-  regex@4.4.0: {}
+  regex@5.0.0: {}
 
   regexp-ast-analysis@0.7.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,7 +53,7 @@ catalog:
   minimist: ^1.2.8
   monaco-editor-core: ^0.52.0
   ofetch: ^1.4.1
-  oniguruma-to-es: 0.1.2
+  oniguruma-to-es: 0.4.1
   picocolors: ^1.1.1
   pinia: ^2.2.6
   pnpm: ^9.13.2

--- a/scripts/report-engine-js-compat.ts
+++ b/scripts/report-engine-js-compat.ts
@@ -204,7 +204,7 @@ async function run() {
     '',
     'Compatibility reference of all built-in grammars with the [JavaScript RegExp engine](/guide/regex-engines#javascript-regexp-engine-experimental).',
     '',
-    `> Genreated on ${new Date().toLocaleDateString('en-US', { dateStyle: 'full' })} `,
+    `> Generated on ${new Date().toLocaleDateString('en-US', { dateStyle: 'full' })} `,
     '>',
     `> Version \`${version}\``,
     '>',


### PR DESCRIPTION
### Description

- Shiki 1.23.0
  - 178 supported, 18 mismatched, and 18 unsupported.
  - *Forgiving:* **183** supported, 31 mismatched, 0 unsupported.
- With this PR 🎉
  - 192 supported, 10 mismatched, 13 unsupported.
  - *Forgiving:* **197** supported, 18 mismatched, 0 unsupported.

(The *forgiving* supported count is more accurate, since it's copying the Oniguruma engine's behavior of silently failing for regexes with invalid Oniguruma syntax.)


Changes that enabled this improvement are described in the `Oniguruma-To-ES` [release notes](https://github.com/slevithan/oniguruma-to-es/releases) for versions 0.3.0 and 0.4.0.

Is this still experimental? Probably. But I thought I'd raise the question since, although it can continue to improve in various ways (supporting a few more grammars, improving performance, etc.), IMO the foundations for a strong JS engine are now in place. The strongest claim for it still being experimental is that we use `'loose'` [accuracy](https://github.com/slevithan/oniguruma-to-es#accuracy) instead of `'default'` (allowing some inaccurate `\G` handling). But unless you plan to not use `'loose'` (and drop the count of supported grammars), there will always be some inaccurate use of `\G` with some target strings.

### Additional context

Feel free to undo or improve any of my documentation edits!

I removed the `target: 'auto'` handling because it's now built into `Oniguruma-To-ES`, and it auto-selects `ES2025` for Node.js 23 and other compatible environments.

I also removed the `simulation` option because its last remaining functionality was removed. I was wrong earlier when I said I might need to bring some of its former handling back.

### More context on `simulation`

The `(^|\\\uFFFF)` to `(^|\\G)` substitution it was doing was no longer having any effect on the number of supported grammars, but it actually *was* lowering the diff count somewhat for mismatched grammars. However, that slight improvement wasn't happening for good, predictable, or easily understandable reasons, which is why I'm removing it. `Oniguruma-To-ES`, in `'loose'` accuracy mode, handles many `\G` anchors accurately but plays fast and loose with some others (like `oniguruma-to-js` did before it). As a result of this not-always-accurate handling, the effects of tweaking various things related to `\G` is unpredictable in whether it will improve or hurt the diff count. E.g., not applying `Oniguruma-To-ES`'s advanced subclass-based `\G` handling *improves* diff count a little when using `loose` accuracy (very unexpected), but it dramatically hurts results if using `default` or `strict` accuracy. And adding additional pre-substitutions for additional ways that `\G` is used in patterns, like swapping `(?!\\\uFFFF)` with `(?!\\G)`, *hurts* the diff count. So, it's only this specific case of `(^|\\\uFFFF)` that happens to slightly improve the numbers on-balance for non-obvious reasons related to which specific patterns are made sticky, etc.

However, I think we want to not focus too much on hyper-optimizing the diff count for specific samples with grammars that are mismatched anyway, and instead make things as predictable and easy to reason about as possible, especially now that the numbers are very solid without hacks like this.

#### What's actually going on with `\\\uFFFF`?

After investigating more what's going on in `vscode-textmate`, it's replacing `\A` and `\G` anchors with `\<literal \uFFFF>` when it ***wants*** `\A` and `\G` anchors to fail to match (for a couple different reasons), so it's correct to respect this and NOT bring some of these `\G`s back. The `vscode-textmate` authors should have used something like `(?!)` to be more explicit and not have edge cases where it inappropriately *does* match certain strings, but no matter. In general, *all* of the various magical pattern substitutions in `vscode-textmate` (for `\A`, `\G`, `\z`, and backreferences) are implemented in hacky and flawed ways, e.g. not correctly accounting for things like escaped backslashes, enclosed numbered backrefs, etc. 😓