### PR TITLE
fix: node10 types and implementation resolution

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,13 @@
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "typesVersions": {
+    "*": {
+      "cli": [
+        "./dist/cli.mts"
+      ]
+    }
+  },
   "bin": {
     "shiki": "bin.mjs",
     "shiki-cli": "bin.mjs",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -33,7 +33,7 @@
   "typesVersions": {
     "*": {
       "cli": [
-        "./dist/cli.d.mts"
+        "./dist/cli.mts"
       ]
     }
   },

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -30,6 +30,13 @@
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "typesVersions": {
+    "*": {
+      "cli": [
+        "./dist/cli.d.mts"
+      ]
+    }
+  },
   "bin": {
     "shiki-codegen": "bin.mjs"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,13 +42,13 @@
   "typesVersions": {
     "*": {
       "wasm-inlined": [
-        "./dist/wasm-inlined.d.mts"
+        "./dist/wasm-inlined.mts"
       ],
       "textmate": [
-        "./dist/textmate.d.mts"
+        "./dist/textmate.mts"
       ],
       "types": [
-        "./dist/types.d.mts"
+        "./dist/types.mts"
       ],
       "*": [
         "./dist/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,11 +44,11 @@
       "wasm-inlined": [
         "./dist/wasm-inlined.d.mts"
       ],
-      "types": [
-        "./dist/types.d.mts"
-      ],
       "textmate": [
         "./dist/textmate.d.mts"
+      ],
+      "types": [
+        "./dist/types.d.mts"
       ],
       "*": [
         "./dist/*",

--- a/packages/engine-javascript/package.json
+++ b/packages/engine-javascript/package.json
@@ -33,7 +33,7 @@
   "typesVersions": {
     "*": {
       "raw": [
-        "./dist/engine-raw.d.mts"
+        "./dist/engine-raw.mts"
       ]
     }
   },

--- a/packages/engine-javascript/package.json
+++ b/packages/engine-javascript/package.json
@@ -30,6 +30,13 @@
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "typesVersions": {
+    "*": {
+      "raw": [
+        "./dist/engine-raw.d.mts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/engine-oniguruma/package.json
+++ b/packages/engine-oniguruma/package.json
@@ -34,7 +34,7 @@
   "typesVersions": {
     "*": {
       "wasm-inlined": [
-        "./dist/wasm-inlined.d.mts"
+        "./dist/wasm-inlined.mts"
       ],
       "*": [
         "./dist/*",

--- a/packages/langs-precompiled/package.json
+++ b/packages/langs-precompiled/package.json
@@ -341,7 +341,10 @@
   "types": "./dist/index.d.mts",
   "typesVersions": {
     "*": {
-      "*": ["./dist/*.mts", "./dist/index.mts"]
+      "*": [
+        "./dist/*.mts",
+        "./dist/index.mts"
+      ]
     }
   },
   "files": [

--- a/packages/langs-precompiled/package.json
+++ b/packages/langs-precompiled/package.json
@@ -339,6 +339,11 @@
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "typesVersions": {
+    "*": {
+      "*": ["./dist/*.mts", "./dist/index.mts"]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/langs/package.json
+++ b/packages/langs/package.json
@@ -341,7 +341,10 @@
   "types": "./dist/index.d.mts",
   "typesVersions": {
     "*": {
-      "*": ["./dist/*.mts", "./dist/index.mts"]
+      "*": [
+        "./dist/*.mts",
+        "./dist/index.mts"
+      ]
     }
   },
   "files": [

--- a/packages/langs/package.json
+++ b/packages/langs/package.json
@@ -339,6 +339,11 @@
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "typesVersions": {
+    "*": {
+      "*": ["./dist/*.mts", "./dist/index.mts"]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/markdown-it/package.json
+++ b/packages/markdown-it/package.json
@@ -37,10 +37,10 @@
   "typesVersions": {
     "*": {
       "core": [
-        "./dist/core.d.mts"
+        "./dist/core.mts"
       ],
       "async": [
-        "./dist/async.d.mts"
+        "./dist/async.mts"
       ],
       "*": [
         "./dist/*",

--- a/packages/rehype/package.json
+++ b/packages/rehype/package.json
@@ -33,7 +33,7 @@
   "typesVersions": {
     "*": {
       "core": [
-        "./dist/core.d.mts"
+        "./dist/core.mts"
       ],
       "*": [
         "./dist/*",

--- a/packages/shiki/package.json
+++ b/packages/shiki/package.json
@@ -78,37 +78,37 @@
   "typesVersions": {
     "*": {
       "core": [
-        "./dist/core.d.mts"
+        "./dist/core.mts"
       ],
       "wasm": [
-        "./dist/wasm.d.mts"
+        "./dist/wasm.mts"
       ],
       "langs": [
-        "./dist/langs.d.mts"
+        "./dist/langs.mts"
       ],
       "themes": [
-        "./dist/themes.d.mts"
+        "./dist/themes.mts"
       ],
       "types": [
-        "./dist/types.d.mts"
+        "./dist/types.mts"
       ],
       "bundle/full": [
-        "./dist/bundle-full.d.mts"
+        "./dist/bundle-full.mts"
       ],
       "bundle/web": [
-        "./dist/bundle-web.d.mts"
+        "./dist/bundle-web.mts"
       ],
       "engine/javascript": [
-        "./dist/engine-javascript.d.mts"
+        "./dist/engine-javascript.mts"
       ],
       "engine/oniguruma": [
-        "./dist/engine-oniguruma.d.mts"
+        "./dist/engine-oniguruma.mts"
       ],
       "textmate": [
-        "./dist/textmate.d.mts"
+        "./dist/textmate.mts"
       ],
       "theme-css-variables": [
-        "./dist/theme-css-variables.d.mts"
+        "./dist/theme-css-variables.mts"
       ],
       "*": [
         "./dist/*",

--- a/packages/shiki/package.json
+++ b/packages/shiki/package.json
@@ -89,6 +89,9 @@
       "themes": [
         "./dist/themes.d.mts"
       ],
+      "types": [
+        "./dist/types.d.mts"
+      ],
       "bundle/full": [
         "./dist/bundle-full.d.mts"
       ],

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -77,6 +77,14 @@
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*.mts",
+        "./dist/index.mts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/twoslash/package.json
+++ b/packages/twoslash/package.json
@@ -36,7 +36,7 @@
   "typesVersions": {
     "*": {
       "./core": [
-        "./dist/core.d.mts"
+        "./dist/core.mts"
       ],
       "*": [
         "./dist/*",

--- a/packages/vitepress-twoslash/package.json
+++ b/packages/vitepress-twoslash/package.json
@@ -42,6 +42,9 @@
       "client": [
         "./dist/client.d.mts"
       ],
+      "cache-fs": [
+        "./dist/cache-fs.d.mts"
+      ],
       "*": [
         "./dist/index.d.mts"
       ]
@@ -49,6 +52,7 @@
   },
   "files": [
     "*.css",
+    "*.css.d.ts",
     "dist"
   ],
   "scripts": {

--- a/packages/vitepress-twoslash/package.json
+++ b/packages/vitepress-twoslash/package.json
@@ -39,20 +39,17 @@
   "types": "./dist/index.d.mts",
   "typesVersions": {
     "*": {
-      "client": [
-        "./dist/client.d.mts"
-      ],
-      "cache-fs": [
-        "./dist/cache-fs.d.mts"
+      "*.css": [
+        "./*.css"
       ],
       "*": [
-        "./dist/index.d.mts"
+        "./dist/*.mts",
+        "./dist/index.mts"
       ]
     }
   },
   "files": [
     "*.css",
-    "*.css.d.ts",
     "dist"
   ],
   "scripts": {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR includes the following fixes for node10 module resolution:
- add missing types
- fix wrong resolution and implementation in VP: `@shikijs/vitepress-twoslash/cache-fs` resolving to default package export (expand https://arethetypeswrong.github.io/?p=%40shikijs%2Fvitepress-twoslash%402.3.2 then expant entrypoints/node10 resolution and implementation and check the filename, check screenshots below)


/cc @antfu 

About the *.mts  `typesVersions`  mapping in `langs`, `langs-precompiled` and `theme` packages, it is a hack to allow resolve both types and implementation correctly, I've send you a few DM at discord with some screenshots with the traces for both.

I also need to review a few repositories :sweat_smile: 

### Linked Issues

### Additional context

![image](https://github.com/user-attachments/assets/8e0de914-c1d6-4eca-af15-9c8309e4c24e)
_current cache-fs subpackage export_

![image](https://github.com/user-attachments/assets/578c0d1d-1b09-4ea9-90f7-72d43c10b43c)
_cache-fs subpackage export with this PR_

<!-- e.g. is there anything you'd like reviewers to focus on? -->
