### PR TITLE
fix(monaco): handle missing settings in textmate theme func

### DIFF
--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -31,7 +31,7 @@ export function textmateThemeToMonacoTheme(theme: ThemeRegistrationResolved): Mo
     rules = []
     const themeSettings = theme.settings || theme.tokenColors
 
-    for (const { scope, settings: { foreground, background, fontStyle } } of themeSettings) {
+    for (const { scope, settings: { foreground, background, fontStyle } = {} } of themeSettings) {
       const scopes = Array.isArray(scope) ? scope : [scope]
 
       for (const s of scopes) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

- [x] prevent type error `undefined` when settings obj is missing.

### Linked Issues

### Screenshot
<img width="1162" alt="image" src="https://github.com/user-attachments/assets/8387e987-61eb-49db-95a5-ef7418de3d2e" />

<!-- e.g. is there anything you'd like reviewers to focus on? -->
