### PR TITLE
docs: remove @ts-expect-error for untyped jsx, jsxs

### DIFF
--- a/docs/packages/next.md
+++ b/docs/packages/next.md
@@ -40,7 +40,6 @@ You can also call `codeToHast` to get the HTML abstract syntax tree, and render 
 ```tsx
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 import { Fragment } from 'react'
-// @ts-expect-error -- untyped
 import { jsx, jsxs } from 'react/jsx-runtime'
 import { codeToHast } from 'shiki'
 
@@ -80,7 +79,6 @@ Create a `shared.ts` for highlighter:
 ```ts
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 import { Fragment } from 'react'
-// @ts-expect-error -- untyped
 import { jsx, jsxs } from 'react/jsx-runtime'
 import { codeToHast } from 'shiki/bundle/web'
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Remove `@ts-expect-error -- untyped` for the `jsx` and `jsxs` imports from `react/jsx-runtime`

### Linked Issues

--

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I am thinking that this has been released with the React 19 types?