### PR TITLE
docs: update js engine compat report

### DIFF
--- a/docs/guide/regex-engines.md
+++ b/docs/guide/regex-engines.md
@@ -6,7 +6,7 @@ outline: deep
 
 TextMate grammars are based on regular expressions that match tokens. More specifically, they assume that [Oniguruma](https://github.com/kkos/oniguruma) (a powerful regex engine written in C) will be used to interpret the regular expressions. To make this work in JavaScript, we compile Oniguruma to WebAssembly to run in the browser or Node.js.
 
-Since v1.15, we expose the ability for users to switch the regex engine or provide a custom implementation. To do so, add an `engine` option to `createHighlighter` or `createHighlighterCore`. For example:
+Shiki also offers the ability to switch the regex engine or provide a custom implementation. To do so, add an `engine` option to `createHighlighter` or `createHighlighterCore`. For example:
 
 ```ts
 import { createHighlighter } from 'shiki'
@@ -54,9 +54,9 @@ const shiki = await createHighlighter({
 const html = shiki.codeToHtml('const a = 1', { lang: 'javascript', theme: 'nord' })
 ```
 
-The advantages of using the JavaScript engine are that it doesn't require loading a large WebAssembly file for Oniguruma and it is faster for some languages (since the regular expressions run as native JavaScript).
+The advantage of using the JavaScript engine is that it doesn't require loading a large WebAssembly file for Oniguruma. It is also faster for some languages, since the regular expressions run as native JavaScript.
 
-Please check the [compatibility table](/references/engine-js-compat) for the support status of languages you are using. Almost all languages are supported.
+Please check the [compatibility table](/references/engine-js-compat) for the support status of languages you are using. As of Shiki 3.9.1, all built-in languages are supported.
 
 ::: info
 The JavaScript engine is best when running in the browser and in cases when you want to control the bundle size. If you run Shiki on Node.js (or at build time) and bundle size or WebAssembly support is not a concern, the Oniguruma engine ensures maximum language compatibility.
@@ -71,7 +71,7 @@ const jsEngine = createJavaScriptRegexEngine({ forgiving: true })
 // ...use the engine
 ```
 
-Please use this option with caution as highlighting mismatches may occur.
+This can result in highlighting mismatches, so check your results.
 
 ### JavaScript Runtime Target
 

--- a/docs/references/engine-js-compat.md
+++ b/docs/references/engine-js-compat.md
@@ -2,9 +2,9 @@
 
 Compatibility reference of all built-in grammars with the [JavaScript RegExp engine](/guide/regex-engines#javascript-regexp-engine).
 
-> Generated on Tuesday, April 29, 2025
+> Generated on Saturday, August 2, 2025
 >
-> Version `3.3.0`
+> Version `3.9.1`
 >
 > Runtime: Node.js v23.11.0
 
@@ -12,10 +12,10 @@ Compatibility reference of all built-in grammars with the [JavaScript RegExp eng
 
 |                 |                       Count |
 | :-------------- | --------------------------: |
-| Total Languages |                         221 |
-| Supported       | [220](#supported-languages) |
+| Total Languages |                         222 |
+| Supported       | [222](#supported-languages) |
 | Mismatched      |  [0](#mismatched-languages) |
-| Unsupported     | [1](#unsupported-languages) |
+| Unsupported     | [0](#unsupported-languages) |
 
 ## Supported Languages
 
@@ -35,17 +35,17 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | applescript        | ✅ OK           |               152 |               - |      |
 | ara                | ✅ OK           |                54 |               - |      |
 | asciidoc           | ✅ OK           |               262 |               - |      |
-| asm                | ✅ OK           |               297 |               - |      |
+| asm                | ✅ OK           |               298 |               - |      |
 | astro              | ✅ OK           |               610 |               - |      |
 | awk                | ✅ OK           |                36 |               - |      |
-| ballerina          | ✅ OK           |               223 |               - |      |
+| ballerina          | ✅ OK           |               224 |               - |      |
 | bash               | ✅ OK           |               147 |               - |      |
 | bat                | ✅ OK           |                58 |               - |      |
 | beancount          | ✅ OK           |                39 |               - |      |
 | berry              | ✅ OK           |                18 |               - |      |
 | bibtex             | ✅ OK           |                19 |               - |      |
 | bicep              | ✅ OK           |                27 |               - |      |
-| blade              | ✅ OK           |              1119 |               - |      |
+| blade              | ✅ OK           |              1120 |               - |      |
 | bsl                | ✅ OK           |                96 |               - |      |
 | c                  | ✅ OK           |               176 |               - |      |
 | cadence            | ✅ OK           |                71 |               - |      |
@@ -59,9 +59,9 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | codeql             | ✅ OK           |               147 |               - |      |
 | coffee             | ✅ OK           |               466 |               - |      |
 | common-lisp        | ✅ OK           |                60 |               - |      |
-| coq                | ✅ OK           |                26 |               - |      |
-| cpp                | ✅ OK           |               505 |               - |      |
-| crystal            | ✅ OK           |              1053 |               - |      |
+| coq                | ✅ OK           |                27 |               - |      |
+| cpp                | ✅ OK           |               506 |               - |      |
+| crystal            | ✅ OK           |              1054 |               - |      |
 | csharp             | ✅ OK           |               301 |               - |      |
 | css                | ✅ OK           |               141 |               - |      |
 | csv                | ✅ OK           |                 1 |               - |      |
@@ -79,8 +79,8 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | elixir             | ✅ OK           |               704 |               - |      |
 | elm                | ✅ OK           |               241 |               - |      |
 | emacs-lisp         | ✅ OK           |               153 |               - |   22 |
-| erb                | ✅ OK           |              1763 |               - |      |
-| erlang             | ✅ OK           |               144 |               - |      |
+| erb                | ✅ OK           |              1764 |               - |      |
+| erlang             | ✅ OK           |               265 |               - |      |
 | fennel             | ✅ OK           |                31 |               - |      |
 | fish               | ✅ OK           |                25 |               - |      |
 | fluent             | ✅ OK           |                23 |               - |      |
@@ -88,8 +88,8 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | fortran-free-form  | ✅ OK           |               326 |               - |      |
 | fsharp             | ✅ OK           |               238 |               - |      |
 | fsl                | ✅ OK           |                30 |               - |      |
-| gdresource         | ✅ OK           |               158 |               - |      |
-| gdscript           | ✅ OK           |                95 |               - |      |
+| gdresource         | ✅ OK           |               157 |               - |      |
+| gdscript           | ✅ OK           |                94 |               - |      |
 | gdshader           | ✅ OK           |                39 |               - |      |
 | genie              | ✅ OK           |                20 |               - |      |
 | gherkin            | ✅ OK           |                19 |               - |      |
@@ -98,10 +98,10 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | glimmer-ts         | ✅ OK           |               673 |               - |      |
 | glsl               | ✅ OK           |               185 |               - |      |
 | gnuplot            | ✅ OK           |                82 |               - |      |
-| go                 | ✅ OK           |               124 |               - |      |
+| go                 | ✅ OK           |               126 |               - |      |
 | graphql            | ✅ OK           |               445 |               - |      |
 | groovy             | ✅ OK           |               130 |               - |      |
-| hack               | ✅ OK           |               940 |               - |      |
+| hack               | ✅ OK           |               941 |               - |      |
 | haml               | ✅ OK           |               559 |               - |      |
 | handlebars         | ✅ OK           |               696 |               - |      |
 | haskell            | ✅ OK           |               157 |               - |      |
@@ -126,10 +126,10 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | jsonnet            | ✅ OK           |                33 |               - |      |
 | jssm               | ✅ OK           |                30 |               - |      |
 | jsx                | ✅ OK           |               375 |               - |      |
-| julia              | ✅ OK           |              1158 |               - |      |
+| julia              | ✅ OK           |              1167 |               - |      |
 | kotlin             | ✅ OK           |                58 |               - |      |
 | kusto              | ✅ OK           |                60 |               - |      |
-| latex              | ✅ OK           |               292 |               - |      |
+| latex              | ✅ OK           |               327 |               - |      |
 | lean               | ✅ OK           |                32 |               - |      |
 | less               | ✅ OK           |               279 |               - |      |
 | liquid             | ✅ OK           |               689 |               - |      |
@@ -140,11 +140,11 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | luau               | ✅ OK           |                88 |               - |      |
 | make               | ✅ OK           |                51 |               - |      |
 | markdown           | ✅ OK           |               118 |               - |      |
-| marko              | ✅ OK           |               915 |               - |      |
+| marko              | ✅ OK           |               929 |               - |      |
 | matlab             | ✅ OK           |                88 |               - |      |
 | mdc                | ✅ OK           |               780 |               - |      |
 | mdx                | ✅ OK           |               197 |               - |      |
-| mermaid            | ✅ OK           |               134 |               - |      |
+| mermaid            | ✅ OK           |               138 |               - |      |
 | mipsasm            | ✅ OK           |                17 |               - |      |
 | mojo               | ✅ OK           |               213 |               - |      |
 | move               | ✅ OK           |               116 |               - |      |
@@ -158,8 +158,8 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | objective-cpp      | ✅ OK           |               306 |               - |      |
 | ocaml              | ✅ OK           |               178 |               - |      |
 | pascal             | ✅ OK           |                23 |               - |      |
-| perl               | ✅ OK           |               936 |               - |      |
-| php                | ✅ OK           |              1123 |               - |      |
+| perl               | ✅ OK           |               937 |               - |      |
+| php                | ✅ OK           |              1124 |               - |      |
 | plsql              | ✅ OK           |                45 |               - |      |
 | po                 | ✅ OK           |                23 |               - |      |
 | polar              | ✅ OK           |                31 |               - |      |
@@ -171,23 +171,23 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | proto              | ✅ OK           |                33 |               - |      |
 | pug                | ✅ OK           |               683 |               - |      |
 | puppet             | ✅ OK           |                60 |               - |      |
-| purescript         | ✅ OK           |                84 |               - |      |
+| purescript         | ✅ OK           |                87 |               - |      |
 | python             | ✅ OK           |               218 |               - |      |
 | qml                | ✅ OK           |               407 |               - |      |
 | qmldir             | ✅ OK           |                 7 |               - |      |
 | qss                | ✅ OK           |                31 |               - |      |
-| r                  | ✅ OK           |                71 |               - |      |
+| r                  | ✅ OK           |                85 |               - |      |
 | racket             | ✅ OK           |                69 |               - |      |
 | raku               | ✅ OK           |                52 |               - |      |
-| razor              | ✅ OK           |               942 |               - |      |
+| razor              | ✅ OK           |               941 |               - |      |
 | reg                | ✅ OK           |                 9 |               - |      |
 | regexp             | ✅ OK           |                34 |               - |      |
 | rel                | ✅ OK           |                17 |               - |      |
 | riscv              | ✅ OK           |                36 |               - |      |
-| rst                | ✅ OK           |              2004 |               - |      |
-| ruby               | ✅ OK           |              1755 |               - |      |
+| rst                | ✅ OK           |              2005 |               - |      |
+| ruby               | ✅ OK           |              1756 |               - |      |
 | rust               | ✅ OK           |                89 |               - |      |
-| sas                | ✅ OK           |                99 |               - |      |
+| sas                | ✅ OK           |               100 |               - |      |
 | sass               | ✅ OK           |                69 |               - |      |
 | scala              | ✅ OK           |               116 |               - |      |
 | scheme             | ✅ OK           |                34 |               - |      |
@@ -196,30 +196,31 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | shaderlab          | ✅ OK           |                87 |               - |      |
 | shellscript        | ✅ OK           |               147 |               - |      |
 | shellsession       | ✅ OK           |               149 |               - |      |
-| smalltalk          | ✅ OK           |                35 |               - |      |
+| smalltalk          | ✅ OK           |                44 |               - |      |
 | solidity           | ✅ OK           |               103 |               - |      |
 | soy                | ✅ OK           |               646 |               - |      |
 | sparql             | ✅ OK           |                19 |               - |      |
 | splunk             | ✅ OK           |                17 |               - |      |
-| sql                | ✅ OK           |                67 |               - |      |
+| sql                | ✅ OK           |                68 |               - |      |
 | ssh-config         | ✅ OK           |                12 |               - |      |
-| stata              | ✅ OK           |               253 |               - |      |
+| stata              | ✅ OK           |               254 |               - |      |
 | stylus             | ✅ OK           |               106 |               - |      |
-| svelte             | ✅ OK           |               636 |               - |      |
+| svelte             | ✅ OK           |               642 |               - |      |
+| swift              | ✅ OK           |               334 |               - |      |
 | system-verilog     | ✅ OK           |               102 |               - |      |
 | systemd            | ✅ OK           |                32 |               - |      |
-| talonscript        | ✅ OK           |                45 |               - |      |
+| talonscript        | ✅ OK           |                46 |               - |      |
 | tasl               | ✅ OK           |                23 |               - |      |
 | tcl                | ✅ OK           |                34 |               - |      |
-| templ              | ✅ OK           |               672 |               - |      |
+| templ              | ✅ OK           |               674 |               - |      |
 | terraform          | ✅ OK           |                68 |               - |      |
-| tex                | ✅ OK           |               106 |               - |      |
+| tex                | ✅ OK           |               120 |               - |      |
 | toml               | ✅ OK           |                44 |               - |      |
-| ts-tags            | ✅ OK           |               989 |               - |      |
+| ts-tags            | ✅ OK           |               990 |               - |      |
 | tsv                | ✅ OK           |                 1 |               - |      |
 | tsx                | ✅ OK           |               375 |               - |      |
 | turtle             | ✅ OK           |                15 |               - |      |
-| twig               | ✅ OK           |              2390 |               - |      |
+| twig               | ✅ OK           |              2391 |               - |      |
 | typescript         | ✅ OK           |               362 |               - |      |
 | typespec           | ✅ OK           |                73 |               - |      |
 | typst              | ✅ OK           |                78 |               - |      |
@@ -231,11 +232,12 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | viml               | ✅ OK           |                72 |               - |      |
 | vue                | ✅ OK           |               690 |               - |      |
 | vue-html           | ✅ OK           |               714 |               - |      |
+| vue-vine           | ✅ OK           |              1203 |               - |      |
 | vyper              | ✅ OK           |               238 |               - |      |
 | wasm               | ✅ OK           |                78 |               - |      |
 | wenyan             | ✅ OK           |                18 |               - |      |
 | wgsl               | ✅ OK           |                44 |               - |      |
-| wikitext           | ✅ OK           |               104 |               - |      |
+| wikitext           | ✅ OK           |               105 |               - |      |
 | wit                | ✅ OK           |                81 |               - |      |
 | wolfram            | ✅ OK           |               501 |               - |      |
 | xml                | ✅ OK           |               168 |               - |      |
@@ -265,4 +267,3 @@ Languages that throw with the JavaScript RegExp engine, either because they cont
 
 | Language | Highlight Match | Patterns Parsable | Patterns Failed | Diff |
 | -------- | :-------------- | ----------------: | --------------: | ---: |
-| swift    | ❌ Error        |               330 |               1 |      |


### PR DESCRIPTION
- Reruns the JS engine compatibility report for Shiki 3.9.1. Swift is now supported, resulting in 100% language compatibility. 🎉
- Minor docs updates.