### PR TITLE
fix: correct style comparison logic in mergeAdjacentStyledTokens

### DIFF
--- a/packages/core/src/highlight/code-to-hast.ts
+++ b/packages/core/src/highlight/code-to-hast.ts
@@ -322,8 +322,8 @@ function mergeAdjacentStyledTokens(tokens: ThemedToken[][]): ThemedToken[][] {
       }
 
       const prevToken = newLine[newLine.length - 1]
-      const prevStyle = prevToken.htmlStyle || stringifyTokenStyle(getTokenStyleObject(prevToken))
-      const currentStyle = token.htmlStyle || stringifyTokenStyle(getTokenStyleObject(token))
+      const prevStyle = stringifyTokenStyle(prevToken.htmlStyle || getTokenStyleObject(prevToken))
+      const currentStyle = stringifyTokenStyle(token.htmlStyle || getTokenStyleObject(token))
       const isPrevDecorated = prevToken.fontStyle && (
         (prevToken.fontStyle & FontStyle.Underline)
         || (prevToken.fontStyle & FontStyle.Strikethrough)

--- a/packages/core/test/hast.test.ts
+++ b/packages/core/test/hast.test.ts
@@ -112,6 +112,38 @@ describe('merge same style', () => {
     expect(html).toMatchInlineSnapshot(`"<pre class="shiki min-light" style="background-color:#ffffff;color:#24292eff" tabindex="0"><code><span class="line"><span style="color:#D32F2F">name:</span><span style="color:#22863A"> CI</span></span></code></pre>"`)
   })
 
+  it('merges adjacent tokens with dual themes', async () => {
+    using shiki = await createHighlighter({
+      themes: ['min-light', 'min-dark'],
+      langs: ['yaml'],
+    })
+
+    const code = 'name: CI'
+    const html = await shiki.codeToHtml(code, {
+      lang: 'yaml',
+      themes: { dark: 'min-dark', light: 'min-light' },
+      mergeSameStyleTokens: true,
+    })
+
+    expect(html).toMatchInlineSnapshot(`"<pre class="shiki shiki-themes min-light min-dark" style="background-color:#ffffff;--shiki-dark-bg:#1f1f1f;color:#24292eff;--shiki-dark:#b392f0" tabindex="0"><code><span class="line"><span style="color:#D32F2F;--shiki-dark:#F8F8F8">name</span><span style="color:#D32F2F;--shiki-dark:#F97583">:</span><span style="color:#22863A;--shiki-dark:#FFAB70"> CI</span></span></code></pre>"`)
+  })
+
+  it('merges adjacent tokens with the same dual themes', async () => {
+    using shiki = await createHighlighter({
+      themes: ['min-light'],
+      langs: ['yaml'],
+    })
+
+    const code = 'name: CI'
+    const html = await shiki.codeToHtml(code, {
+      lang: 'yaml',
+      themes: { dark: 'min-light', light: 'min-light' },
+      mergeSameStyleTokens: true,
+    })
+
+    expect(html).toMatchInlineSnapshot(`"<pre class="shiki shiki-themes min-light min-light" style="background-color:#ffffff;--shiki-dark-bg:#ffffff;color:#24292eff;--shiki-dark:#24292eff" tabindex="0"><code><span class="line"><span style="color:#D32F2F;--shiki-dark:#D32F2F">name:</span><span style="color:#22863A;--shiki-dark:#22863A"> CI</span></span></code></pre>"`)
+  })
+
   it('does not merge tokens with decorations', async () => {
     using shiki = await createHighlighter({
       themes: ['min-light'],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR fixes an issue where adjacent tokens with identical styles weren't being merged correctly when multiple themes were applied.

Debug logs showed that even though prevStyle and currentStyle contained the same CSS properties, the === comparison was returning false because they were different object instances.

### Linked Issues
fix #1003 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
