### PR TITLE
fix: restore missing langs/*.mjs exports

### DIFF
--- a/packages/shiki/package.json
+++ b/packages/shiki/package.json
@@ -35,7 +35,7 @@
       "types": "./dist/langs.d.mts",
       "default": "./dist/langs.mjs"
     },
-    "./langs/*": {
+    "./langs/*.mjs": {
       "types": "./dist/langs/*.d.mts",
       "default": "./dist/langs/*.mjs"
     },

--- a/packages/shiki/package.json
+++ b/packages/shiki/package.json
@@ -35,6 +35,10 @@
       "types": "./dist/langs.d.mts",
       "default": "./dist/langs.mjs"
     },
+    "./langs/*": {
+      "types": "./dist/langs/*.d.mts",
+      "default": "./dist/langs/*.mjs"
+    },
     "./themes": {
       "types": "./dist/themes.d.mts",
       "default": "./dist/themes.mjs"


### PR DESCRIPTION


### Description
Fixes the breaking change in 1.25 related to `shiki/langs/<lang>.mjs` imports

### Linked Issues

FIxes https://github.com/shikijs/shiki/issues/881

### Additional context

