### PR TITLE
feat: add handling for `FontStyle.Strikethrough`

### DIFF
--- a/docs/.vitepress/theme/transformers.css
+++ b/docs/.vitepress/theme/transformers.css
@@ -23,16 +23,24 @@
   border-radius: 4px;
 }
 
+.vp-doc [class*='language-'] pre {
+  background-color: var(--shiki-light-bg, inherit);
+}
+
+.dark .vp-doc [class*='language-'] pre {
+  background-color: var(--shiki-dark-bg, inherit);
+}
+
 .vp-code,
-.vp-code span {
-  /* background-color: var(--shiki-light-bg, inherit); */
+.vp-code span:not(.line.highlighted):not(.line.highlighted *) {
+  background-color: var(--shiki-light-bg, inherit);
   text-decoration: var(--shiki-light-text-decoration, inherit);
   font-weight: var(--shiki-light-font-weight, inherit);
 }
 
 .dark .vp-code,
-.dark .vp-code span {
-  /* background-color: var(--shiki-dark-bg, inherit); */
+.dark .vp-code span:not(.line.highlighted):not(.line.highlighted *) {
+  background-color: var(--shiki-dark-bg, inherit);
   text-decoration: var(--shiki-dark-text-decoration, inherit);
   font-weight: var(--shiki-dark-font-weight, inherit);
 }

--- a/docs/.vitepress/theme/transformers.css
+++ b/docs/.vitepress/theme/transformers.css
@@ -22,3 +22,17 @@
   margin: -1px -3px;
   border-radius: 4px;
 }
+
+.vp-code,
+.vp-code span {
+  /* background-color: var(--shiki-bg, inherit); */
+  text-decoration: var(--shiki-text-decoration, inherit);
+  font-weight: var(--shiki-font-weight, inherit);
+}
+
+.dark .vp-code,
+.dark .vp-code span {
+  /* background-color: var(--shiki-dark-bg, inherit); */
+  text-decoration: var(--shiki-dark-text-decoration, inherit);
+  font-weight: var(--shiki-dark-font-weight, inherit);
+}

--- a/docs/.vitepress/theme/transformers.css
+++ b/docs/.vitepress/theme/transformers.css
@@ -25,9 +25,9 @@
 
 .vp-code,
 .vp-code span {
-  /* background-color: var(--shiki-bg, inherit); */
-  text-decoration: var(--shiki-text-decoration, inherit);
-  font-weight: var(--shiki-font-weight, inherit);
+  /* background-color: var(--shiki-light-bg, inherit); */
+  text-decoration: var(--shiki-light-text-decoration, inherit);
+  font-weight: var(--shiki-light-font-weight, inherit);
 }
 
 .dark .vp-code,

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -21,7 +21,7 @@ import { codeToHtml } from 'shiki'
 
 const html = codeToHtml('console.log("Hello World")', {
   lang: 'text', // [!code hl]
-  theme: 'vitesse-light', 
+  theme: 'vitesse-light',
 })
 ```
 
@@ -32,22 +32,15 @@ const html = codeToHtml('console.log("Hello World")', {
 A special processed language `ansi` is provided to highlight terminal outputs. For example:
 
 ```ansi
-[0;90m┌[0m  [0;36;1mWelcome to VitePress![0m[0m
-[0;90m│[0m[0m
-[0;32m◇[0m  Where should VitePress initialize the config?[0m
-[0;90m│[0m  [0;2m./docs[0m[0m
-[0;90m│[0m[0m
-[0;32m◇[0m  Site title:[0m
-[0;90m│[0m  [0;2mMy Awesome Project[0m[0m
-[0;90m│[0m[0m
-[0;32m◇[0m  Site description:[0m
-[0;90m│[0m  [0;2mA VitePress Site[0m[0m
-[0;90m│[0m[0m
-[0;36m◆[0m  Theme:[0m
-[0;36m│[0m  [0;32m●[0m Default Theme [0;2m(Out of the box, good-looking docs)[0m[0m
-[0;36m│[0m  [0;2m○[0m [0;2mDefault Theme + Customization[0m[0m
-[0;36m│[0m  [0;2m○[0m [0;2mCustom Theme[0m[0m
-[0;36m└[0m
+[0;32mcolored foreground[0m
+[0;42mcolored background[0m
+
+[0;1mbold text[0m
+[0;2mdimmed text[0m
+[0;4munderlined text[0m
+[0;7mreversed text[0m
+[0;9mstrikethrough text[0m
+[0;4;9munderlined + strikethrough text[0m
 ```
 
 Check the [raw markdown of code snippet above](https://github.com/shikijs/shiki/blob/main/docs/languages.md?plain=1#L35).

--- a/packages/cli/src/code-to-ansi.ts
+++ b/packages/cli/src/code-to-ansi.ts
@@ -28,6 +28,8 @@ export async function codeToANSI(code: string, lang: BundledLanguage, theme: Bun
           text = c.italic(text)
         if (token.fontStyle & FontStyle.Underline)
           text = c.underline(text)
+        if (token.fontStyle & FontStyle.Strikethrough)
+          text = c.strikethrough(text)
       }
       output += text
     }

--- a/packages/core/src/highlight/code-to-hast.ts
+++ b/packages/core/src/highlight/code-to-hast.ts
@@ -232,8 +232,11 @@ function mergeWhitespaceTokens(tokens: ThemedToken[][]): ThemedToken[][] {
     let carryOnContent = ''
     let firstOffset = 0
     line.forEach((token, idx) => {
-      const isUnderline = token.fontStyle && token.fontStyle & FontStyle.Underline
-      const couldMerge = !isUnderline
+      const isDecorated = token.fontStyle && (
+        (token.fontStyle & FontStyle.Underline)
+        || (token.fontStyle & FontStyle.Strikethrough)
+      )
+      const couldMerge = !isDecorated
       if (couldMerge && token.content.match(/^\s+$/) && line[idx + 1]) {
         if (!firstOffset)
           firstOffset = token.offset

--- a/packages/core/src/highlight/code-to-tokens-ansi.ts
+++ b/packages/core/src/highlight/code-to-tokens-ansi.ts
@@ -57,6 +57,9 @@ export function tokenizeAnsiWithTheme(
       if (token.decorations.has('underline'))
         fontStyle |= FontStyle.Underline
 
+      if (token.decorations.has('strikethrough'))
+        fontStyle |= FontStyle.Strikethrough
+
       return {
         content: token.value,
         offset: line[1], // TODO: more accurate offset? might need to fork ansi-sequence-parser

--- a/packages/core/src/utils/tokens.ts
+++ b/packages/core/src/utils/tokens.ts
@@ -116,8 +116,13 @@ export function getTokenStyleObject(token: TokenStyles): Record<string, string> 
       styles['font-style'] = 'italic'
     if (token.fontStyle & FontStyle.Bold)
       styles['font-weight'] = 'bold'
+    const decorations = []
     if (token.fontStyle & FontStyle.Underline)
-      styles['text-decoration'] = 'underline'
+      decorations.push('underline')
+    if (token.fontStyle & FontStyle.Strikethrough)
+      decorations.push('line-through')
+    if (decorations.length)
+      styles['text-decoration'] = decorations.join(' ')
   }
   return styles
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds support for handling the `FontStyle.Strikethrough` in a few places where it was not present. The primary motivation was to support ANSI strikethrough which is supported by the underlying `ansi-sequence-parser` package but not by Shiki.

### Linked Issues

Fixes #975 by myself

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I would appreciate any help in pointing out the new test cases which should be added to cover the changed code (and where to add them).
