### PR TITLE
Chore: correct misspelling

### DIFF
--- a/docs/packages/vitepress.md
+++ b/docs/packages/vitepress.md
@@ -52,7 +52,7 @@ export default defineConfig({
       transformerTwoslash() // [!code hl]
     ],
     // [!code hl:2]
-    // Explicitly load these languages for types hightlighting
+    // Explicitly load these languages for types highlighting
     languages: ['js', 'jsx', 'ts', 'tsx']
   }
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hi respectable devs! I just found a small spelling mistake while browsing shiki's homepage
https://github.com/shikijs/shiki/blob/29f89143b339855814f0b40e9db18be7e0141dd2/docs/packages/vitepress.md?plain=1#L55
Maybe it's `highlighting`, not `hightlighting` :)
### Additional context

A huge thank for your hard work on this amazing project!
