### PR TITLE
fix(twoslash): pass-through unrecognized `options.lang` to `codeToHast`

### DIFF
--- a/packages/twoslash/src/renderer-rich.ts
+++ b/packages/twoslash/src/renderer-rich.ts
@@ -232,6 +232,12 @@ export function rendererRich(options: RendererRichOptions = {}): TwoslashRendere
 
     const popupContents: ElementContent[] = []
 
+    let lang = this.options.lang
+    if (lang === 'jsx')
+      lang = 'tsx'
+    else if (lang === 'js' || lang === 'javascript')
+      lang = 'ts'
+
     const typeCode: Element = {
       type: 'element',
       tagName: 'code',
@@ -242,9 +248,7 @@ export function rendererRich(options: RendererRichOptions = {}): TwoslashRendere
           ...this.options,
           meta: {},
           transformers: [],
-          lang: (this.options.lang === 'tsx' || this.options.lang === 'jsx')
-            ? 'tsx'
-            : 'ts',
+          lang,
           structure: content.trim().includes('\n') ? 'classic' : 'inline',
         },
       ).children as ElementContent[],


### PR DESCRIPTION
I've been experimenting with using twoslash for a non-Typescript language.

I've gotten this to mostly work by providing a custom "twoslasher" to `createTransformerFactory` to inject type information:
```typescript
transformers: [
  createTransformerFactory(
   (code, filename, options) => {
     nodes = /* code to insert hover with types / errors here */;
     return {
         code: code,
         nodes,
     };
   },
   rendererRich({
       lang: 'julia',
       processHoverInfo: text => text,
   }),
  )
}
```

This works well, except for the `codeToHast` call in the rich renderer, which overrides the language used to syntax highlight the type in any `'hover'` nodes, etc.
