### PR TITLE
fix: Improve Twoslash error handling

### DIFF
--- a/packages/twoslash/src/core.ts
+++ b/packages/twoslash/src/core.ts
@@ -129,7 +129,7 @@ export function createTransformerFactory(
           catch (error) {
             const result = onTwoslashError(error, code, lang, this.options)
             if (typeof result === 'string')
-              return code
+              return result
           }
         }
       },

--- a/packages/vitepress-twoslash/src/index.ts
+++ b/packages/vitepress-twoslash/src/index.ts
@@ -19,7 +19,7 @@ export function transformerTwoslash(options: VitePressPluginTwoslashOptions = {}
     explicitTrigger = true,
   } = options
 
-  const onError = (error: any, code: string): void => {
+  const onError = (error: any, code: string): string | void => {
     const isCI = typeof process !== 'undefined' && process?.env?.CI
     const isDev = typeof process !== 'undefined' && process?.env?.NODE_ENV === 'development'
     const shouldThrow = (options.throws || isCI || !isDev) && options.throws !== false
@@ -28,7 +28,7 @@ export function transformerTwoslash(options: VitePressPluginTwoslashOptions = {}
       throw error
     else
       console.error(error)
-    removeTwoslashNotations(code)
+    return removeTwoslashNotations(code)
   }
 
   const twoslash = createTransformerFactory(


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixes error handling in Twoslash packages to properly return cleaned code when errors occur, instead of ignoring the error handler's return value.

### Linked Issues

close #1069

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
