### PR TITLE
docs: add type assertion to React.JSX.Element type

### DIFF
--- a/docs/packages/next.md
+++ b/docs/packages/next.md
@@ -49,9 +49,9 @@ async function CodeBlock(props: Props) {
 You can also call `codeToHast` to get the HTML abstract syntax tree, and render it using [`hast-util-to-jsx-runtime`](https://github.com/syntax-tree/hast-util-to-jsx-runtime). With this method, you can render your own `pre` and `code` components.
 
 ```tsx
+import type { JSX } from 'react'
 import type { BundledLanguage } from 'shiki'
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
-import type { JSX } from 'react'
 import { Fragment } from 'react'
 import { jsx, jsxs } from 'react/jsx-runtime'
 import { codeToHast } from 'shiki'
@@ -100,9 +100,9 @@ We can start by creating a client `CodeBlock` component.
 Create a `shared.ts` for highlighter:
 
 ```ts
+import type { JSX } from 'react'
 import type { BundledLanguage } from 'shiki/bundle/web'
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
-import type { JSX } from 'react'
 import { Fragment } from 'react'
 import { jsx, jsxs } from 'react/jsx-runtime'
 import { codeToHast } from 'shiki/bundle/web'

--- a/docs/packages/next.md
+++ b/docs/packages/next.md
@@ -51,6 +51,7 @@ You can also call `codeToHast` to get the HTML abstract syntax tree, and render 
 ```tsx
 import type { BundledLanguage } from 'shiki'
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
+import type { JSX } from 'react'
 import { Fragment } from 'react'
 import { jsx, jsxs } from 'react/jsx-runtime'
 import { codeToHast } from 'shiki'
@@ -87,7 +88,7 @@ async function CodeBlock(props: Props) {
       // your custom `pre` element
       pre: props => <pre data-custom-codeblock {...props} />
     },
-  })
+  }) as JSX.Element
 }
 ```
 
@@ -101,6 +102,7 @@ Create a `shared.ts` for highlighter:
 ```ts
 import type { BundledLanguage } from 'shiki/bundle/web'
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
+import type { JSX } from 'react'
 import { Fragment } from 'react'
 import { jsx, jsxs } from 'react/jsx-runtime'
 import { codeToHast } from 'shiki/bundle/web'
@@ -115,7 +117,7 @@ export async function highlight(code: string, lang: BundledLanguage) {
     Fragment,
     jsx,
     jsxs,
-  })
+  }) as JSX.Element
 }
 ```
 


### PR DESCRIPTION

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Add TypeScript type assertion to the `React.JSX.Element` type, because `hast-util-to-jsx-runtime` will not update types for React 19:

- https://github.com/syntax-tree/hast-util-to-jsx-runtime/issues/10#issuecomment-2523396087

The `hast-util-to-jsx-runtime` project recommends adding back the JSX global namespace:

- https://github.com/syntax-tree/hast-util-to-jsx-runtime/issues/10#issuecomment-2523893859

But this seems like an unusual way, considering that the ecosystem is moving away from that.

So I suggest the type assertion to work around this.

@antfu if you would prefer a different type eg. `ReactElement` or some other method like adding back the global `JSX` namespace, I can do that instead.

### Linked Issues

--

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

--