### PR TITLE
Fix error so TypeScript stops complaining.

### DIFF
--- a/packages/langs/scripts/langs.ts
+++ b/packages/langs/scripts/langs.ts
@@ -138,7 +138,7 @@ export { default } from './${json.name}.mjs'
       await fs.writeFile(
         `./dist/${name}.d.mts`,
         `import type { LanguageRegistration } from '@shikijs/types'
-const langs: LanguageRegistration []
+declare const langs: LanguageRegistration []
 export default langs
 `,
         'utf-8',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixes an issue TypeScript complains about:

> Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

```
node_modules/@shikijs/langs/dist/bash.d.mts:2:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

2 const langs: LanguageRegistration []
  ~~~~~
```

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
