### PR TITLE
docs: fix markup for warnings

### DIFF
--- a/docs/guide/compat.md
+++ b/docs/guide/compat.md
@@ -4,7 +4,7 @@ outline: deep
 
 # Compatibility Build
 
-::: warn
+::: warning
 This is a compatibility build for v0.x users. And this package is no longer maintained since v3. Please migrate to the latest version.
 :::
 

--- a/docs/guide/regex-engines.md
+++ b/docs/guide/regex-engines.md
@@ -87,7 +87,7 @@ const jsEngine = createJavaScriptRegexEngine({
 
 Instead of compiling regular expressions on-the-fly, we also provide pre-compiled languages for the JavaScript engine to further reduce startup time.
 
-::: warn
+::: warning
 Pre-compiled languages are not yet supported, due to a [known issue](https://github.com/shikijs/shiki/issues/918) that affects many languages. Please use with caution.
 :::
 


### PR DESCRIPTION
Warnings aren't being displayed correctly in the docs. This fixes it.