### PR TITLE
ci: use oidc for npm publish & codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,6 @@ jobs:
         run: nr test --coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,9 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - run: pnpm run publish:ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
+
+      - name: Upgrade npm
+        run: npm i -g npm@latest
+
+      - name: Publish to NPM
+        run: pnpm run publish:ci


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Enable trusted publisher, required steps:
1. Connect shiki repository to all npm packages at `https://www.npmjs.com/package/<package-name>/access`
2. Safely remove npm tokens and `CODECOV_TOKEN`
3. [optional] Disallow tokens and trusted publishing will still work

<img width="512" height="276" alt="Image" src="https://github.com/user-attachments/assets/64211c66-a268-43d0-b268-37c864bdca19" />

### Linked Issues

### Additional context

https://github.com/e18e/ecosystem-issues/issues/201

<!-- e.g. is there anything you'd like reviewers to focus on? -->
