### PR TITLE
feat: add support for CSS `light-dark()` function in dual themes

### DIFF
--- a/docs/guide/dual-themes.md
+++ b/docs/guide/dual-themes.md
@@ -77,7 +77,9 @@ html.dark .shiki span {
 
 ## `light-dark()` Function
 
-If you want to use the [`light-dark()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) function along with the `--shiki-*` CSS variables, you can do so by using the `useLightDarkFunction` option in `codeToHtml`:
+You can also use [`light-dark()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) function to avoid manually maintaining the CSS variables.
+
+Set `defaultColor` to a special value `light-dark()` to use it. When using this, it requires both `light` and `dark` themes to be provided.
 
 ```ts twoslash
 import { codeToHtml } from 'shiki'
@@ -88,12 +90,12 @@ const code = await codeToHtml('console.log("hello")', {
     light: 'min-light',
     dark: 'nord',
   },
-  useLightDarkFunction: true, // [!code hl]
+  defaultColor: 'light-dark()', // [!code hl]
 })
 ```
 
 :::info Compatibility Note
-The `light-dark()` function is relatively new and may not be supported in older browsers. If you need to support older browsers, consider using the class-based or query-based dark mode methods instead.
+The `light-dark()` function is relatively new and may not be supported in older browsers. [Can I use?](https://caniuse.com/?search=css-light-dark)
 :::
 
 ## Multiple Themes

--- a/docs/guide/dual-themes.md
+++ b/docs/guide/dual-themes.md
@@ -75,29 +75,6 @@ html.dark .shiki span {
 }
 ```
 
-## `light-dark()` Function
-
-You can also use [`light-dark()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) function to avoid manually maintaining the CSS variables.
-
-Set `defaultColor` to a special value `light-dark()` to use it. When using this, it requires both `light` and `dark` themes to be provided.
-
-```ts twoslash
-import { codeToHtml } from 'shiki'
-
-const code = await codeToHtml('console.log("hello")', {
-  lang: 'javascript',
-  themes: {
-    light: 'min-light',
-    dark: 'nord',
-  },
-  defaultColor: 'light-dark()', // [!code hl]
-})
-```
-
-:::info Compatibility Note
-The `light-dark()` function is relatively new and may not be supported in older browsers. [Can I use?](https://caniuse.com/?search=css-light-dark)
-:::
-
 ## Multiple Themes
 
 It's also possible to support more than two themes. In the `themes` object, you can have an arbitrary number of themes, and specify the default theme with `defaultColor` option.
@@ -170,3 +147,26 @@ With it, a token would be generated like:
 In that case, the generated HTML would have no style out of the box, you need to add your own CSS to control the colors.
 
 It's also possible to control the theme in CSS variables. For more, refer to the great research and examples by [@mayank99](https://github.com/mayank99) in [this issue #6](https://github.com/antfu/shikiji/issues/6).
+
+## `light-dark()` Function
+
+You can also use [`light-dark()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) function to avoid manually maintaining the CSS variables.
+
+Set `defaultColor` to a special value `light-dark()` to use it. When using this, it requires both `light` and `dark` themes to be provided.
+
+```ts twoslash
+import { codeToHtml } from 'shiki'
+
+const code = await codeToHtml('console.log("hello")', {
+  lang: 'javascript',
+  themes: {
+    light: 'min-light',
+    dark: 'nord',
+  },
+  defaultColor: 'light-dark()', // [!code hl]
+})
+```
+
+:::info Compatibility Note
+The `light-dark()` function is relatively new and may not be supported in older browsers. [Can I use?](https://caniuse.com/?search=css-light-dark)
+:::

--- a/docs/guide/dual-themes.md
+++ b/docs/guide/dual-themes.md
@@ -75,6 +75,27 @@ html.dark .shiki span {
 }
 ```
 
+## `light-dark()` Function
+
+If you want to use the [`light-dark()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) function along with the `--shiki-*` CSS variables, you can do so by using the `useLightDarkFunction` option in `codeToHtml`:
+
+```ts twoslash
+import { codeToHtml } from 'shiki'
+
+const code = await codeToHtml('console.log("hello")', {
+  lang: 'javascript',
+  themes: {
+    light: 'min-light',
+    dark: 'nord',
+  },
+  useLightDarkFunction: true, // [!code hl]
+})
+```
+
+:::info Compatibility Note
+The `light-dark()` function is relatively new and may not be supported in older browsers. If you need to support older browsers, consider using the class-based or query-based dark mode methods instead.
+:::
+
 ## Multiple Themes
 
 It's also possible to support more than two themes. In the `themes` object, you can have an arbitrary number of themes, and specify the default theme with `defaultColor` option.

--- a/packages/core/src/highlight/code-to-tokens.ts
+++ b/packages/core/src/highlight/code-to-tokens.ts
@@ -1,7 +1,8 @@
 import type { CodeToTokensOptions, GrammarState, ShikiInternal, StringLiteralUnion, ThemedToken, ThemeRegistrationAny, TokensResult } from '@shikijs/types'
 import { ShikiError } from '@shikijs/types'
 import { getLastGrammarStateFromMap, setLastGrammarStateToMap } from '../textmate/grammar-state'
-import { applyColorReplacements, DEFAULT_THEME_LIGHT_DARK, flatTokenVariants, resolveColorReplacements } from '../utils'
+import { applyColorReplacements, flatTokenVariants, resolveColorReplacements } from '../utils'
+import { DEFAULT_COLOR_LIGHT_DARK } from '../utils/_constants'
 import { codeToTokensBase } from './code-to-tokens-base'
 import { codeToTokensWithThemes } from './code-to-tokens-themes'
 
@@ -45,7 +46,7 @@ export function codeToTokens(
 
     grammarState = getLastGrammarStateFromMap(themeTokens)
 
-    if (defaultColor && DEFAULT_THEME_LIGHT_DARK !== defaultColor && !themes.find(t => t.color === defaultColor))
+    if (defaultColor && DEFAULT_COLOR_LIGHT_DARK !== defaultColor && !themes.find(t => t.color === defaultColor))
       throw new ShikiError(`\`themes\` option must contain the defaultColor key \`${defaultColor}\``)
 
     const themeRegs = themes.map(t => internal.getTheme(t.theme))
@@ -107,7 +108,7 @@ function mapThemeColors(
       const cssVar = `${cssVariablePrefix + t.color}${property === 'bg' ? '-bg' : ''}:${value}`
       if (idx === 0 && defaultColor) {
         // light-dark()
-        if (defaultColor === DEFAULT_THEME_LIGHT_DARK && themes.length > 1) {
+        if (defaultColor === DEFAULT_COLOR_LIGHT_DARK && themes.length > 1) {
           const lightIndex = themes.findIndex(t => t.color === 'light')
           const darkIndex = themes.findIndex(t => t.color === 'dark')
           if (lightIndex === -1 || darkIndex === -1)

--- a/packages/core/src/utils/_constants.ts
+++ b/packages/core/src/utils/_constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_COLOR_LIGHT_DARK = 'light-dark()'

--- a/packages/core/src/utils/tokens.ts
+++ b/packages/core/src/utils/tokens.ts
@@ -1,8 +1,7 @@
 import type { ThemedToken, ThemedTokenWithVariants, TokenStyles } from '@shikijs/types'
 import { ShikiError } from '@shikijs/types'
 import { FontStyle } from '@shikijs/vscode-textmate'
-
-export const DEFAULT_THEME_LIGHT_DARK = 'light-dark()'
+import { DEFAULT_COLOR_LIGHT_DARK } from './_constants'
 
 /**
  * Split a token into multiple tokens by given offsets.
@@ -95,7 +94,7 @@ export function flatTokenVariants(
 
       if (idx === 0 && defaultColor) {
         // light-dark()
-        if (defaultColor === DEFAULT_THEME_LIGHT_DARK && styles.length > 1) {
+        if (defaultColor === DEFAULT_COLOR_LIGHT_DARK && styles.length > 1) {
           const lightIndex = variantsOrder.findIndex(t => t === 'light')
           const darkIndex = variantsOrder.findIndex(t => t === 'dark')
           if (lightIndex === -1 || darkIndex === -1)

--- a/packages/core/src/utils/tokens.ts
+++ b/packages/core/src/utils/tokens.ts
@@ -73,6 +73,7 @@ export function flatTokenVariants(
   variantsOrder: string[],
   cssVariablePrefix: string,
   defaultColor: string | boolean,
+  useLightDarkFunction: boolean,
 ): ThemedToken {
   const token: ThemedToken = {
     content: merged.content,
@@ -91,7 +92,15 @@ export function flatTokenVariants(
       const value = cur[key] || 'inherit'
 
       if (idx === 0 && defaultColor) {
-        mergedStyles[key] = value
+        if (useLightDarkFunction && styles.length > 1) {
+          mergedStyles[key] = `light-dark(${value}, ${styles[idx + 1][key] || 'inherit'})`
+          const keyName = key === 'color' ? '' : key === 'background-color' ? '-bg' : `-${key}`
+          const varKey = cssVariablePrefix + variantsOrder[idx] + (key === 'color' ? '' : keyName)
+          mergedStyles[varKey] = value
+        }
+        else {
+          mergedStyles[key] = value
+        }
       }
       else {
         const keyName = key === 'color' ? '' : key === 'background-color' ? '-bg' : `-${key}`

--- a/packages/core/test/__snapshots__/tokens.test.ts.snap
+++ b/packages/core/test/__snapshots__/tokens.test.ts.snap
@@ -1,5 +1,423 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`defaultColor light-dark() > basic > css-vars 1`] = `
+{
+  "bg": "--shiki-light-bg:#ffffff;--shiki-dark-bg:#121212",
+  "fg": "--shiki-light:#393a34;--shiki-dark:#dbd7caee",
+  "grammarState": {
+    "lang": "javascript",
+    "scopes": [
+      "source.js",
+    ],
+    "theme": "vitesse-light",
+    "themes": [
+      "vitesse-light",
+      "vitesse-dark",
+    ],
+  },
+  "rootStyle": "--shiki-light:#393a34;--shiki-dark:#dbd7caee;--shiki-light-bg:#ffffff;--shiki-dark-bg:#121212",
+  "themeName": "shiki-themes vitesse-light vitesse-dark",
+  "tokens": [
+    [
+      {
+        "content": "console",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#BD976A",
+          "--shiki-light": "#B07D48",
+        },
+        "offset": 0,
+      },
+      {
+        "content": ".",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+        },
+        "offset": 7,
+      },
+      {
+        "content": "log",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#80A665",
+          "--shiki-light": "#59873A",
+        },
+        "offset": 8,
+      },
+      {
+        "content": "(",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+        },
+        "offset": 11,
+      },
+      {
+        "content": """,
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#C98A7D77",
+          "--shiki-light": "#B5695977",
+        },
+        "offset": 12,
+      },
+      {
+        "content": "hello",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#C98A7D",
+          "--shiki-light": "#B56959",
+        },
+        "offset": 13,
+      },
+      {
+        "content": """,
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#C98A7D77",
+          "--shiki-light": "#B5695977",
+        },
+        "offset": 18,
+      },
+      {
+        "content": ")",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+        },
+        "offset": 19,
+      },
+    ],
+  ],
+}
+`;
+
+exports[`defaultColor light-dark() > basic > light-dark() 1`] = `
+{
+  "bg": "light-dark(#ffffff, #121212);--shiki-light-bg:#ffffff;--shiki-dark-bg:#121212",
+  "fg": "light-dark(#393a34, #dbd7caee);--shiki-light:#393a34;--shiki-dark:#dbd7caee",
+  "grammarState": {
+    "lang": "javascript",
+    "scopes": [
+      "source.js",
+    ],
+    "theme": "vitesse-light",
+    "themes": [
+      "vitesse-light",
+      "vitesse-dark",
+    ],
+  },
+  "rootStyle": undefined,
+  "themeName": "shiki-themes vitesse-light vitesse-dark",
+  "tokens": [
+    [
+      {
+        "content": "console",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#BD976A",
+          "--shiki-light": "#B07D48",
+          "color": "light-dark(#B07D48, #BD976A)",
+        },
+        "offset": 0,
+      },
+      {
+        "content": ".",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+          "color": "light-dark(#999999, #666666)",
+        },
+        "offset": 7,
+      },
+      {
+        "content": "log",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#80A665",
+          "--shiki-light": "#59873A",
+          "color": "light-dark(#59873A, #80A665)",
+        },
+        "offset": 8,
+      },
+      {
+        "content": "(",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+          "color": "light-dark(#999999, #666666)",
+        },
+        "offset": 11,
+      },
+      {
+        "content": """,
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#C98A7D77",
+          "--shiki-light": "#B5695977",
+          "color": "light-dark(#B5695977, #C98A7D77)",
+        },
+        "offset": 12,
+      },
+      {
+        "content": "hello",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#C98A7D",
+          "--shiki-light": "#B56959",
+          "color": "light-dark(#B56959, #C98A7D)",
+        },
+        "offset": 13,
+      },
+      {
+        "content": """,
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#C98A7D77",
+          "--shiki-light": "#B5695977",
+          "color": "light-dark(#B5695977, #C98A7D77)",
+        },
+        "offset": 18,
+      },
+      {
+        "content": ")",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+          "color": "light-dark(#999999, #666666)",
+        },
+        "offset": 19,
+      },
+    ],
+  ],
+}
+`;
+
+exports[`defaultColor light-dark() > defaultColor light-dark() with multiple themes > css-vars 1`] = `
+{
+  "bg": "--shiki-dark-bg:#121212;--shiki-light-bg:#ffffff;--shiki-custom-bg:#24292e",
+  "fg": "--shiki-dark:#dbd7caee;--shiki-light:#393a34;--shiki-custom:#e1e4e8",
+  "grammarState": {
+    "lang": "javascript",
+    "scopes": [
+      "source.js",
+    ],
+    "theme": "vitesse-dark",
+    "themes": [
+      "vitesse-dark",
+      "vitesse-light",
+      "github-dark",
+    ],
+  },
+  "rootStyle": "--shiki-dark:#dbd7caee;--shiki-light:#393a34;--shiki-custom:#e1e4e8;--shiki-dark-bg:#121212;--shiki-light-bg:#ffffff;--shiki-custom-bg:#24292e",
+  "themeName": "shiki-themes vitesse-dark vitesse-light github-dark",
+  "tokens": [
+    [
+      {
+        "content": "console",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#E1E4E8",
+          "--shiki-dark": "#BD976A",
+          "--shiki-light": "#B07D48",
+        },
+        "offset": 0,
+      },
+      {
+        "content": ".",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#E1E4E8",
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+        },
+        "offset": 7,
+      },
+      {
+        "content": "log",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#B392F0",
+          "--shiki-dark": "#80A665",
+          "--shiki-light": "#59873A",
+        },
+        "offset": 8,
+      },
+      {
+        "content": "(",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#E1E4E8",
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+        },
+        "offset": 11,
+      },
+      {
+        "content": """,
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#9ECBFF",
+          "--shiki-dark": "#C98A7D77",
+          "--shiki-light": "#B5695977",
+        },
+        "offset": 12,
+      },
+      {
+        "content": "hello",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#9ECBFF",
+          "--shiki-dark": "#C98A7D",
+          "--shiki-light": "#B56959",
+        },
+        "offset": 13,
+      },
+      {
+        "content": """,
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#9ECBFF",
+          "--shiki-dark": "#C98A7D77",
+          "--shiki-light": "#B5695977",
+        },
+        "offset": 18,
+      },
+      {
+        "content": ")",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#E1E4E8",
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+        },
+        "offset": 19,
+      },
+    ],
+  ],
+}
+`;
+
+exports[`defaultColor light-dark() > defaultColor light-dark() with multiple themes > light-dark() 1`] = `
+{
+  "bg": "light-dark(#ffffff, #121212);--shiki-dark-bg:#121212;--shiki-light-bg:#ffffff;--shiki-custom-bg:#24292e",
+  "fg": "light-dark(#393a34, #dbd7caee);--shiki-dark:#dbd7caee;--shiki-light:#393a34;--shiki-custom:#e1e4e8",
+  "grammarState": {
+    "lang": "javascript",
+    "scopes": [
+      "source.js",
+    ],
+    "theme": "vitesse-dark",
+    "themes": [
+      "vitesse-dark",
+      "vitesse-light",
+      "github-dark",
+    ],
+  },
+  "rootStyle": undefined,
+  "themeName": "shiki-themes vitesse-dark vitesse-light github-dark",
+  "tokens": [
+    [
+      {
+        "content": "console",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#E1E4E8",
+          "--shiki-dark": "#BD976A",
+          "--shiki-light": "#B07D48",
+          "color": "light-dark(#B07D48, #BD976A)",
+        },
+        "offset": 0,
+      },
+      {
+        "content": ".",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#E1E4E8",
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+          "color": "light-dark(#999999, #666666)",
+        },
+        "offset": 7,
+      },
+      {
+        "content": "log",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#B392F0",
+          "--shiki-dark": "#80A665",
+          "--shiki-light": "#59873A",
+          "color": "light-dark(#59873A, #80A665)",
+        },
+        "offset": 8,
+      },
+      {
+        "content": "(",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#E1E4E8",
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+          "color": "light-dark(#999999, #666666)",
+        },
+        "offset": 11,
+      },
+      {
+        "content": """,
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#9ECBFF",
+          "--shiki-dark": "#C98A7D77",
+          "--shiki-light": "#B5695977",
+          "color": "light-dark(#B5695977, #C98A7D77)",
+        },
+        "offset": 12,
+      },
+      {
+        "content": "hello",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#9ECBFF",
+          "--shiki-dark": "#C98A7D",
+          "--shiki-light": "#B56959",
+          "color": "light-dark(#B56959, #C98A7D)",
+        },
+        "offset": 13,
+      },
+      {
+        "content": """,
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#9ECBFF",
+          "--shiki-dark": "#C98A7D77",
+          "--shiki-light": "#B5695977",
+          "color": "light-dark(#B5695977, #C98A7D77)",
+        },
+        "offset": 18,
+      },
+      {
+        "content": ")",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-custom": "#E1E4E8",
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+          "color": "light-dark(#999999, #666666)",
+        },
+        "offset": 19,
+      },
+    ],
+  ],
+}
+`;
+
 exports[`includeExplanation > false 1`] = `
 [
   [
@@ -637,204 +1055,4 @@ exports[`includeExplanation > true 1`] = `
     },
   ],
 ]
-`;
-
-exports[`useLightDarkFunction > false 1`] = `
-{
-  "bg": "#ffffff;--shiki-dark-bg:#121212",
-  "fg": "#393a34;--shiki-dark:#dbd7caee",
-  "grammarState": {
-    "lang": "javascript",
-    "scopes": [
-      "source.js",
-    ],
-    "theme": "vitesse-light",
-    "themes": [
-      "vitesse-light",
-      "vitesse-dark",
-    ],
-  },
-  "rootStyle": undefined,
-  "themeName": "shiki-themes vitesse-light vitesse-dark",
-  "tokens": [
-    [
-      {
-        "content": "console",
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#BD976A",
-          "color": "#B07D48",
-        },
-        "offset": 0,
-      },
-      {
-        "content": ".",
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#666666",
-          "color": "#999999",
-        },
-        "offset": 7,
-      },
-      {
-        "content": "log",
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#80A665",
-          "color": "#59873A",
-        },
-        "offset": 8,
-      },
-      {
-        "content": "(",
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#666666",
-          "color": "#999999",
-        },
-        "offset": 11,
-      },
-      {
-        "content": """,
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#C98A7D77",
-          "color": "#B5695977",
-        },
-        "offset": 12,
-      },
-      {
-        "content": "hello",
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#C98A7D",
-          "color": "#B56959",
-        },
-        "offset": 13,
-      },
-      {
-        "content": """,
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#C98A7D77",
-          "color": "#B5695977",
-        },
-        "offset": 18,
-      },
-      {
-        "content": ")",
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#666666",
-          "color": "#999999",
-        },
-        "offset": 19,
-      },
-    ],
-  ],
-}
-`;
-
-exports[`useLightDarkFunction > true 1`] = `
-{
-  "bg": "light-dark(#ffffff, #121212);--shiki-light-bg:#ffffff;--shiki-dark-bg:#121212",
-  "fg": "light-dark(#393a34, #dbd7caee);--shiki-light:#393a34;--shiki-dark:#dbd7caee",
-  "grammarState": {
-    "lang": "javascript",
-    "scopes": [
-      "source.js",
-    ],
-    "theme": "vitesse-light",
-    "themes": [
-      "vitesse-light",
-      "vitesse-dark",
-    ],
-  },
-  "rootStyle": undefined,
-  "themeName": "shiki-themes vitesse-light vitesse-dark",
-  "tokens": [
-    [
-      {
-        "content": "console",
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#BD976A",
-          "--shiki-light": "#B07D48",
-          "color": "light-dark(#B07D48, #BD976A)",
-        },
-        "offset": 0,
-      },
-      {
-        "content": ".",
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#666666",
-          "--shiki-light": "#999999",
-          "color": "light-dark(#999999, #666666)",
-        },
-        "offset": 7,
-      },
-      {
-        "content": "log",
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#80A665",
-          "--shiki-light": "#59873A",
-          "color": "light-dark(#59873A, #80A665)",
-        },
-        "offset": 8,
-      },
-      {
-        "content": "(",
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#666666",
-          "--shiki-light": "#999999",
-          "color": "light-dark(#999999, #666666)",
-        },
-        "offset": 11,
-      },
-      {
-        "content": """,
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#C98A7D77",
-          "--shiki-light": "#B5695977",
-          "color": "light-dark(#B5695977, #C98A7D77)",
-        },
-        "offset": 12,
-      },
-      {
-        "content": "hello",
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#C98A7D",
-          "--shiki-light": "#B56959",
-          "color": "light-dark(#B56959, #C98A7D)",
-        },
-        "offset": 13,
-      },
-      {
-        "content": """,
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#C98A7D77",
-          "--shiki-light": "#B5695977",
-          "color": "light-dark(#B5695977, #C98A7D77)",
-        },
-        "offset": 18,
-      },
-      {
-        "content": ")",
-        "explanation": undefined,
-        "htmlStyle": {
-          "--shiki-dark": "#666666",
-          "--shiki-light": "#999999",
-          "color": "light-dark(#999999, #666666)",
-        },
-        "offset": 19,
-      },
-    ],
-  ],
-}
 `;

--- a/packages/core/test/__snapshots__/tokens.test.ts.snap
+++ b/packages/core/test/__snapshots__/tokens.test.ts.snap
@@ -638,3 +638,203 @@ exports[`includeExplanation > true 1`] = `
   ],
 ]
 `;
+
+exports[`useLightDarkFunction > false 1`] = `
+{
+  "bg": "#ffffff;--shiki-dark-bg:#121212",
+  "fg": "#393a34;--shiki-dark:#dbd7caee",
+  "grammarState": {
+    "lang": "javascript",
+    "scopes": [
+      "source.js",
+    ],
+    "theme": "vitesse-light",
+    "themes": [
+      "vitesse-light",
+      "vitesse-dark",
+    ],
+  },
+  "rootStyle": undefined,
+  "themeName": "shiki-themes vitesse-light vitesse-dark",
+  "tokens": [
+    [
+      {
+        "content": "console",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#BD976A",
+          "color": "#B07D48",
+        },
+        "offset": 0,
+      },
+      {
+        "content": ".",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#666666",
+          "color": "#999999",
+        },
+        "offset": 7,
+      },
+      {
+        "content": "log",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#80A665",
+          "color": "#59873A",
+        },
+        "offset": 8,
+      },
+      {
+        "content": "(",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#666666",
+          "color": "#999999",
+        },
+        "offset": 11,
+      },
+      {
+        "content": """,
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#C98A7D77",
+          "color": "#B5695977",
+        },
+        "offset": 12,
+      },
+      {
+        "content": "hello",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#C98A7D",
+          "color": "#B56959",
+        },
+        "offset": 13,
+      },
+      {
+        "content": """,
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#C98A7D77",
+          "color": "#B5695977",
+        },
+        "offset": 18,
+      },
+      {
+        "content": ")",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#666666",
+          "color": "#999999",
+        },
+        "offset": 19,
+      },
+    ],
+  ],
+}
+`;
+
+exports[`useLightDarkFunction > true 1`] = `
+{
+  "bg": "light-dark(#ffffff, #121212);--shiki-light-bg:#ffffff;--shiki-dark-bg:#121212",
+  "fg": "light-dark(#393a34, #dbd7caee);--shiki-light:#393a34;--shiki-dark:#dbd7caee",
+  "grammarState": {
+    "lang": "javascript",
+    "scopes": [
+      "source.js",
+    ],
+    "theme": "vitesse-light",
+    "themes": [
+      "vitesse-light",
+      "vitesse-dark",
+    ],
+  },
+  "rootStyle": undefined,
+  "themeName": "shiki-themes vitesse-light vitesse-dark",
+  "tokens": [
+    [
+      {
+        "content": "console",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#BD976A",
+          "--shiki-light": "#B07D48",
+          "color": "light-dark(#B07D48, #BD976A)",
+        },
+        "offset": 0,
+      },
+      {
+        "content": ".",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+          "color": "light-dark(#999999, #666666)",
+        },
+        "offset": 7,
+      },
+      {
+        "content": "log",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#80A665",
+          "--shiki-light": "#59873A",
+          "color": "light-dark(#59873A, #80A665)",
+        },
+        "offset": 8,
+      },
+      {
+        "content": "(",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+          "color": "light-dark(#999999, #666666)",
+        },
+        "offset": 11,
+      },
+      {
+        "content": """,
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#C98A7D77",
+          "--shiki-light": "#B5695977",
+          "color": "light-dark(#B5695977, #C98A7D77)",
+        },
+        "offset": 12,
+      },
+      {
+        "content": "hello",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#C98A7D",
+          "--shiki-light": "#B56959",
+          "color": "light-dark(#B56959, #C98A7D)",
+        },
+        "offset": 13,
+      },
+      {
+        "content": """,
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#C98A7D77",
+          "--shiki-light": "#B5695977",
+          "color": "light-dark(#B5695977, #C98A7D77)",
+        },
+        "offset": 18,
+      },
+      {
+        "content": ")",
+        "explanation": undefined,
+        "htmlStyle": {
+          "--shiki-dark": "#666666",
+          "--shiki-light": "#999999",
+          "color": "light-dark(#999999, #666666)",
+        },
+        "offset": 19,
+      },
+    ],
+  ],
+}
+`;

--- a/packages/core/test/tokens.test.ts
+++ b/packages/core/test/tokens.test.ts
@@ -1,6 +1,6 @@
 import { createJavaScriptRegexEngine } from 'shiki'
 import { expect, it } from 'vitest'
-import { codeToTokensBase, createShikiInternal } from '../src'
+import { codeToTokens, codeToTokensBase, createShikiInternal } from '../src'
 
 it('includeExplanation', async () => {
   using engine = await createShikiInternal({
@@ -21,4 +21,24 @@ it('includeExplanation', async () => {
   expect(caseFalse).toMatchSnapshot('false')
   expect(caseTrue).toMatchSnapshot('true')
   expect(caseScopeName).toMatchSnapshot('scopeName')
+})
+
+it('useLightDarkFunction', async () => {
+  using engine = await createShikiInternal({
+    themes: [
+      import('@shikijs/themes/vitesse-light'),
+      import('@shikijs/themes/vitesse-dark'),
+    ],
+    langs: [
+      import('@shikijs/langs/javascript'),
+    ],
+    engine: createJavaScriptRegexEngine(),
+  })
+
+  const code = 'console.log("hello")'
+  const caseFalse = codeToTokens(engine, code, { lang: 'js', themes: { light: 'vitesse-light', dark: 'vitesse-dark' }, useLightDarkFunction: false })
+  const caseTrue = codeToTokens(engine, code, { lang: 'js', themes: { light: 'vitesse-light', dark: 'vitesse-dark' }, useLightDarkFunction: true })
+
+  expect(caseFalse).toMatchSnapshot('false')
+  expect(caseTrue).toMatchSnapshot('true')
 })

--- a/packages/core/test/tokens.test.ts
+++ b/packages/core/test/tokens.test.ts
@@ -1,5 +1,5 @@
 import { createJavaScriptRegexEngine } from 'shiki'
-import { expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { codeToTokens, codeToTokensBase, createShikiInternal } from '../src'
 
 it('includeExplanation', async () => {
@@ -23,22 +23,116 @@ it('includeExplanation', async () => {
   expect(caseScopeName).toMatchSnapshot('scopeName')
 })
 
-it('useLightDarkFunction', async () => {
-  using engine = await createShikiInternal({
-    themes: [
-      import('@shikijs/themes/vitesse-light'),
-      import('@shikijs/themes/vitesse-dark'),
-    ],
-    langs: [
-      import('@shikijs/langs/javascript'),
-    ],
-    engine: createJavaScriptRegexEngine(),
+describe('defaultColor light-dark()', () => {
+  it('basic', async () => {
+    using engine = await createShikiInternal({
+      themes: [
+        import('@shikijs/themes/vitesse-light'),
+        import('@shikijs/themes/vitesse-dark'),
+      ],
+      langs: [
+        import('@shikijs/langs/javascript'),
+      ],
+      engine: createJavaScriptRegexEngine(),
+    })
+
+    const code = 'console.log("hello")'
+    const caseCssVars = codeToTokens(engine, code, {
+      lang: 'js',
+      themes: { light: 'vitesse-light', dark: 'vitesse-dark' },
+      defaultColor: false,
+    })
+    const caseLightDark = codeToTokens(engine, code, {
+      lang: 'js',
+      themes: { light: 'vitesse-light', dark: 'vitesse-dark' },
+      defaultColor: 'light-dark()',
+    })
+
+    expect(caseCssVars).toMatchSnapshot('css-vars')
+    expect(caseLightDark).toMatchSnapshot('light-dark()')
   })
 
-  const code = 'console.log("hello")'
-  const caseFalse = codeToTokens(engine, code, { lang: 'js', themes: { light: 'vitesse-light', dark: 'vitesse-dark' }, useLightDarkFunction: false })
-  const caseTrue = codeToTokens(engine, code, { lang: 'js', themes: { light: 'vitesse-light', dark: 'vitesse-dark' }, useLightDarkFunction: true })
+  it('defaultColor light-dark() with multiple themes', async () => {
+    using engine = await createShikiInternal({
+      themes: [
+        import('@shikijs/themes/vitesse-light'),
+        import('@shikijs/themes/vitesse-dark'),
+        import('@shikijs/themes/github-dark'),
+      ],
+      langs: [
+        import('@shikijs/langs/javascript'),
+      ],
+      engine: createJavaScriptRegexEngine(),
+    })
 
-  expect(caseFalse).toMatchSnapshot('false')
-  expect(caseTrue).toMatchSnapshot('true')
+    const code = 'console.log("hello")'
+    const caseCssVars = codeToTokens(engine, code, {
+      lang: 'js',
+      themes: {
+        dark: 'vitesse-dark',
+        light: 'vitesse-light',
+        custom: 'github-dark',
+      },
+      defaultColor: false,
+    })
+    const caseLightDark = codeToTokens(engine, code, {
+      lang: 'js',
+      themes: {
+        dark: 'vitesse-dark',
+        light: 'vitesse-light',
+        custom: 'github-dark',
+      },
+      defaultColor: 'light-dark()',
+    })
+
+    expect(caseCssVars).toMatchSnapshot('css-vars')
+    expect(caseLightDark).toMatchSnapshot('light-dark()')
+  })
+
+  it('should throw when no light or dark theme is provided', async () => {
+    using engine = await createShikiInternal({
+      themes: [
+        import('@shikijs/themes/vitesse-light'),
+        import('@shikijs/themes/vitesse-dark'),
+        import('@shikijs/themes/github-dark'),
+      ],
+      langs: [
+        import('@shikijs/langs/javascript'),
+      ],
+      engine: createJavaScriptRegexEngine(),
+    })
+
+    const code = 'console.log("hello")'
+
+    expect(() => {
+      codeToTokens(engine, code, {
+        lang: 'js',
+        themes: {
+          dark2: 'vitesse-dark',
+          light1: 'vitesse-light',
+        },
+        defaultColor: 'light-dark()',
+      })
+    })
+      .toThrowErrorMatchingInlineSnapshot(`[ShikiError: When using \`defaultColor: "light-dark()"\`, you must provide both \`light\` and \`dark\` themes]`)
+
+    expect(() => {
+      codeToTokens(engine, code, {
+        lang: 'js',
+        themes: {
+          dark: 'vitesse-dark',
+          light1: 'vitesse-light',
+        },
+        defaultColor: 'light-dark()',
+      })
+    })
+      .toThrowErrorMatchingInlineSnapshot(`[ShikiError: When using \`defaultColor: "light-dark()"\`, you must provide both \`light\` and \`dark\` themes]`)
+
+    // not throw when only one theme is provided
+    codeToTokens(engine, code, {
+      lang: 'js',
+      theme: 'vitesse-dark',
+      defaultColor: 'light-dark()',
+    })
+  })
 })

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -101,10 +101,15 @@ export interface CodeOptionsMultipleThemes<Themes extends string = string> {
    * <span style="--shiki-light:#{light};--shiki-dark:#{dark};--shiki-custom:#{custom};">code</span>
    * ```
    *
+   * When set to `light-dark()`, the default color will be rendered as `light-dark(#{light}, #{dark})`.
+   *
+   * ```html
+   * <span style="color:light-dark(#{light}, #{dark});--shiki-dark:#{dark};--shiki-custom:#{custom};">code</span>
+   * ```
    *
    * @default 'light'
    */
-  defaultColor?: StringLiteralUnion<'light' | 'dark'> | false
+  defaultColor?: StringLiteralUnion<'light' | 'dark'> | 'light-dark()' | false
 
   /**
    * Prefix of CSS variables used to store the color of the other theme.
@@ -112,13 +117,6 @@ export interface CodeOptionsMultipleThemes<Themes extends string = string> {
    * @default '--shiki-'
    */
   cssVariablePrefix?: string
-
-  /**
-   * Use `light-dark()` CSS function along with CSS variables to toggle themes.
-   *
-   * @default false
-   */
-  useLightDarkFunction?: boolean
 }
 
 export type CodeOptionsThemes<Themes extends string = string> =

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -112,6 +112,13 @@ export interface CodeOptionsMultipleThemes<Themes extends string = string> {
    * @default '--shiki-'
    */
   cssVariablePrefix?: string
+
+  /**
+   * Use `light-dark()` CSS function along with CSS variables to toggle themes.
+   *
+   * @default false
+   */
+  useLightDarkFunction?: boolean
 }
 
 export type CodeOptionsThemes<Themes extends string = string> =


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This pull request introduces support for the `light-dark()` CSS function in the Shiki library, allowing for dynamic theme switching between light and dark modes using CSS variables. It includes updates to the core logic, documentation, and tests to implement and validate this feature.

API-wise, it adds `useLightDarkFunction` option to enable this feature.

### Linked Issues

- https://github.com/shikijs/shiki/issues/1027

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

This is my first PR to the Shiki project.  I'm new to the codebase, so please let me know if I've missed anything or if there are any project conventions I should follow more closely.

I'm happy to make any changes as needed.  Thank you for your review and guidance!