### PR TITLE
feat(twoslash)!: make default `moduleResolution` to `bundler`

### DIFF
--- a/packages/twoslash/src/core.ts
+++ b/packages/twoslash/src/core.ts
@@ -6,6 +6,7 @@ import type { ShikiTransformer, ShikiTransformerContextMeta } from '@shikijs/typ
 import type { Element, ElementContent, Text } from 'hast'
 import type { TwoslashExecuteOptions, TwoslashGenericFunction } from 'twoslash'
 
+import type { ModuleResolutionKind } from 'typescript'
 import type { TransformerTwoslashOptions, TwoslashRenderer, TwoslashShikiFunction, TwoslashShikiReturn } from './types'
 import { splitTokens } from '@shikijs/core'
 import { ShikiTwoslashError } from './error'
@@ -20,6 +21,9 @@ export * from './types'
 export function defaultTwoslashOptions(): TwoslashExecuteOptions {
   return {
     customTags: ['annotate', 'log', 'warn', 'error'],
+    compilerOptions: {
+      moduleResolution: 100 satisfies ModuleResolutionKind.Bundler,
+    },
   }
 }
 

--- a/packages/twoslash/src/index.ts
+++ b/packages/twoslash/src/index.ts
@@ -1,5 +1,6 @@
 import type { ShikiTransformer } from '@shikijs/types'
 import type { CreateTwoslashOptions } from 'twoslash'
+import type { ModuleResolutionKind } from 'typescript'
 import type { RendererRichOptions, TransformerTwoslashOptions } from './core'
 import { createTwoslasher } from 'twoslash'
 import { createTransformerFactory, rendererRich } from './core'
@@ -20,7 +21,12 @@ export interface TransformerTwoslashIndexOptions extends TransformerTwoslashOpti
  */
 export function transformerTwoslash(options: TransformerTwoslashIndexOptions = {}): ShikiTransformer {
   return createTransformerFactory(
-    createTwoslasher({ cache: options?.cache }),
+    createTwoslasher({
+      cache: options?.cache,
+      compilerOptions: {
+        moduleResolution: 100 satisfies ModuleResolutionKind.Bundler,
+      },
+    }),
     rendererRich(options.rendererRich),
   )(options)
 }


### PR DESCRIPTION
`moduleResolution: Bundler` should be pretty compatible with both modern (node16+) and legacy (node10) resolution, and I believe it's a better and modern default than typescript's current default `node10`