### PR TITLE
fix: failed to run shiki docs server locally

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -144,7 +144,7 @@ export default withMermaid(defineConfig({
       transformerRemoveNotationEscape(),
       transformerColorizedBrackets({ explicitTrigger: true }),
     ],
-    languages: ['js', 'jsx', 'ts', 'tsx'],
+    languages: ['js', 'jsx', 'ts', 'tsx', 'html'],
     config: (md) => {
       md.use(groupIconMdPlugin)
     },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Improve docs local development setup experience. Make it literally work. ⚡
<img width="609" alt="image" src="https://github.com/user-attachments/assets/f3b9eebd-afd5-4fe1-9d5f-1035a3690201" />

### Linked Issues

### Additional context

Hi maintainers! Today I tried to set up a local development environment for self-testing and ready for contributions. Gladly, I found the `CONTRIBUTING.md` and followed the steps. 

However, it doesn't work out well... 😢 The issue arises from some essential configurations being missed, leading to problems for users.

<img width="1296" alt="image" src="https://github.com/user-attachments/assets/bc8763de-1089-4e05-bbd4-c775d6dfd93c" />

 
