### PR TITLE
feat(rehype): Support `fallbackLanguage` on lazy mode

### DIFF
--- a/packages/rehype/src/types.ts
+++ b/packages/rehype/src/types.ts
@@ -26,9 +26,7 @@ export interface RehypeShikiExtraOptions {
   defaultLanguage?: string
 
   /**
-   * The fallback language to use when specified language is not loaded
-   *
-   * Ignored if `lazy` is enabled
+   * The fallback language to use when specified language is not loaded, or not included in the bundle
    */
   fallbackLanguage?: string
 

--- a/packages/rehype/test/core.test.ts
+++ b/packages/rehype/test/core.test.ts
@@ -99,3 +99,27 @@ it('run with rehype-raw', async () => {
 
   await expect(file.toString()).toMatchFileSnapshot('./fixtures/a.core.out.html')
 })
+
+it('run with lazy + fallback language', async () => {
+  const highlighter = await createHighlighter({
+    themes: [
+      'vitesse-light',
+    ],
+    langs: [],
+  })
+
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkRehype)
+    .use(rehypeShikiFromHighlighter, highlighter, {
+      lazy: true,
+      theme: 'vitesse-light',
+      defaultLanguage: 'text',
+      fallbackLanguage: 'text',
+      langs: [],
+    })
+    .use(rehypeStringify)
+    .process(await fs.readFile(new URL('./fixtures/d.md', import.meta.url)))
+
+  await expect(file.toString()).toMatchFileSnapshot('./fixtures/d.out.html')
+})

--- a/packages/rehype/test/fixtures/d.md
+++ b/packages/rehype/test/fixtures/d.md
@@ -1,0 +1,3 @@
+```invalid
+Should use fallback language (plaintext)
+```

--- a/packages/rehype/test/fixtures/d.out.html
+++ b/packages/rehype/test/fixtures/d.out.html
@@ -1,0 +1,1 @@
+<pre class="shiki vitesse-light" style="background-color:#ffffff;color:#393a34" tabindex="0"><code><span class="line"><span>Should use fallback language (plaintext)</span></span></code></pre>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Support `fallbackLanguage` when `lazy` is set to true, you can consider this as a successor of #821.

Since `highlighter.loadLanguage` throws error on languages that's not included in the bundle, we can use it to detect whether fallback is needed.

### Linked Issues

N/A

### Additional context

Unit test added
