### PR TITLE
docs: Update dual-themes.md to fix key name

### DIFF
--- a/docs/guide/dual-themes.md
+++ b/docs/guide/dual-themes.md
@@ -6,7 +6,7 @@ outline: deep
 
 Shiki supports outputting light/dark dual or multiple themes. Shiki's dual themes approach uses CSS variables to store the colors on each token.
 
-Change the `theme` option in `codeToHtml` to `options` with `light` and `dark` keys to generate two themes.
+Change the `theme` option in `codeToHtml` to `themes` with `light` and `dark` keys to generate two themes.
 
 ```ts twoslash
 import { codeToHtml } from 'shiki'


### PR DESCRIPTION
### Description

simply fix an error in the doc. It is mentioned that the themes's key is `options` when in fact it is `themes`

