### PR TITLE
feat(engine-js): update deps, support new languages

### DIFF
--- a/docs/references/engine-js-compat.md
+++ b/docs/references/engine-js-compat.md
@@ -2,9 +2,9 @@
 
 Compatibility reference of all built-in grammars with the [JavaScript RegExp engine](/guide/regex-engines#javascript-regexp-engine).
 
-> Generated on Saturday, December 21, 2024
+> Generated on Friday, December 27, 2024
 >
-> Version `1.24.3`
+> Version `1.24.4`
 >
 > Runtime: Node.js v22.11.0
 
@@ -13,8 +13,8 @@ Compatibility reference of all built-in grammars with the [JavaScript RegExp eng
 |                 |                       Count |
 | :-------------- | --------------------------: |
 | Total Languages |                         218 |
-| Supported       | [208](#supported-languages) |
-| Mismatched      |  [4](#mismatched-languages) |
+| Supported       | [210](#supported-languages) |
+| Mismatched      |  [2](#mismatched-languages) |
 | Unsupported     | [6](#unsupported-languages) |
 
 ## Supported Languages
@@ -29,6 +29,7 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | angular-html       | ✅ OK           |               670 |               - |      |
 | angular-ts         | ✅ OK           |               779 |               - |      |
 | apache             | ✅ OK           |                60 |               - |      |
+| apex               | ✅ OK           |               187 |               - |      |
 | apl                | ✅ OK           |               917 |               - |      |
 | applescript        | ✅ OK           |               152 |               - |      |
 | ara                | ✅ OK           |                54 |               - |      |
@@ -58,6 +59,7 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | coffee             | ✅ OK           |               469 |               - |      |
 | common-lisp        | ✅ OK           |                60 |               - |      |
 | coq                | ✅ OK           |                26 |               - |      |
+| cpp                | ✅ OK           |               512 |               - |      |
 | crystal            | ✅ OK           |              1067 |               - |      |
 | css                | ✅ OK           |               141 |               - |      |
 | csv                | ✅ OK           |                 1 |               - |      |
@@ -218,8 +220,8 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | verilog            | ✅ OK           |                33 |               - |      |
 | vhdl               | ✅ OK           |                82 |               - |      |
 | viml               | ✅ OK           |                72 |               - |      |
-| vue                | ✅ OK           |               692 |               - |      |
-| vue-html           | ✅ OK           |               716 |               - |      |
+| vue                | ✅ OK           |               694 |               - |      |
+| vue-html           | ✅ OK           |               718 |               - |      |
 | vyper              | ✅ OK           |               238 |               - |      |
 | wasm               | ✅ OK           |                78 |               - |      |
 | wenyan             | ✅ OK           |                18 |               - |      |
@@ -246,8 +248,6 @@ Languages that do not throw with the JavaScript RegExp engine, but will produce 
 
 | Language | Highlight Match                                                            | Patterns Parsable | Patterns Failed | Diff |
 | -------- | :------------------------------------------------------------------------- | ----------------: | --------------: | ---: |
-| apex     | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=apex)  |               187 |               - |   33 |
-| cpp      | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=cpp)   |               512 |               - |    8 |
 | kusto    | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=kusto) |                60 |               - |   40 |
 | nginx    | [🚧 Mismatch](https://textmate-grammars-themes.netlify.app/?grammar=nginx) |               378 |               - |  122 |
 
@@ -260,6 +260,6 @@ Languages that throw with the JavaScript RegExp engine, either because they cont
 | ada        | ✅ OK           |               201 |               1 |      |
 | hack       | ❌ Error        |               947 |               1 |  114 |
 | purescript | ❌ Error        |                72 |               1 |      |
-| csharp     | ❌ Error        |               306 |               3 |  148 |
+| csharp     | ❌ Error        |               306 |               3 |  137 |
 | swift      | ❌ Error        |               326 |               3 |    8 |
-| razor      | ❌ Error        |               952 |               5 |   14 |
+| razor      | ❌ Error        |               952 |               5 |      |

--- a/packages/engine-javascript/src/index.ts
+++ b/packages/engine-javascript/src/index.ts
@@ -59,13 +59,13 @@ export function defaultJavaScriptRegexConstructor(pattern: string, options?: Oni
       rules: {
         // Needed since TextMate grammars merge backrefs across patterns
         allowOrphanBackrefs: true,
-        // Removing `\G` anchors in cases when they're not supported for emulation allows
-        // supporting more grammars, but also allows some mismatches
-        allowUnhandledGAnchors: true,
         // Improves search performance for generated regexes
         asciiWordBoundaries: true,
         // Follow `vscode-oniguruma` which enables this Oniguruma option by default
         captureGroup: true,
+        // Removing `\G` anchors in cases when they're not supported for emulation allows
+        // supporting more grammars, but also allows some mismatches
+        ignoreUnsupportedGAnchors: true,
       },
       ...options,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ catalogs:
       specifier: ^1.1.4
       version: 1.1.4
     oniguruma-to-es:
-      specifier: 0.8.1
-      version: 0.8.1
+      specifier: 0.9.0
+      version: 0.9.0
     picocolors:
       specifier: ^1.1.1
       version: 1.1.1
@@ -555,7 +555,7 @@ importers:
         version: 9.3.1
       oniguruma-to-es:
         specifier: 'catalog:'
-        version: 0.8.1
+        version: 0.9.0
 
   packages/engine-oniguruma:
     dependencies:
@@ -4044,8 +4044,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  oniguruma-to-es@0.8.1:
-    resolution: {integrity: sha512-dekySTEvCxCj0IgKcA2uUCO/e4ArsqpucDPcX26w9ajx+DvMWLc5eZeJaRQkd7oC/+rwif5gnT900tA34uN9Zw==}
+  oniguruma-to-es@0.9.0:
+    resolution: {integrity: sha512-hdGeGqzIgizcsButPbb4F3YLPMkBRo7cV3oA3dSFbUl/pwp6ipLy/ijZUwBEmHgTQxVL1pr064uoqJ3V7P036A==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -4434,14 +4434,14 @@ packages:
     resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  regex-recursion@5.0.0:
-    resolution: {integrity: sha512-UwyOqeobrCCqTXPcsSqH4gDhOjD5cI/b8kjngWgSZbxYh5yVjAwTjO5+hAuPRNiuR70+5RlWSs+U9PVcVcW9Lw==}
+  regex-recursion@5.1.1:
+    resolution: {integrity: sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==}
 
   regex-utilities@2.3.0:
     resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
 
-  regex@5.0.2:
-    resolution: {integrity: sha512-/pczGbKIQgfTMRV0XjABvc5RzLqQmwqxLHdQao2RTXPk+pmTXB2P0IaUHYdYyk412YLwUIkaeMd5T+RzVgTqnQ==}
+  regex@5.1.1:
+    resolution: {integrity: sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==}
 
   regexp-ast-analysis@0.7.1:
     resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
@@ -9082,11 +9082,11 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  oniguruma-to-es@0.8.1:
+  oniguruma-to-es@0.9.0:
     dependencies:
       emoji-regex-xs: 1.0.0
-      regex: 5.0.2
-      regex-recursion: 5.0.0
+      regex: 5.1.1
+      regex-recursion: 5.1.1
 
   optionator@0.9.4:
     dependencies:
@@ -9436,13 +9436,14 @@ snapshots:
     dependencies:
       '@eslint-community/regexpp': 4.12.1
 
-  regex-recursion@5.0.0:
+  regex-recursion@5.1.1:
     dependencies:
+      regex: 5.1.1
       regex-utilities: 2.3.0
 
   regex-utilities@2.3.0: {}
 
-  regex@5.0.2:
+  regex@5.1.1:
     dependencies:
       regex-utilities: 2.3.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,7 +54,7 @@ catalog:
   monaco-editor-core: ^0.52.2
   ofetch: ^1.4.1
   ohash: ^1.1.4
-  oniguruma-to-es: 0.8.1
+  oniguruma-to-es: 0.9.0
   picocolors: ^1.1.1
   pinia: ^2.3.0
   pnpm: ^9.15.1


### PR DESCRIPTION
Bumps `oniguruma-to-es` to [0.9.0](https://github.com/slevithan/oniguruma-to-es/releases), moving C++ and Apex from *Mismatched* to *Supported* in the JS engine report.

These improvements to `oniguruma-to-es` required complex changes in the base library and a couple dependencies. Heads up that this version also externalized dependencies in `oniguruma-to-es`'s ESM bundle.

There are only two languages left under *Mismatched*: Kusto and NGINX.

- Kusto is blocked by an Oniguruma bug ([see details](https://github.com/rosshamish/kuskus/issues/209)). The JS engine is actually the one producing the correct results.
- Running the NGINX sample through `compare.test.ts` produces identical output for the JS and WASM engines. I'm not sure how to investigate further.