### PR TITLE
chore: update oniguruma-to-es and use new api

### DIFF
--- a/docs/references/engine-js-compat.md
+++ b/docs/references/engine-js-compat.md
@@ -2,20 +2,20 @@
 
 Compatibility reference of all built-in grammars with the [JavaScript RegExp engine](/guide/regex-engines#javascript-regexp-engine).
 
-> Generated on Thursday, January 2, 2025
+> Generated on Wednesday, January 8, 2025
 >
-> Version `1.24.4`
+> Version `1.26.1`
 >
-> Runtime: Node.js v20.18.0
+> Runtime: Node.js v22.11.0
 
 ## Report Summary
 
 |                 |                       Count |
 | :-------------- | --------------------------: |
 | Total Languages |                         219 |
-| Supported       | [213](#supported-languages) |
+| Supported       | [212](#supported-languages) |
 | Mismatched      |  [1](#mismatched-languages) |
-| Unsupported     | [5](#unsupported-languages) |
+| Unsupported     | [6](#unsupported-languages) |
 
 ## Supported Languages
 
@@ -56,7 +56,6 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | cmake              | ✅ OK           |                23 |               - |      |
 | cobol              | ✅ OK           |               863 |               - |      |
 | codeowners         | ✅ OK           |                 4 |               - |      |
-| codeql             | ✅ OK           |               151 |               - |      |
 | coffee             | ✅ OK           |               469 |               - |      |
 | common-lisp        | ✅ OK           |                60 |               - |      |
 | coq                | ✅ OK           |                26 |               - |      |
@@ -259,6 +258,7 @@ Languages that throw with the JavaScript RegExp engine, either because they cont
 
 | Language   | Highlight Match | Patterns Parsable | Patterns Failed | Diff |
 | ---------- | :-------------- | ----------------: | --------------: | ---: |
+| codeql     | ✅ OK           |               150 |               1 |      |
 | hack       | ❌ Error        |               947 |               1 |  114 |
 | purescript | ❌ Error        |                72 |               1 |      |
 | csharp     | ❌ Error        |               306 |               3 |  137 |

--- a/packages/engine-javascript/src/engine-compile.ts
+++ b/packages/engine-javascript/src/engine-compile.ts
@@ -8,13 +8,12 @@ export interface JavaScriptRegexEngineOptions extends JavaScriptRegexScannerOpti
   /**
    * The target ECMAScript version.
    *
-   * Oniguruma-To-ES uses RegExp features from later versions of ECMAScript to provide improved
-   * accuracy and add support for more grammars. If using target `ES2024` or later, the RegExp `v`
-   * flag is used which requires Node.js 20+ or Chrome 112+.
+   * Oniguruma-To-ES uses RegExp features from later versions of ECMAScript to add support for a
+   * few more grammars. If using target `ES2024` or later, the RegExp `v` flag is used which
+   * requires Node.js 20+ or Chrome 112+.
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets
    *
-   * For maximum compatibility, you can set it to `ES2018` which uses the RegExp `u` flag but
-   * supports a few less grammars.
+   * For maximum compatibility, you can set it to `ES2018` which uses the RegExp `u` flag.
    *
    * Set to `auto` to automatically detect the latest version supported by the environment.
    *
@@ -22,10 +21,10 @@ export interface JavaScriptRegexEngineOptions extends JavaScriptRegexScannerOpti
    */
   target?: 'auto' | 'ES2025' | 'ES2024' | 'ES2018'
 }
-/**
- * The default RegExp constructor for JavaScript regex engine.
- */
 
+/**
+ * The default regex constructor for the JavaScript RegExp engine.
+ */
 export function defaultJavaScriptRegexConstructor(pattern: string, options?: OnigurumaToEsOptions): RegExp {
   return toRegExp(
     pattern,
@@ -42,11 +41,15 @@ export function defaultJavaScriptRegexConstructor(pattern: string, options?: Oni
         // Removing `\G` anchors in cases when they're not supported for emulation allows
         // supporting more grammars, but also allows some mismatches
         ignoreUnsupportedGAnchors: true,
+        // Oniguruma uses depth limit `20`; lowered here to keep regexes shorter and maybe
+        // sometimes faster, but can be increased if issues reported due to low limit
+        recursionLimit: 5,
       },
       ...options,
     },
   )
 }
+
 /**
  * Use the modern JavaScript RegExp engine to implement the OnigScanner.
  *
@@ -55,7 +58,6 @@ export function defaultJavaScriptRegexConstructor(pattern: string, options?: Oni
  * unsupported patterns, and when the grammar includes patterns that use invalid Oniguruma syntax.
  * Set `forgiving` to `true` to ignore these errors and skip any unsupported or invalid patterns.
  */
-
 export function createJavaScriptRegexEngine(options: JavaScriptRegexEngineOptions = {}): RegexEngine {
   const _options: JavaScriptRegexEngineOptions = Object.assign(
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ catalogs:
       specifier: ^1.1.4
       version: 1.1.4
     oniguruma-to-es:
-      specifier: 0.10.0
-      version: 0.10.0
+      specifier: ^1.0.0
+      version: 1.0.0
     picocolors:
       specifier: ^1.1.1
       version: 1.1.1
@@ -560,7 +560,7 @@ importers:
         version: 10.0.1
       oniguruma-to-es:
         specifier: 'catalog:'
-        version: 0.10.0
+        version: 1.0.0
 
   packages/engine-oniguruma:
     dependencies:
@@ -592,7 +592,7 @@ importers:
         version: link:../types
       oniguruma-to-es:
         specifier: 'catalog:'
-        version: 0.10.0
+        version: 1.0.0
     devDependencies:
       tm-grammars:
         specifier: 'catalog:'
@@ -4075,8 +4075,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  oniguruma-to-es@0.10.0:
-    resolution: {integrity: sha512-zapyOUOCJxt+xhiNRPPMtfJkHGsZ98HHB9qJEkdT8BGytO/+kpe4m1Ngf0MzbzTmhacn11w9yGeDP6tzDhnCdg==}
+  oniguruma-to-es@1.0.0:
+    resolution: {integrity: sha512-kihvp0O4lFwf5tZMkfanwQLIZ9ORe9OeOFgZonH0BQeThgwfJiaZFeOfvvJVnJIM9TiVmx0RDD35hUJDR0++rQ==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -9084,7 +9084,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  oniguruma-to-es@0.10.0:
+  oniguruma-to-es@1.0.0:
     dependencies:
       emoji-regex-xs: 1.0.0
       regex: 5.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,7 +54,7 @@ catalog:
   monaco-editor-core: ^0.52.2
   ofetch: ^1.4.1
   ohash: ^1.1.4
-  oniguruma-to-es: 0.10.0
+  oniguruma-to-es: ^1.0.0
   picocolors: ^1.1.1
   pinia: ^2.3.0
   pnpm: ^9.15.2


### PR DESCRIPTION
- Bumps `oniguruma-to-es` from `0.10.0` to `^1.0.0`.
  - Adds `rules.recursionLimit` and sets it to `5`. This reproduces the default behavior of v0.3.0 to v0.10.0.
    - v1.0.0 changed the default recursion depth limit to `20` to match Oniguruma.
  - v1.0.0 drops support for the CodeQL grammar because it contains an invalid Oniguruma regex that `oniguruma-to-es` is now able to detect (use of lookahead within lookbehind).
    - The grammar works the same in the Oniguruma and JS RegExp engines if `forgiving` is enabled.