### PR TITLE
feat: bump js engine dependencies to support more grammars

### DIFF
--- a/docs/references/engine-js-compat.md
+++ b/docs/references/engine-js-compat.md
@@ -2,7 +2,7 @@
 
 Compatibility reference of all built-in grammars with the [JavaScript RegExp engine](/guide/regex-engines#javascript-regexp-engine-experimental).
 
-> Generated on Sunday, November 24, 2024
+> Generated on Wednesday, November 27, 2024
 >
 > Version `1.23.1`
 >
@@ -10,12 +10,12 @@ Compatibility reference of all built-in grammars with the [JavaScript RegExp eng
 
 ## Report Summary
 
-|                 |                        Count |
-| :-------------- | ---------------------------: |
-| Total Languages |                          215 |
-| Supported       |  [193](#supported-languages) |
-| Mismatched      |   [9](#mismatched-languages) |
-| Unsupported     | [13](#unsupported-languages) |
+|                 |                       Count |
+| :-------------- | --------------------------: |
+| Total Languages |                         215 |
+| Supported       | [197](#supported-languages) |
+| Mismatched      | [12](#mismatched-languages) |
+| Unsupported     | [6](#unsupported-languages) |
 
 ## Supported Languages
 
@@ -80,6 +80,7 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | fluent             | ✅ OK           |                23 |               - |      |
 | fortran-fixed-form | ✅ OK           |               332 |               - |      |
 | fortran-free-form  | ✅ OK           |               328 |               - |      |
+| fsharp             | ✅ OK           |               239 |               - |      |
 | fsl                | ✅ OK           |                30 |               - |      |
 | gdresource         | ✅ OK           |               157 |               - |      |
 | gdscript           | ✅ OK           |                93 |               - |      |
@@ -117,6 +118,7 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | jsonnet            | ✅ OK           |                33 |               - |      |
 | jssm               | ✅ OK           |                30 |               - |      |
 | jsx                | ✅ OK           |               376 |               - |      |
+| julia              | ✅ OK           |              1168 |               - |      |
 | latex              | ✅ OK           |               283 |               - |      |
 | lean               | ✅ OK           |                32 |               - |      |
 | less               | ✅ OK           |               280 |               - |      |
@@ -128,6 +130,7 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | make               | ✅ OK           |                51 |               - |      |
 | marko              | ✅ OK           |               926 |               - |      |
 | matlab             | ✅ OK           |                88 |               - |      |
+| mdc                | ✅ OK           |               783 |               - |      |
 | mdx                | ✅ OK           |               197 |               - |      |
 | mermaid            | ✅ OK           |               129 |               - |      |
 | mipsasm            | ✅ OK           |                17 |               - |      |
@@ -135,6 +138,7 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | move               | ✅ OK           |               120 |               - |      |
 | narrat             | ✅ OK           |                34 |               - |      |
 | nextflow           | ✅ OK           |                32 |               - |      |
+| nim                | ✅ OK           |              1126 |               - |      |
 | nix                | ✅ OK           |                80 |               - |      |
 | nushell            | ✅ OK           |                81 |               - |      |
 | objective-c        | ✅ OK           |               223 |               - |      |
@@ -155,7 +159,7 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | qmldir             | ✅ OK           |                 7 |               - |      |
 | qss                | ✅ OK           |                31 |               - |      |
 | r                  | ✅ OK           |                71 |               - |      |
-| racket             | ✅ OK           |                69 |               - |    8 |
+| racket             | ✅ OK           |                69 |               - |      |
 | raku               | ✅ OK           |                52 |               - |      |
 | reg                | ✅ OK           |                 9 |               - |      |
 | regexp             | ✅ OK           |                34 |               - |      |
@@ -210,7 +214,7 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | wenyan             | ✅ OK           |                18 |               - |      |
 | wgsl               | ✅ OK           |                44 |               - |      |
 | wikitext           | ✅ OK           |               104 |               - |      |
-| wolfram            | ✅ OK           |               501 |               - |   10 |
+| wolfram            | ✅ OK           |               501 |               - |      |
 | xml                | ✅ OK           |               169 |               - |      |
 | xsl                | ✅ OK           |               171 |               - |      |
 | yaml               | ✅ OK           |                48 |               - |      |
@@ -233,30 +237,26 @@ Languages that do not throw with the JavaScript RegExp engine, but will produce 
 | --------- | :----------------------------------------------------------------------------- | ----------------: | --------------: | ---: |
 | apex      | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=apex)      |               187 |               - |  236 |
 | beancount | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=beancount) |                39 |               - |  171 |
+| cpp       | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=cpp)       |               512 |               - |    8 |
 | haskell   | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=haskell)   |               157 |               - |   39 |
 | kotlin    | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=kotlin)    |                58 |               - | 1953 |
 | kusto     | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=kusto)     |                60 |               - |   40 |
+| markdown  | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=markdown)  |               118 |               - |  915 |
 | nginx     | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=nginx)     |               378 |               - |    4 |
 | php       | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=php)       |              1131 |               - |  605 |
 | po        | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=po)        |                23 |               - |  423 |
 | pug       | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=pug)       |               686 |               - |  164 |
+| rst       | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=rst)       |              1857 |               - |   62 |
 
 ## Unsupported Languages
 
 Languages that throw with the JavaScript RegExp engine, either because they contain syntax we can't polyfill yet or because the grammar contains an invalid Oniguruma regex (that would also fail when using the WASM engine, but silently). You can try these languages with the `forgiving` option to skip errors, but usually it's best to use the Oniguruma engine instead.
 
-| Language   | Highlight Match                                                          | Patterns Parsable | Patterns Failed | Diff |
-| ---------- | :----------------------------------------------------------------------- | ----------------: | --------------: | ---: |
-| ada        | ✅ OK                                                                    |               201 |               1 |      |
-| julia      | ✅ OK                                                                    |              1166 |               2 |      |
-| fsharp     | ✅ OK                                                                    |               236 |               3 |      |
-| nim        | ✅ OK                                                                    |              1123 |               3 |      |
-| rst        | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=rst) |              1855 |               2 |   62 |
-| hack       | ❌ Error                                                                 |               947 |               1 |  114 |
-| purescript | ❌ Error                                                                 |                72 |               1 |   42 |
-| cpp        | ❌ Error                                                                 |               510 |               2 |    8 |
-| csharp     | ❌ Error                                                                 |               306 |               3 |  204 |
-| markdown   | ❌ Error                                                                 |               115 |               3 |  857 |
-| swift      | ❌ Error                                                                 |               326 |               3 |   40 |
-| mdc        | ❌ Error                                                                 |               779 |               4 |      |
-| razor      | ❌ Error                                                                 |               952 |               5 |   22 |
+| Language   | Highlight Match | Patterns Parsable | Patterns Failed | Diff |
+| ---------- | :-------------- | ----------------: | --------------: | ---: |
+| ada        | ✅ OK           |               201 |               1 |      |
+| hack       | ❌ Error        |               947 |               1 |  114 |
+| purescript | ❌ Error        |                72 |               1 |   42 |
+| csharp     | ❌ Error        |               306 |               3 |  204 |
+| swift      | ❌ Error        |               326 |               3 |   40 |
+| razor      | ❌ Error        |               952 |               5 |   22 |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ catalogs:
       specifier: ^1.4.1
       version: 1.4.1
     oniguruma-to-es:
-      specifier: 0.6.1
-      version: 0.6.1
+      specifier: 0.7.0
+      version: 0.7.0
     picocolors:
       specifier: ^1.1.1
       version: 1.1.1
@@ -553,7 +553,7 @@ importers:
         version: 9.3.0
       oniguruma-to-es:
         specifier: 'catalog:'
-        version: 0.6.1
+        version: 0.7.0
 
   packages/engine-oniguruma:
     dependencies:
@@ -4250,8 +4250,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  oniguruma-to-es@0.6.1:
-    resolution: {integrity: sha512-YQmbeCaNmSrSwuMuTq1oYCvb+jkISsruMu2XQTJAgLvHQkFKEMqJI33NVtq8EGPuRvFa0CHcH32l2CpTS9Fs/Q==}
+  oniguruma-to-es@0.7.0:
+    resolution: {integrity: sha512-HRaRh09cE0gRS3+wi2zxekB+I5L8C/gN60S+vb11eADHUaB/q4u8wGGOX3GvwvitG8ixaeycZfeoyruKQzUgNg==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -4639,8 +4639,8 @@ packages:
     resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  regex-recursion@4.2.1:
-    resolution: {integrity: sha512-QHNZyZAeKdndD1G3bKAbBEKOSSK4KOHQrAJ01N1LJeb0SoH4DJIeFhp0uUpETgONifS4+P3sOgoA1dhzgrQvhA==}
+  regex-recursion@4.3.0:
+    resolution: {integrity: sha512-5LcLnizwjcQ2ALfOj95MjcatxyqF5RPySx9yT+PaXu3Gox2vyAtLDjHB8NTJLtMGkvyau6nI3CfpwFCjPUIs/A==}
 
   regex-utilities@2.3.0:
     resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
@@ -9502,11 +9502,11 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  oniguruma-to-es@0.6.1:
+  oniguruma-to-es@0.7.0:
     dependencies:
       emoji-regex-xs: 1.0.0
       regex: 5.0.2
-      regex-recursion: 4.2.1
+      regex-recursion: 4.3.0
 
   optionator@0.9.4:
     dependencies:
@@ -9849,7 +9849,7 @@ snapshots:
     dependencies:
       '@eslint-community/regexpp': 4.12.1
 
-  regex-recursion@4.2.1:
+  regex-recursion@4.3.0:
     dependencies:
       regex-utilities: 2.3.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,7 +53,7 @@ catalog:
   minimist: ^1.2.8
   monaco-editor-core: ^0.52.0
   ofetch: ^1.4.1
-  oniguruma-to-es: 0.6.1
+  oniguruma-to-es: 0.7.0
   picocolors: ^1.1.1
   pinia: ^2.2.6
   pnpm: ^9.13.2


### PR DESCRIPTION
Latest [`oniguruma-to-es`](https://github.com/slevithan/oniguruma-to-es) adds support for more grammars (193 ➜ 197).

(Since there have been a few recent related PRs, note that I don't expect additional updates in the near future unless bug fixes are needed.)