### PR TITLE
feat(engine-js): update deps, support more languages

### DIFF
--- a/docs/guide/regex-engines.md
+++ b/docs/guide/regex-engines.md
@@ -91,7 +91,7 @@ Instead of compiling regular expressions on-the-fly, we also provide pre-compile
 Pre-compiled languages require support for RegExp UnicodeSets (the `v` flag), which requires **ES2024** or Node.js 20+, and may not work in older environments. [Can I use](https://caniuse.com/mdn-javascript_builtins_regexp_unicodesets).
 :::
 
-You can install them with `@shikijs/langs-precompiled`, and then change your `@shikijs/langs` imports to `@shikijs/langs-precompiled`:
+You can install them with `@shikijs/langs-precompiled`, and change your `@shikijs/langs` imports to `@shikijs/langs-precompiled`:
 
 ```ts
 import { createHighlighterCore } from 'shiki/core'

--- a/docs/references/engine-js-compat.md
+++ b/docs/references/engine-js-compat.md
@@ -2,9 +2,9 @@
 
 Compatibility reference of all built-in grammars with the [JavaScript RegExp engine](/guide/regex-engines#javascript-regexp-engine).
 
-> Generated on Monday, January 20, 2025
+> Generated on Tuesday, January 21, 2025
 >
-> Version `1.27.2`
+> Version `2.0.3`
 >
 > Runtime: Node.js v22.11.0
 
@@ -13,9 +13,9 @@ Compatibility reference of all built-in grammars with the [JavaScript RegExp eng
 |                 |                       Count |
 | :-------------- | --------------------------: |
 | Total Languages |                         219 |
-| Supported       | [213](#supported-languages) |
+| Supported       | [214](#supported-languages) |
 | Mismatched      |  [0](#mismatched-languages) |
-| Unsupported     | [6](#unsupported-languages) |
+| Unsupported     | [5](#unsupported-languages) |
 
 ## Supported Languages
 
@@ -54,7 +54,7 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | clj                | ✅ OK           |                38 |               - |      |
 | clojure            | ✅ OK           |                38 |               - |      |
 | cmake              | ✅ OK           |                23 |               - |      |
-| cobol              | ✅ OK           |               867 |               - |      |
+| cobol              | ✅ OK           |               868 |               - |      |
 | codeowners         | ✅ OK           |                 4 |               - |      |
 | coffee             | ✅ OK           |               471 |               - |      |
 | common-lisp        | ✅ OK           |                60 |               - |      |
@@ -183,7 +183,8 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | ruby               | ✅ OK           |              1787 |               - |      |
 | rust               | ✅ OK           |                89 |               - |      |
 | sas                | ✅ OK           |               101 |               - |      |
-| scala              | ✅ OK           |               117 |               - |      |
+| sass               | ✅ OK           |                69 |               - |      |
+| scala              | ✅ OK           |               118 |               - |      |
 | scheme             | ✅ OK           |                34 |               - |      |
 | scss               | ✅ OK           |               234 |               - |      |
 | sdbl               | ✅ OK           |                23 |               - |      |
@@ -259,8 +260,7 @@ Languages that throw with the JavaScript RegExp engine, either because they cont
 | Language   | Highlight Match | Patterns Parsable | Patterns Failed | Diff |
 | ---------- | :-------------- | ----------------: | --------------: | ---: |
 | codeql     | ✅ OK           |               150 |               1 |      |
-| sass       | ✅ OK           |                67 |               2 |      |
+| csharp     | ❌ Error        |               312 |               1 |  137 |
 | purescript | ❌ Error        |                72 |               1 |      |
-| csharp     | ❌ Error        |               310 |               3 |  137 |
-| razor      | ❌ Error        |               959 |               3 |      |
-| swift      | ❌ Error        |               326 |               3 |      |
+| razor      | ❌ Error        |               961 |               1 |      |
+| swift      | ❌ Error        |               330 |               1 |      |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ catalogs:
       specifier: ^1.1.4
       version: 1.1.4
     oniguruma-to-es:
-      specifier: ^2.2.0
-      version: 2.2.0
+      specifier: ^2.3.0
+      version: 2.3.0
     picocolors:
       specifier: ^1.1.1
       version: 1.1.1
@@ -196,8 +196,8 @@ catalogs:
       specifier: ^18.2.0
       version: 18.2.0
     tm-grammars:
-      specifier: ^1.22.8
-      version: 1.22.8
+      specifier: ^1.22.9
+      version: 1.22.9
     tm-themes:
       specifier: ^1.9.8
       version: 1.9.8
@@ -578,7 +578,7 @@ importers:
         version: 10.0.1
       oniguruma-to-es:
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.3.0
 
   packages/engine-oniguruma:
     dependencies:
@@ -601,7 +601,7 @@ importers:
     devDependencies:
       tm-grammars:
         specifier: 'catalog:'
-        version: 1.22.8
+        version: 1.22.9
 
   packages/langs-precompiled:
     dependencies:
@@ -610,11 +610,11 @@ importers:
         version: link:../types
       oniguruma-to-es:
         specifier: 'catalog:'
-        version: 2.2.0
+        version: 2.3.0
     devDependencies:
       tm-grammars:
         specifier: 'catalog:'
-        version: 1.22.8
+        version: 1.22.9
 
   packages/markdown-it:
     dependencies:
@@ -726,7 +726,7 @@ importers:
         version: 3.5.0
       tm-grammars:
         specifier: 'catalog:'
-        version: 1.22.8
+        version: 1.22.9
       tm-themes:
         specifier: 'catalog:'
         version: 1.9.8
@@ -4116,8 +4116,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  oniguruma-to-es@2.2.0:
-    resolution: {integrity: sha512-EEsso27ri0sf+t4uRFEj5C5gvXQj0d0w1Y2qq06b+hDLBnvzO1rWTwEW4C7ytan6nhg4WPwE26eLoiPhHUbvKg==}
+  oniguruma-to-es@2.3.0:
+    resolution: {integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -4866,8 +4866,8 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
-  tm-grammars@1.22.8:
-    resolution: {integrity: sha512-htD1bhek5kDiwkjZcNxBTQea5I9zmXR7cWcqZ7jzMGlR4Wdgrba4RDFRIhf3pfpUiKjFOOeyqtd0W2CcWSG6cg==}
+  tm-grammars@1.22.9:
+    resolution: {integrity: sha512-PhznAxT+NBe22Gvwozs9KTWLYFlXFeOVmEpFYbcOgJQYJ1XNGZwDjsrPpIMjta+FRmCJNKLyJhzRZ9Ap6Ewchw==}
 
   tm-themes@1.9.8:
     resolution: {integrity: sha512-XbsuHkBCRBAt/MYXYFDHLfBH70SHa55TwJ50Qsw5UE6w9s12RDNNFyA3wkljkJw/LTG1F672QaO3BOMcIGBfJQ==}
@@ -9140,7 +9140,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  oniguruma-to-es@2.2.0:
+  oniguruma-to-es@2.3.0:
     dependencies:
       emoji-regex-xs: 1.0.0
       regex: 5.1.1
@@ -9892,7 +9892,7 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
-  tm-grammars@1.22.8: {}
+  tm-grammars@1.22.9: {}
 
   tm-themes@1.9.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,7 +56,7 @@ catalog:
   monaco-editor-core: ^0.52.2
   ofetch: ^1.4.1
   ohash: ^1.1.4
-  oniguruma-to-es: ^2.2.0
+  oniguruma-to-es: ^2.3.0
   picocolors: ^1.1.1
   pinia: ^2.3.0
   pnpm: ^9.15.4
@@ -73,7 +73,7 @@ catalog:
   shiki-legacy: npm:shiki@^0.14.7
   simple-git-hooks: ^2.11.1
   taze: ^18.2.0
-  tm-grammars: ^1.22.8
+  tm-grammars: ^1.22.9
   tm-themes: ^1.9.8
   twoslash: ^0.2.12
   twoslash-vue: ^0.2.12


### PR DESCRIPTION
- Bump `oniguruma-to-es` and `tm-grammars`.
  - Support `sass`.
  - Lower error count for `csharp`, `razor`, `swift`.
- Refresh the JS engine compat report.
- Undo one tweak I previously made in the docs.