### PR TITLE
feat(engine-js): bump deps to work around Safari bug with some grammars

### DIFF
--- a/docs/references/engine-js-compat.md
+++ b/docs/references/engine-js-compat.md
@@ -2,11 +2,11 @@
 
 Compatibility reference of all built-in grammars with the [JavaScript RegExp engine](/guide/regex-engines#javascript-regexp-engine).
 
-> Generated on Wednesday, February 5, 2025
+> Generated on Thursday, February 20, 2025
 >
-> Version `2.3.1`
+> Version `3.0.0`
 >
-> Runtime: Node.js v22.13.1
+> Runtime: Node.js v22.14.0
 
 ## Report Summary
 
@@ -206,7 +206,7 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | svelte             | ✅ OK           |               645 |               - |      |
 | system-verilog     | ✅ OK           |               102 |               - |      |
 | systemd            | ✅ OK           |                32 |               - |      |
-| talonscript        | ✅ OK           |                44 |               - |      |
+| talonscript        | ✅ OK           |                45 |               - |      |
 | tasl               | ✅ OK           |                23 |               - |      |
 | tcl                | ✅ OK           |                34 |               - |      |
 | templ              | ✅ OK           |               682 |               - |      |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,8 +151,8 @@ catalogs:
       specifier: ^1.1.4
       version: 1.1.4
     oniguruma-to-es:
-      specifier: ^3.1.0
-      version: 3.1.0
+      specifier: ^3.1.1
+      version: 3.1.1
     pinia:
       specifier: ^3.0.1
       version: 3.0.1
@@ -550,7 +550,7 @@ importers:
         version: 10.0.2
       oniguruma-to-es:
         specifier: 'catalog:'
-        version: 3.1.0
+        version: 3.1.1
 
   packages/engine-oniguruma:
     dependencies:
@@ -582,7 +582,7 @@ importers:
         version: link:../types
       oniguruma-to-es:
         specifier: 'catalog:'
-        version: 3.1.0
+        version: 3.1.1
     devDependencies:
       tm-grammars:
         specifier: 'catalog:'
@@ -4273,8 +4273,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  oniguruma-to-es@3.1.0:
-    resolution: {integrity: sha512-BJ3Jy22YlgejHSO7Fvmz1kKazlaPmRSUH+4adTDUS/dKQ4wLxI+gALZ8updbaux7/m7fIlpgOZ5fp/Inq5jUAw==}
+  oniguruma-to-es@3.1.1:
+    resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -9384,7 +9384,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  oniguruma-to-es@3.1.0:
+  oniguruma-to-es@3.1.1:
     dependencies:
       emoji-regex-xs: 1.0.0
       regex: 6.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,7 +57,7 @@ catalog:
   monaco-editor-core: ^0.52.2
   ofetch: ^1.4.1
   ohash: ^1.1.4
-  oniguruma-to-es: ^3.1.0
+  oniguruma-to-es: ^3.1.1
   pinia: ^3.0.1
   pnpm: ^10.4.1
   prettier: ^3.5.1


### PR DESCRIPTION
Bumps `oniguruma-to-es` to v3.1.1, which includes a workaround for a WebKit regex parser bug that is affecting at least the YAML grammar. Fixes #927.