### PR TITLE
Add missing JSX import

### DIFF
--- a/docs/packages/next.md
+++ b/docs/packages/next.md
@@ -125,7 +125,7 @@ In your `codeblock.tsx`:
 
 ```tsx
 'use client'
-import { useLayoutEffect, useState } from 'react'
+import { JSX, useLayoutEffect, useState } from 'react'
 import { highlight } from './shared'
 
 export function CodeBlock({ initial }: { initial?: JSX.Element }) {


### PR DESCRIPTION
### Description

Adds a missing import in the Next JS `codeblock.ts` docs example when using `shiki` client-side.

