### PR TITLE
docs: update CDN shiki version to v3.0.0 (current)

### DIFF
--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -220,9 +220,9 @@ To use `shiki` in the browser via CDN, you can use [esm.run](https://esm.run) or
 
   <script type="module">
     // be sure to specify the exact version
-    import { codeToHtml } from 'https://esm.sh/shiki@1.0.0'
+    import { codeToHtml } from 'https://esm.sh/shiki@3.0.0'
     // or
-    // import { codeToHtml } from 'https://esm.run/shiki@1.0.0'
+    // import { codeToHtml } from 'https://esm.run/shiki@3.0.0'
 
     const foo = document.getElementById('foo')
     foo.innerHTML = await codeToHtml('console.log("Hi, Shiki on CDN :)")', {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Update `shiki` version to v3.0.0 in [CDN Usage](https://shiki.matsu.io/guide/install#cdn-usage)

### Linked Issues

### Additional context

Yesterday, my friend wanted to download `shiki` through CDN but the documentation didn't provide the latest version to her. I think it would mislead others as well, especially for the newbies who can't find help but fully trust the documentation.

### Demo
|Before|After|
|:---:|:---:|
|<img width="800" alt="image" src="https://github.com/user-attachments/assets/51ef9c23-00e8-4e51-a511-abf7b1019e29" />|<img width="800" alt="image" src="https://github.com/user-attachments/assets/0474d959-47e5-41a8-92d3-4af988179cbb" />|
