### PR TITLE
feat(transformers): `transformerRemoveNotationEscape` support rehype plugin usage

### DIFF
--- a/packages/transformers/src/transformers/remove-notation-escape.ts
+++ b/packages/transformers/src/transformers/remove-notation-escape.ts
@@ -1,4 +1,5 @@
 import type { ShikiTransformer } from '@shikijs/types'
+import type { ElementContent } from 'hast'
 
 /**
  * Remove notation escapes.
@@ -8,8 +9,20 @@ import type { ShikiTransformer } from '@shikijs/types'
 export function transformerRemoveNotationEscape(): ShikiTransformer {
   return {
     name: '@shikijs/transformers:remove-notation-escape',
-    postprocess(code) {
-      return code.replace(/\[\\!code/g, '[!code')
+    code(hast) {
+      function replace(node: ElementContent): void {
+        if (node.type === 'text') {
+          node.value = node.value.replace('\\[!code', '[!code')
+        }
+        else if ('children' in node) {
+          for (const child of node.children) {
+            replace(child)
+          }
+        }
+      }
+
+      replace(hast)
+      return hast
     },
   }
 }


### PR DESCRIPTION


<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Support usage with `rehypeShiki`, which doesn't support `postprocess` and some other transformer hooks.

This is possible by using `line` hook instead.

### Linked Issues

fixes #1010 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
