### PR TITLE
feat(vitepress-twoslash): add option for custom twoslasher

### DIFF
--- a/packages/vitepress-twoslash/src/index.ts
+++ b/packages/vitepress-twoslash/src/index.ts
@@ -33,7 +33,7 @@ export function transformerTwoslash(options: VitePressPluginTwoslashOptions = {}
     removeTwoslashNotations(code)
   }
 
-  const defaultTwoslasher = createTwoslasher(options.twoslashOptions)
+  const defaultTwoslasher = options.twoslasher || createTwoslasher(options.twoslashOptions)
 
   let twoslasher = defaultTwoslasher
   // Wrap twoslasher with cache when `resultCache` is provided

--- a/packages/vitepress-twoslash/src/types.ts
+++ b/packages/vitepress-twoslash/src/types.ts
@@ -1,5 +1,5 @@
 import type { TransformerTwoslashOptions } from '@shikijs/twoslash/core'
-import type { TwoslashReturn } from 'twoslash'
+import type { TwoslashInstance, TwoslashReturn } from 'twoslash'
 import type { VueSpecificOptions } from 'twoslash-vue'
 import type { TwoslashFloatingVueRendererOptions } from './renderer-floating-vue'
 
@@ -30,6 +30,12 @@ export interface VitePressPluginTwoslashOptions extends TransformerTwoslashVueOp
    * ```
    */
   typesCache?: TwoslashTypesCache
+
+  /**
+   * Custom twoslasher instance
+   * @default twoslash-vue
+   */
+  twoslasher?: TwoslashInstance
 }
 
 export interface TwoslashTypesCache {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hi, I  write a [@ts-macro/twoslash](https://github.com/ts-macro/twoslash) plugin for [ts-macro](https://github.com/ts-macro/ts-macro).
So can we export an option let me to custom twoslasher?

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
