### PR TITLE
fix(hast)!: unwrap a Root node and rename property class to className

### DIFF
--- a/packages/core/src/highlight/code-to-hast.ts
+++ b/packages/core/src/highlight/code-to-hast.ts
@@ -106,7 +106,7 @@ export function tokensToHast(
     type: 'element',
     tagName: 'pre',
     properties: {
-      class: `shiki ${options.themeName || ''}`,
+      className: `shiki ${options.themeName || ''}`,
       style: options.rootStyle || `background-color:${options.bg};color:${options.fg}`,
       ...(tabindex !== false && tabindex != null)
         ? {
@@ -170,13 +170,17 @@ export function tokensToHast(
     let lineNode: Element = {
       type: 'element',
       tagName: 'span',
-      properties: { class: 'line' },
+      properties: { className: 'line' },
       children: [],
     }
 
     let col = 0
 
     for (const token of line) {
+      if (token.htmlAttrs?.class) {
+        token.htmlAttrs.className = token.htmlAttrs.class
+        delete token.htmlAttrs.class
+      }
       let tokenNode: Element = {
         type: 'element',
         tagName: 'span',

--- a/packages/core/src/transformer-decorations.ts
+++ b/packages/core/src/transformer-decorations.ts
@@ -158,14 +158,19 @@ export function transformerDecorations(): ShikiTransformer {
         const properties = decoration.properties || {}
         const transform = decoration.transform || (i => i)
 
+        if (properties.class && properties.className === undefined) {
+          properties.className = properties.class
+          delete properties.class
+        }
+
         el.tagName = decoration.tagName || 'span'
         el.properties = {
           ...el.properties,
           ...properties,
-          class: el.properties.class,
+          className: el.properties.className,
         }
-        if (decoration.properties?.class)
-          addClassToHast(el, decoration.properties.class as string[])
+        if (decoration.properties?.className)
+          addClassToHast(el, decoration.properties.className as string[])
         el = transform(el, type) || el
         return el
       }

--- a/packages/core/src/utils/hast.ts
+++ b/packages/core/src/utils/hast.ts
@@ -3,22 +3,22 @@ import type { Element } from 'hast'
 /**
  * Utility to append class to a hast node
  *
- * If the `property.class` is a string, it will be splitted by space and converted to an array.
+ * If the `property.className` is a string, it will be splitted by space and converted to an array.
  */
 export function addClassToHast(node: Element, className: string | string[]): Element {
   if (!className)
     return node
   node.properties ||= {}
-  node.properties.class ||= []
-  if (typeof node.properties.class === 'string')
-    node.properties.class = node.properties.class.split(/\s+/g)
-  if (!Array.isArray(node.properties.class))
-    node.properties.class = []
+  node.properties.className ||= []
+  if (typeof node.properties.className === 'string')
+    node.properties.className = node.properties.className.split(/\s+/g)
+  if (!Array.isArray(node.properties.className))
+    node.properties.className = []
 
   const targets = Array.isArray(className) ? className : className.split(/\s+/g)
   for (const c of targets) {
-    if (c && !node.properties.class.includes(c))
-      node.properties.class.push(c)
+    if (c && !node.properties.className.includes(c))
+      node.properties.className.push(c)
   }
   return node
 }

--- a/packages/rehype/src/core.ts
+++ b/packages/rehype/src/core.ts
@@ -143,7 +143,7 @@ function rehypeShikiFromHighlighter(
           }
         }
 
-        parent.children[index] = fragment as any
+        parent.children.splice(index, 1, ...fragment.children)
       }
 
       if (lazyLoad) {

--- a/packages/twoslash/test/out/completion-end-multifile-2.ts.json
+++ b/packages/twoslash/test/out/completion-end-multifile-2.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "vitesse-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -260,7 +260,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -272,7 +272,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -585,7 +585,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }

--- a/packages/twoslash/test/out/completion-end-multifile.ts.json
+++ b/packages/twoslash/test/out/completion-end-multifile.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "vitesse-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -260,7 +260,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -286,7 +286,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -348,7 +348,7 @@
                                   "type": "element",
                                   "tagName": "pre",
                                   "properties": {
-                                    "class": "shiki vitesse-dark",
+                                    "className": "shiki vitesse-dark",
                                     "style": "background-color:#121212;color:#dbd7caee",
                                     "tabindex": "0"
                                   },
@@ -362,7 +362,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -427,7 +427,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -622,7 +622,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -692,7 +692,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1084,7 +1084,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1110,7 +1110,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1136,7 +1136,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1291,7 +1291,7 @@
                                   "type": "element",
                                   "tagName": "pre",
                                   "properties": {
-                                    "class": "shiki vitesse-dark",
+                                    "className": "shiki vitesse-dark",
                                     "style": "background-color:#121212;color:#dbd7caee",
                                     "tabindex": "0"
                                   },
@@ -1305,7 +1305,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -1370,7 +1370,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -1565,7 +1565,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -1910,7 +1910,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -2505,7 +2505,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }

--- a/packages/twoslash/test/out/completion-end.ts.json
+++ b/packages/twoslash/test/out/completion-end.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "vitesse-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -324,7 +324,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -336,7 +336,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -348,7 +348,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -397,7 +397,7 @@
                                   "type": "element",
                                   "tagName": "pre",
                                   "properties": {
-                                    "class": "shiki vitesse-dark",
+                                    "className": "shiki vitesse-dark",
                                     "style": "background-color:#121212;color:#dbd7caee",
                                     "tabindex": "0"
                                   },
@@ -411,7 +411,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -463,7 +463,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -658,7 +658,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -1107,7 +1107,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1395,7 +1395,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1421,7 +1421,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1457,7 +1457,7 @@
                                   "type": "element",
                                   "tagName": "pre",
                                   "properties": {
-                                    "class": "shiki vitesse-dark",
+                                    "className": "shiki vitesse-dark",
                                     "style": "background-color:#121212;color:#dbd7caee",
                                     "tabindex": "0"
                                   },
@@ -1471,7 +1471,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -1523,7 +1523,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -1718,7 +1718,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -1881,7 +1881,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -1893,7 +1893,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -1905,7 +1905,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1941,7 +1941,7 @@
                                   "type": "element",
                                   "tagName": "pre",
                                   "properties": {
-                                    "class": "shiki vitesse-dark",
+                                    "className": "shiki vitesse-dark",
                                     "style": "background-color:#121212;color:#dbd7caee",
                                     "tabindex": "0"
                                   },
@@ -1955,7 +1955,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -2007,7 +2007,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -2202,7 +2202,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -2722,7 +2722,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -2734,7 +2734,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -2746,7 +2746,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -2782,7 +2782,7 @@
                                   "type": "element",
                                   "tagName": "pre",
                                   "properties": {
-                                    "class": "shiki vitesse-dark",
+                                    "className": "shiki vitesse-dark",
                                     "style": "background-color:#121212;color:#dbd7caee",
                                     "tabindex": "0"
                                   },
@@ -2796,7 +2796,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -2848,7 +2848,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -3043,7 +3043,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -3509,7 +3509,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -3521,7 +3521,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -3533,7 +3533,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -3569,7 +3569,7 @@
                                   "type": "element",
                                   "tagName": "pre",
                                   "properties": {
-                                    "class": "shiki vitesse-dark",
+                                    "className": "shiki vitesse-dark",
                                     "style": "background-color:#121212;color:#dbd7caee",
                                     "tabindex": "0"
                                   },
@@ -3583,7 +3583,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -3635,7 +3635,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -3830,7 +3830,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -4322,7 +4322,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -4334,7 +4334,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -4346,7 +4346,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -4382,7 +4382,7 @@
                                   "type": "element",
                                   "tagName": "pre",
                                   "properties": {
-                                    "class": "shiki vitesse-dark",
+                                    "className": "shiki vitesse-dark",
                                     "style": "background-color:#121212;color:#dbd7caee",
                                     "tabindex": "0"
                                   },
@@ -4396,7 +4396,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -4448,7 +4448,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -4643,7 +4643,7 @@
                                           "type": "element",
                                           "tagName": "span",
                                           "properties": {
-                                            "class": "line"
+                                            "className": "line"
                                           },
                                           "children": [
                                             {
@@ -5189,7 +5189,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }

--- a/packages/twoslash/test/out/completion-string.ts.json
+++ b/packages/twoslash/test/out/completion-string.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "github-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -338,7 +338,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -350,7 +350,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -816,7 +816,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }

--- a/packages/twoslash/test/out/highlights.ts.json
+++ b/packages/twoslash/test/out/highlights.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "vitesse-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -347,7 +347,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -359,7 +359,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -684,7 +684,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -696,7 +696,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1034,7 +1034,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -1046,7 +1046,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1654,7 +1654,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }

--- a/packages/twoslash/test/out/import-vue.ts.json
+++ b/packages/twoslash/test/out/import-vue.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "vitesse-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -872,7 +872,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -884,7 +884,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1526,7 +1526,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1648,7 +1648,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }

--- a/packages/twoslash/test/out/query-offset.ts.json
+++ b/packages/twoslash/test/out/query-offset.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "vitesse-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -229,7 +229,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -241,7 +241,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -253,7 +253,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -265,7 +265,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -470,7 +470,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -482,7 +482,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -494,7 +494,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -506,7 +506,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -711,7 +711,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }

--- a/packages/vitepress-twoslash/test/out/completion-end-multifile-2.ts.json
+++ b/packages/vitepress-twoslash/test/out/completion-end-multifile-2.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "vitesse-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -283,7 +283,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -295,7 +295,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1410,7 +1410,7 @@
                                             "type": "element",
                                             "tagName": "pre",
                                             "properties": {
-                                              "class": "shiki vitesse-dark",
+                                              "className": "shiki vitesse-dark",
                                               "style": "background-color:#121212;color:#dbd7caee",
                                               "tabindex": "0"
                                             },
@@ -1424,7 +1424,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1541,7 +1541,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1567,7 +1567,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1736,7 +1736,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1762,7 +1762,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1918,7 +1918,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1944,7 +1944,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1970,7 +1970,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1996,7 +1996,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2022,7 +2022,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2048,7 +2048,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2074,7 +2074,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2100,7 +2100,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2126,7 +2126,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2152,7 +2152,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": []
                                                   },
@@ -2164,7 +2164,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2268,7 +2268,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2437,7 +2437,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2564,7 +2564,7 @@
                                             "type": "element",
                                             "tagName": "pre",
                                             "properties": {
-                                              "class": "shiki vitesse-dark",
+                                              "className": "shiki vitesse-dark",
                                               "style": "background-color:#121212;color:#dbd7caee",
                                               "tabindex": "0"
                                             },
@@ -2578,7 +2578,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2656,7 +2656,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2734,7 +2734,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2903,7 +2903,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": []
                                                   },
@@ -2915,7 +2915,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3032,7 +3032,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3058,7 +3058,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3227,7 +3227,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3253,7 +3253,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3409,7 +3409,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3435,7 +3435,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": []
                                                   },
@@ -3447,7 +3447,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3551,7 +3551,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3720,7 +3720,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -4020,7 +4020,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }

--- a/packages/vitepress-twoslash/test/out/completion-end-multifile.ts.json
+++ b/packages/vitepress-twoslash/test/out/completion-end-multifile.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "vitesse-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -283,7 +283,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -309,7 +309,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -394,7 +394,7 @@
                                         "type": "element",
                                         "tagName": "pre",
                                         "properties": {
-                                          "class": "shiki vitesse-dark",
+                                          "className": "shiki vitesse-dark",
                                           "style": "background-color:#121212;color:#dbd7caee",
                                           "tabindex": "0"
                                         },
@@ -408,7 +408,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -473,7 +473,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -668,7 +668,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -738,7 +738,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1153,7 +1153,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1179,7 +1179,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1205,7 +1205,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1406,7 +1406,7 @@
                                         "type": "element",
                                         "tagName": "pre",
                                         "properties": {
-                                          "class": "shiki vitesse-dark",
+                                          "className": "shiki vitesse-dark",
                                           "style": "background-color:#121212;color:#dbd7caee",
                                           "tabindex": "0"
                                         },
@@ -1420,7 +1420,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -1485,7 +1485,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -1680,7 +1680,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -2048,7 +2048,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -2716,7 +2716,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }

--- a/packages/vitepress-twoslash/test/out/completion-end.ts.json
+++ b/packages/vitepress-twoslash/test/out/completion-end.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "vitesse-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1139,7 +1139,7 @@
                                             "type": "element",
                                             "tagName": "pre",
                                             "properties": {
-                                              "class": "shiki vitesse-dark",
+                                              "className": "shiki vitesse-dark",
                                               "style": "background-color:#121212;color:#dbd7caee",
                                               "tabindex": "0"
                                             },
@@ -1153,7 +1153,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1270,7 +1270,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1296,7 +1296,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1465,7 +1465,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1491,7 +1491,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1647,7 +1647,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1673,7 +1673,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1699,7 +1699,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1725,7 +1725,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1751,7 +1751,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1777,7 +1777,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1803,7 +1803,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1829,7 +1829,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1855,7 +1855,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1881,7 +1881,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": []
                                                   },
@@ -1893,7 +1893,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -1997,7 +1997,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2166,7 +2166,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2293,7 +2293,7 @@
                                             "type": "element",
                                             "tagName": "pre",
                                             "properties": {
-                                              "class": "shiki vitesse-dark",
+                                              "className": "shiki vitesse-dark",
                                               "style": "background-color:#121212;color:#dbd7caee",
                                               "tabindex": "0"
                                             },
@@ -2307,7 +2307,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2385,7 +2385,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2463,7 +2463,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2632,7 +2632,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": []
                                                   },
@@ -2644,7 +2644,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2761,7 +2761,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2787,7 +2787,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2956,7 +2956,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2982,7 +2982,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3138,7 +3138,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3164,7 +3164,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": []
                                                   },
@@ -3176,7 +3176,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3280,7 +3280,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3449,7 +3449,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3736,7 +3736,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -3748,7 +3748,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -3760,7 +3760,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -3832,7 +3832,7 @@
                                         "type": "element",
                                         "tagName": "pre",
                                         "properties": {
-                                          "class": "shiki vitesse-dark",
+                                          "className": "shiki vitesse-dark",
                                           "style": "background-color:#121212;color:#dbd7caee",
                                           "tabindex": "0"
                                         },
@@ -3846,7 +3846,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -3898,7 +3898,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -4093,7 +4093,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -4565,7 +4565,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -4876,7 +4876,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -4902,7 +4902,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -4961,7 +4961,7 @@
                                         "type": "element",
                                         "tagName": "pre",
                                         "properties": {
-                                          "class": "shiki vitesse-dark",
+                                          "className": "shiki vitesse-dark",
                                           "style": "background-color:#121212;color:#dbd7caee",
                                           "tabindex": "0"
                                         },
@@ -4975,7 +4975,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -5027,7 +5027,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -5222,7 +5222,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -5412,7 +5412,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -5424,7 +5424,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -5436,7 +5436,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -5495,7 +5495,7 @@
                                         "type": "element",
                                         "tagName": "pre",
                                         "properties": {
-                                          "class": "shiki vitesse-dark",
+                                          "className": "shiki vitesse-dark",
                                           "style": "background-color:#121212;color:#dbd7caee",
                                           "tabindex": "0"
                                         },
@@ -5509,7 +5509,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -5561,7 +5561,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -5756,7 +5756,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -6326,7 +6326,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -6338,7 +6338,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -6350,7 +6350,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -6409,7 +6409,7 @@
                                         "type": "element",
                                         "tagName": "pre",
                                         "properties": {
-                                          "class": "shiki vitesse-dark",
+                                          "className": "shiki vitesse-dark",
                                           "style": "background-color:#121212;color:#dbd7caee",
                                           "tabindex": "0"
                                         },
@@ -6423,7 +6423,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -6475,7 +6475,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -6670,7 +6670,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -7186,7 +7186,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -7198,7 +7198,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -7210,7 +7210,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -7269,7 +7269,7 @@
                                         "type": "element",
                                         "tagName": "pre",
                                         "properties": {
-                                          "class": "shiki vitesse-dark",
+                                          "className": "shiki vitesse-dark",
                                           "style": "background-color:#121212;color:#dbd7caee",
                                           "tabindex": "0"
                                         },
@@ -7283,7 +7283,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -7335,7 +7335,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -7530,7 +7530,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -8072,7 +8072,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -8084,7 +8084,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -8096,7 +8096,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -8155,7 +8155,7 @@
                                         "type": "element",
                                         "tagName": "pre",
                                         "properties": {
-                                          "class": "shiki vitesse-dark",
+                                          "className": "shiki vitesse-dark",
                                           "style": "background-color:#121212;color:#dbd7caee",
                                           "tabindex": "0"
                                         },
@@ -8169,7 +8169,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -8221,7 +8221,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -8416,7 +8416,7 @@
                                                 "type": "element",
                                                 "tagName": "span",
                                                 "properties": {
-                                                  "class": "line"
+                                                  "className": "line"
                                                 },
                                                 "children": [
                                                   {
@@ -9012,7 +9012,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }

--- a/packages/vitepress-twoslash/test/out/completion-string.ts.json
+++ b/packages/vitepress-twoslash/test/out/completion-string.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "github-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -361,7 +361,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -373,7 +373,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -889,7 +889,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }

--- a/packages/vitepress-twoslash/test/out/highlights.ts.json
+++ b/packages/vitepress-twoslash/test/out/highlights.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "vitesse-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -370,7 +370,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -382,7 +382,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -753,7 +753,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -765,7 +765,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1149,7 +1149,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -1161,7 +1161,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -2276,7 +2276,7 @@
                                             "type": "element",
                                             "tagName": "pre",
                                             "properties": {
-                                              "class": "shiki vitesse-dark",
+                                              "className": "shiki vitesse-dark",
                                               "style": "background-color:#121212;color:#dbd7caee",
                                               "tabindex": "0"
                                             },
@@ -2290,7 +2290,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2407,7 +2407,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2433,7 +2433,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2602,7 +2602,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2628,7 +2628,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2784,7 +2784,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2810,7 +2810,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2836,7 +2836,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2862,7 +2862,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2888,7 +2888,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2914,7 +2914,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2940,7 +2940,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2966,7 +2966,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -2992,7 +2992,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3018,7 +3018,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": []
                                                   },
@@ -3030,7 +3030,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3134,7 +3134,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3303,7 +3303,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3430,7 +3430,7 @@
                                             "type": "element",
                                             "tagName": "pre",
                                             "properties": {
-                                              "class": "shiki vitesse-dark",
+                                              "className": "shiki vitesse-dark",
                                               "style": "background-color:#121212;color:#dbd7caee",
                                               "tabindex": "0"
                                             },
@@ -3444,7 +3444,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3522,7 +3522,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3600,7 +3600,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3769,7 +3769,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": []
                                                   },
@@ -3781,7 +3781,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3898,7 +3898,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -3924,7 +3924,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -4093,7 +4093,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -4119,7 +4119,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -4275,7 +4275,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -4301,7 +4301,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": []
                                                   },
@@ -4313,7 +4313,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -4417,7 +4417,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -4586,7 +4586,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -5276,7 +5276,7 @@
                                             "type": "element",
                                             "tagName": "pre",
                                             "properties": {
-                                              "class": "shiki vitesse-dark",
+                                              "className": "shiki vitesse-dark",
                                               "style": "background-color:#121212;color:#dbd7caee",
                                               "tabindex": "0"
                                             },
@@ -5290,7 +5290,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -5368,7 +5368,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -5511,7 +5511,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -5537,7 +5537,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -5680,7 +5680,7 @@
                                                     "type": "element",
                                                     "tagName": "span",
                                                     "properties": {
-                                                      "class": "line"
+                                                      "className": "line"
                                                     },
                                                     "children": [
                                                       {
@@ -5967,7 +5967,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }

--- a/packages/vitepress-twoslash/test/out/import-vue.ts.json
+++ b/packages/vitepress-twoslash/test/out/import-vue.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "vitesse-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1033,7 +1033,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -1045,7 +1045,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1871,7 +1871,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -1993,7 +1993,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }

--- a/packages/vitepress-twoslash/test/out/query-offset.ts.json
+++ b/packages/vitepress-twoslash/test/out/query-offset.ts.json
@@ -5,7 +5,7 @@
       "type": "element",
       "tagName": "pre",
       "properties": {
-        "class": [
+        "className": [
           "shiki",
           "vitesse-dark",
           "twoslash",
@@ -24,7 +24,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -253,7 +253,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -265,7 +265,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -277,7 +277,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -289,7 +289,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -518,7 +518,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -530,7 +530,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -542,7 +542,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             },
@@ -554,7 +554,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": [
                 {
@@ -783,7 +783,7 @@
               "type": "element",
               "tagName": "span",
               "properties": {
-                "class": "line"
+                "className": "line"
               },
               "children": []
             }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

- fix #1033
- rename property class to className

hast uses `className` instead of `class`. Utilities such as `hast-util-classnames` handle only `className`.

> The HTML attributes class and for respectively become className and htmlFor in alignment with the DOM. No other attributes gain different names as properties, other than a change in casing.
> <https://github.com/syntax-tree/hast?tab=readme-ov-file#propertyname>


### Linked Issues

#1033

### Additional context

`processNode` was modified in #896.
