### PR TITLE
docs: clarify that the `forgiving` option is for unsupported languages

### DIFF
--- a/docs/guide/regex-engines.md
+++ b/docs/guide/regex-engines.md
@@ -37,7 +37,7 @@ const shiki = await createShiki({
 
 ## JavaScript RegExp Engine
 
-This engine uses JavaScript's native `RegExp`. Since regular expressions used by TextMate grammars are written for Oniguruma, they might contain syntax that is not supported by JavaScript's `RegExp`, or expect different behavior for the same syntax. So we use [Oniguruma-To-ES](https://github.com/slevithan/oniguruma-to-es) to transpile Oniguruma patterns to native JavaScript regexes.
+This engine uses JavaScript's native `RegExp`. Since regular expressions used by TextMate grammars are written for Oniguruma, we use [Oniguruma-To-ES](https://github.com/slevithan/oniguruma-to-es) to transpile Oniguruma patterns to native JavaScript regexes.
 
 ```ts {2,4,9}
 import { createHighlighter } from 'shiki'
@@ -54,22 +54,24 @@ const shiki = await createHighlighter({
 const html = shiki.codeToHtml('const a = 1', { lang: 'javascript', theme: 'nord' })
 ```
 
-The advantages of using the JavaScript engine are that it doesn't require loading a large WebAssembly file for Oniguruma and it is faster for some grammars (since the regular expressions run as native JavaScript).
+The advantages of using the JavaScript engine are that it doesn't require loading a large WebAssembly file for Oniguruma and it is faster for some languages (since the regular expressions run as native JavaScript).
 
-Please check the [compatibility table](/references/engine-js-compat) for the support status of languages you are using.
+Please check the [compatibility table](/references/engine-js-compat) for the support status of languages you are using. Almost all languages are supported.
 
-The JavaScript engine is strict by default, and will throw an error if it encounters a pattern that it cannot convert. If mismatches are acceptable and you want best-effort results for unsupported grammars, you can enable the `forgiving` option to suppress any conversion errors:
+::: info
+The JavaScript engine is best when running in the browser and in cases when you want to control the bundle size. If you run Shiki on Node.js (or at build time) and bundle size or WebAssembly support is not a concern, the Oniguruma engine ensures maximum language compatibility.
+:::
+
+### Use with Unsupported Languages
+
+Unlike the Oniguruma engine, the JavaScript engine is strict by default. It will throw an error if it encounters an invalid Oniguruma pattern or a pattern that it cannot convert. If you want best-effort results for unsupported grammars, you can enable the `forgiving` option to suppress any conversion errors:
 
 ```ts
 const jsEngine = createJavaScriptRegexEngine({ forgiving: true })
 // ...use the engine
 ```
 
-::: info
-If you run Shiki on Node.js (or at build time) and bundle size or WebAssembly support is not a concern, we still recommend using the Oniguruma engine.
-
-The JavaScript engine is best when running in the browser and in cases when you want to control the bundle size.
-:::
+Please use this option with caution as highlighting mismatches may occur.
 
 ### JavaScript Runtime Target
 
@@ -92,7 +94,7 @@ Pre-compiled languages are not yet supported, due to a [known issue](https://git
 :::
 
 ::: info
-Pre-compiled languages require support for RegExp UnicodeSets (the `v` flag), which requires **ES2024** or Node.js 20+, and may not work in older environments. [Can I use](https://caniuse.com/mdn-javascript_builtins_regexp_unicodesets).
+Pre-compiled languages require support for RegExp UnicodeSets (the `v` flag), which requires ES2024 or Node.js 20+, and may not work in older environments. [Can I use](https://caniuse.com/mdn-javascript_builtins_regexp_unicodesets).
 :::
 
 You can install them with `@shikijs/langs-precompiled`, and change your `@shikijs/langs` imports to `@shikijs/langs-precompiled`:

--- a/docs/references/engine-js-compat.md
+++ b/docs/references/engine-js-compat.md
@@ -2,11 +2,11 @@
 
 Compatibility reference of all built-in grammars with the [JavaScript RegExp engine](/guide/regex-engines#javascript-regexp-engine).
 
-> Generated on Tuesday, March 11, 2025
+> Generated on Tuesday, April 29, 2025
 >
-> Version `3.1.0`
+> Version `3.3.0`
 >
-> Runtime: Node.js v22.13.1
+> Runtime: Node.js v23.11.0
 
 ## Report Summary
 
@@ -26,9 +26,9 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | ------------------ | :-------------- | ----------------: | --------------: | ---: |
 | abap               | ✅ OK           |                52 |               - |      |
 | actionscript-3     | ✅ OK           |                57 |               - |      |
-| ada                | ✅ OK           |               201 |               - |      |
-| angular-html       | ✅ OK           |               665 |               - |      |
-| angular-ts         | ✅ OK           |               772 |               - |      |
+| ada                | ✅ OK           |               200 |               - |      |
+| angular-html       | ✅ OK           |               669 |               - |      |
+| angular-ts         | ✅ OK           |               776 |               - |      |
 | apache             | ✅ OK           |                60 |               - |      |
 | apex               | ✅ OK           |               186 |               - |      |
 | apl                | ✅ OK           |               912 |               - |      |
@@ -39,30 +39,30 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | astro              | ✅ OK           |               610 |               - |      |
 | awk                | ✅ OK           |                36 |               - |      |
 | ballerina          | ✅ OK           |               223 |               - |      |
-| bash               | ✅ OK           |               148 |               - |      |
+| bash               | ✅ OK           |               147 |               - |      |
 | bat                | ✅ OK           |                58 |               - |      |
 | beancount          | ✅ OK           |                39 |               - |      |
 | berry              | ✅ OK           |                18 |               - |      |
 | bibtex             | ✅ OK           |                19 |               - |      |
 | bicep              | ✅ OK           |                27 |               - |      |
-| blade              | ✅ OK           |              1121 |               - |      |
+| blade              | ✅ OK           |              1119 |               - |      |
 | bsl                | ✅ OK           |                96 |               - |      |
 | c                  | ✅ OK           |               176 |               - |      |
 | cadence            | ✅ OK           |                71 |               - |      |
 | cairo              | ✅ OK           |               236 |               - |      |
-| clarity            | ✅ OK           |                43 |               - |      |
+| clarity            | ✅ OK           |                42 |               - |      |
 | clj                | ✅ OK           |                38 |               - |      |
 | clojure            | ✅ OK           |                38 |               - |      |
 | cmake              | ✅ OK           |                23 |               - |      |
 | cobol              | ✅ OK           |               858 |               - |      |
 | codeowners         | ✅ OK           |                 4 |               - |      |
-| codeql             | ✅ OK           |               148 |               - |      |
-| coffee             | ✅ OK           |               467 |               - |      |
+| codeql             | ✅ OK           |               147 |               - |      |
+| coffee             | ✅ OK           |               466 |               - |      |
 | common-lisp        | ✅ OK           |                60 |               - |      |
 | coq                | ✅ OK           |                26 |               - |      |
 | cpp                | ✅ OK           |               505 |               - |      |
-| crystal            | ✅ OK           |              1056 |               - |      |
-| csharp             | ✅ OK           |               302 |               - |      |
+| crystal            | ✅ OK           |              1053 |               - |      |
+| csharp             | ✅ OK           |               301 |               - |      |
 | css                | ✅ OK           |               141 |               - |      |
 | csv                | ✅ OK           |                 1 |               - |      |
 | cue                | ✅ OK           |                85 |               - |      |
@@ -79,13 +79,13 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | elixir             | ✅ OK           |               704 |               - |      |
 | elm                | ✅ OK           |               241 |               - |      |
 | emacs-lisp         | ✅ OK           |               153 |               - |   22 |
-| erb                | ✅ OK           |              1767 |               - |      |
+| erb                | ✅ OK           |              1763 |               - |      |
 | erlang             | ✅ OK           |               144 |               - |      |
 | fennel             | ✅ OK           |                31 |               - |      |
 | fish               | ✅ OK           |                25 |               - |      |
 | fluent             | ✅ OK           |                23 |               - |      |
-| fortran-fixed-form | ✅ OK           |               331 |               - |      |
-| fortran-free-form  | ✅ OK           |               327 |               - |      |
+| fortran-fixed-form | ✅ OK           |               330 |               - |      |
+| fortran-free-form  | ✅ OK           |               326 |               - |      |
 | fsharp             | ✅ OK           |               238 |               - |      |
 | fsl                | ✅ OK           |                30 |               - |      |
 | gdresource         | ✅ OK           |               158 |               - |      |
@@ -98,19 +98,19 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | glimmer-ts         | ✅ OK           |               673 |               - |      |
 | glsl               | ✅ OK           |               185 |               - |      |
 | gnuplot            | ✅ OK           |                82 |               - |      |
-| go                 | ✅ OK           |               123 |               - |      |
+| go                 | ✅ OK           |               124 |               - |      |
 | graphql            | ✅ OK           |               445 |               - |      |
 | groovy             | ✅ OK           |               130 |               - |      |
-| hack               | ✅ OK           |               943 |               - |      |
+| hack               | ✅ OK           |               940 |               - |      |
 | haml               | ✅ OK           |               559 |               - |      |
 | handlebars         | ✅ OK           |               696 |               - |      |
-| haskell            | ✅ OK           |               163 |               - |      |
+| haskell            | ✅ OK           |               157 |               - |      |
 | haxe               | ✅ OK           |               173 |               - |      |
 | hcl                | ✅ OK           |                67 |               - |      |
 | hjson              | ✅ OK           |                57 |               - |      |
 | hlsl               | ✅ OK           |                52 |               - |      |
 | html               | ✅ OK           |               608 |               - |      |
-| http               | ✅ OK           |               747 |               - |      |
+| http               | ✅ OK           |               746 |               - |      |
 | hxml               | ✅ OK           |               181 |               - |      |
 | hy                 | ✅ OK           |                12 |               - |      |
 | imba               | ✅ OK           |               239 |               - |      |
@@ -126,17 +126,17 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | jsonnet            | ✅ OK           |                33 |               - |      |
 | jssm               | ✅ OK           |                30 |               - |      |
 | jsx                | ✅ OK           |               375 |               - |      |
-| julia              | ✅ OK           |              1159 |               - |      |
+| julia              | ✅ OK           |              1158 |               - |      |
 | kotlin             | ✅ OK           |                58 |               - |      |
 | kusto              | ✅ OK           |                60 |               - |      |
-| latex              | ✅ OK           |               286 |               - |      |
+| latex              | ✅ OK           |               292 |               - |      |
 | lean               | ✅ OK           |                32 |               - |      |
 | less               | ✅ OK           |               279 |               - |      |
 | liquid             | ✅ OK           |               689 |               - |      |
 | llvm               | ✅ OK           |                25 |               - |      |
 | log                | ✅ OK           |                31 |               - |      |
 | logo               | ✅ OK           |                 9 |               - |      |
-| lua                | ✅ OK           |               277 |               - |      |
+| lua                | ✅ OK           |               276 |               - |      |
 | luau               | ✅ OK           |                88 |               - |      |
 | make               | ✅ OK           |                51 |               - |      |
 | markdown           | ✅ OK           |               118 |               - |      |
@@ -147,19 +147,19 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | mermaid            | ✅ OK           |               134 |               - |      |
 | mipsasm            | ✅ OK           |                17 |               - |      |
 | mojo               | ✅ OK           |               213 |               - |      |
-| move               | ✅ OK           |               118 |               - |      |
+| move               | ✅ OK           |               116 |               - |      |
 | narrat             | ✅ OK           |                34 |               - |      |
 | nextflow           | ✅ OK           |                32 |               - |      |
-| nginx              | ✅ OK           |               376 |               - |      |
-| nim                | ✅ OK           |              1118 |               - |      |
+| nginx              | ✅ OK           |               375 |               - |      |
+| nim                | ✅ OK           |              1117 |               - |      |
 | nix                | ✅ OK           |                80 |               - |      |
-| nushell            | ✅ OK           |                81 |               - |      |
+| nushell            | ✅ OK           |                85 |               - |      |
 | objective-c        | ✅ OK           |               222 |               - |      |
-| objective-cpp      | ✅ OK           |               307 |               - |      |
+| objective-cpp      | ✅ OK           |               306 |               - |      |
 | ocaml              | ✅ OK           |               178 |               - |      |
 | pascal             | ✅ OK           |                23 |               - |      |
 | perl               | ✅ OK           |               936 |               - |      |
-| php                | ✅ OK           |              1125 |               - |      |
+| php                | ✅ OK           |              1123 |               - |      |
 | plsql              | ✅ OK           |                45 |               - |      |
 | po                 | ✅ OK           |                23 |               - |      |
 | polar              | ✅ OK           |                31 |               - |      |
@@ -179,13 +179,13 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | r                  | ✅ OK           |                71 |               - |      |
 | racket             | ✅ OK           |                69 |               - |      |
 | raku               | ✅ OK           |                52 |               - |      |
-| razor              | ✅ OK           |               943 |               - |      |
+| razor              | ✅ OK           |               942 |               - |      |
 | reg                | ✅ OK           |                 9 |               - |      |
 | regexp             | ✅ OK           |                34 |               - |      |
 | rel                | ✅ OK           |                17 |               - |      |
 | riscv              | ✅ OK           |                36 |               - |      |
-| rst                | ✅ OK           |              2008 |               - |      |
-| ruby               | ✅ OK           |              1759 |               - |      |
+| rst                | ✅ OK           |              2004 |               - |      |
+| ruby               | ✅ OK           |              1755 |               - |      |
 | rust               | ✅ OK           |                89 |               - |      |
 | sas                | ✅ OK           |                99 |               - |      |
 | sass               | ✅ OK           |                69 |               - |      |
@@ -194,10 +194,10 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | scss               | ✅ OK           |               233 |               - |      |
 | sdbl               | ✅ OK           |                23 |               - |      |
 | shaderlab          | ✅ OK           |                87 |               - |      |
-| shellscript        | ✅ OK           |               148 |               - |      |
-| shellsession       | ✅ OK           |               150 |               - |      |
+| shellscript        | ✅ OK           |               147 |               - |      |
+| shellsession       | ✅ OK           |               149 |               - |      |
 | smalltalk          | ✅ OK           |                35 |               - |      |
-| solidity           | ✅ OK           |               102 |               - |      |
+| solidity           | ✅ OK           |               103 |               - |      |
 | soy                | ✅ OK           |               646 |               - |      |
 | sparql             | ✅ OK           |                19 |               - |      |
 | splunk             | ✅ OK           |                17 |               - |      |
@@ -211,15 +211,15 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | talonscript        | ✅ OK           |                45 |               - |      |
 | tasl               | ✅ OK           |                23 |               - |      |
 | tcl                | ✅ OK           |                34 |               - |      |
-| templ              | ✅ OK           |               671 |               - |      |
+| templ              | ✅ OK           |               672 |               - |      |
 | terraform          | ✅ OK           |                68 |               - |      |
 | tex                | ✅ OK           |               106 |               - |      |
 | toml               | ✅ OK           |                44 |               - |      |
-| ts-tags            | ✅ OK           |               990 |               - |      |
+| ts-tags            | ✅ OK           |               989 |               - |      |
 | tsv                | ✅ OK           |                 1 |               - |      |
 | tsx                | ✅ OK           |               375 |               - |      |
 | turtle             | ✅ OK           |                15 |               - |      |
-| twig               | ✅ OK           |              2397 |               - |      |
+| twig               | ✅ OK           |              2390 |               - |      |
 | typescript         | ✅ OK           |               362 |               - |      |
 | typespec           | ✅ OK           |                73 |               - |      |
 | typst              | ✅ OK           |                78 |               - |      |
@@ -227,7 +227,7 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | vala               | ✅ OK           |                20 |               - |      |
 | vb                 | ✅ OK           |                34 |               - |      |
 | verilog            | ✅ OK           |                33 |               - |      |
-| vhdl               | ✅ OK           |                81 |               - |      |
+| vhdl               | ✅ OK           |                82 |               - |      |
 | viml               | ✅ OK           |                72 |               - |      |
 | vue                | ✅ OK           |               690 |               - |      |
 | vue-html           | ✅ OK           |               714 |               - |      |
@@ -243,7 +243,7 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | yaml               | ✅ OK           |                48 |               - |      |
 | zenscript          | ✅ OK           |                21 |               - |      |
 | zig                | ✅ OK           |                51 |               - |      |
-| zsh                | ✅ OK           |               148 |               - |      |
+| zsh                | ✅ OK           |               147 |               - |      |
 
 ###### Table Field Explanations
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,8 +202,8 @@ catalogs:
       specifier: ^6.7.14
       version: 6.7.14
     oniguruma-to-es:
-      specifier: ^4.2.0
-      version: 4.2.0
+      specifier: ^4.3.1
+      version: 4.3.1
   testing:
     '@vitest/coverage-v8':
       specifier: ^3.1.2
@@ -552,7 +552,7 @@ importers:
         version: 10.0.2
       oniguruma-to-es:
         specifier: catalog:prod
-        version: 4.2.0
+        version: 4.3.1
 
   packages/engine-oniguruma:
     dependencies:
@@ -584,7 +584,7 @@ importers:
         version: link:../types
       oniguruma-to-es:
         specifier: catalog:prod
-        version: 4.2.0
+        version: 4.3.1
     devDependencies:
       tm-grammars:
         specifier: catalog:inlined
@@ -2894,9 +2894,6 @@ packages:
   electron-to-chromium@1.5.76:
     resolution: {integrity: sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==}
 
-  emoji-regex-xs@1.0.0:
-    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
-
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
 
@@ -3975,11 +3972,11 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  oniguruma-parser@0.11.0:
-    resolution: {integrity: sha512-9M+tFRnJWtRxsgh4XFlkw+AVFtzEtI8UfTifx6sDbtt47SpEl/K65PunQyp/jvfp0xwLGjtbE5aKQcL8j6AXYw==}
+  oniguruma-parser@0.12.0:
+    resolution: {integrity: sha512-fD9o5ebCmEAA9dLysajdQvuKzLL7cj+w7DQjuO3Cb6IwafENfx6iL+RGkmyW82pVRsvgzixsWinHvgxTMJvdIA==}
 
-  oniguruma-to-es@4.2.0:
-    resolution: {integrity: sha512-MDPs6KSOLS0tKQ7joqg44dRIRZUyotfTy0r+7oEEs6VwWWP0+E2PPDYWMFN0aqOjRyWHBYq7RfKw9GQk2S2z5g==}
+  oniguruma-to-es@4.3.1:
+    resolution: {integrity: sha512-VtX1kepWO+7HG7IWV5v72JhiqofK7XsiHmtgnvurnNOTdIvE5mrdWYtsOrQyrXCv1L2Ckm08hywp+MFO7rC4Ug==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -7341,8 +7338,6 @@ snapshots:
 
   electron-to-chromium@1.5.76: {}
 
-  emoji-regex-xs@1.0.0: {}
-
   emoji-regex@10.4.0: {}
 
   emoji-regex@8.0.0: {}
@@ -8774,12 +8769,11 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  oniguruma-parser@0.11.0: {}
+  oniguruma-parser@0.12.0: {}
 
-  oniguruma-to-es@4.2.0:
+  oniguruma-to-es@4.3.1:
     dependencies:
-      emoji-regex-xs: 1.0.0
-      oniguruma-parser: 0.11.0
+      oniguruma-parser: 0.12.0
       regex: 6.0.1
       regex-recursion: 6.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,7 +86,7 @@ catalogs:
     '@shikijs/vscode-textmate': ^10.0.2
     ansis: ^3.17.0
     cac: ^6.7.14
-    oniguruma-to-es: ^4.2.0
+    oniguruma-to-es: ^4.3.1
 
   testing:
     '@vitest/coverage-v8': ^3.1.2


### PR DESCRIPTION
- Updates to `regex-engines.md` for clarity.
- Bump `oniguruma-to-es`, and rerun the engine compatibility report (no changes).