### PR TITLE
docs: fix markdown-it and rehype examples

### DIFF
--- a/docs/packages/markdown-it.md
+++ b/docs/packages/markdown-it.md
@@ -51,6 +51,7 @@ By default, the full bundle of `shiki` will be imported. If you are using a [fin
 import { fromHighlighter } from '@shikijs/markdown-it/core'
 import MarkdownIt from 'markdown-it'
 import { createHighlighterCore } from 'shiki/core'
+import { createOnigurumaEngine } from 'shiki/engine/oniguruma'
 
 const highlighter = await createHighlighterCore({
   themes: [
@@ -59,7 +60,7 @@ const highlighter = await createHighlighterCore({
   langs: [
     import('@shikijs/langs/javascript'),
   ],
-  loadWasm: import('shiki/wasm')
+  engine: createOnigurumaEngine(() => import('shiki/wasm'))
 })
 
 const md = MarkdownIt()

--- a/docs/packages/rehype.md
+++ b/docs/packages/rehype.md
@@ -67,6 +67,7 @@ import rehypeStringify from 'rehype-stringify'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import { createHighlighterCore } from 'shiki/core'
+import { createOnigurumaEngine } from 'shiki/engine/oniguruma'
 
 import { unified } from 'unified'
 
@@ -77,7 +78,7 @@ const highlighter = await createHighlighterCore({
   langs: [
     import('@shikijs/langs/javascript'),
   ],
-  loadWasm: import('shiki/wasm')
+  engine: createOnigurumaEngine(() => import('shiki/wasm'))
 })
 
 const raw = await fs.readFile('./input.md')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In 3.0 version, `loadWasm` field in `createHighlighterCore` is replaced with `engine` field while the examples are still incorrect.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
