### PR TITLE
refactor(packages/monaco): decomposed into logical parts

### DIFF
--- a/packages/monaco/src/tokenizer.ts
+++ b/packages/monaco/src/tokenizer.ts
@@ -1,0 +1,29 @@
+import type { StateStack } from '@shikijs/vscode-textmate'
+import type monacoNs from 'monaco-editor-core'
+
+export class TokenizerState implements monacoNs.languages.IState {
+  constructor(
+    private _ruleStack: StateStack,
+  ) { }
+
+  public get ruleStack(): StateStack {
+    return this._ruleStack
+  }
+
+  public clone(): TokenizerState {
+    return new TokenizerState(this._ruleStack)
+  }
+
+  public equals(other: monacoNs.languages.IState): boolean {
+    if (
+      !other
+      || !(other instanceof TokenizerState)
+      || other !== this
+      || other._ruleStack !== this._ruleStack
+    ) {
+      return false
+    }
+
+    return true
+  }
+}

--- a/packages/monaco/src/types.ts
+++ b/packages/monaco/src/types.ts
@@ -1,0 +1,4 @@
+export interface MonacoLineToken {
+  startIndex: number
+  scopes: string
+}

--- a/packages/monaco/src/utils.ts
+++ b/packages/monaco/src/utils.ts
@@ -1,0 +1,21 @@
+export function normalizeColor(color: undefined): undefined
+export function normalizeColor(color: string | string[]): string
+export function normalizeColor(color: string | string[] | undefined): string | undefined
+export function normalizeColor(color: string | string[] | undefined): string | undefined {
+  // Some themes have an array of colors (not yet sure why), here we pick the first one
+  // https://github.com/shikijs/shiki/issues/894
+  // https://github.com/shikijs/textmate-grammars-themes/pull/117
+  if (Array.isArray(color))
+    color = color[0]
+
+  if (!color)
+    return undefined
+
+  color = (color.charCodeAt(0) === 35 ? color.slice(1) : color).toLowerCase()
+
+  // #RGB => #RRGGBB - Monaco does not support hex color with 3 or 4 digits
+  if (color.length === 3 || color.length === 4)
+    color = color.split('').map(c => c + c).join('')
+
+  return color
+}


### PR DESCRIPTION
### Description

- removed `any` types
- added indentations for better readability
- helper functions moved to `./utils.ts`
- types in `./types.ts`

