### PR TITLE
feat(transformers): support `meta.indent` for indent guides

### DIFF
--- a/packages/transformers/src/transformers/render-indent-guides.ts
+++ b/packages/transformers/src/transformers/render-indent-guides.ts
@@ -2,7 +2,7 @@ import type { ShikiTransformer } from '@shikijs/types'
 import type { Element } from 'hast'
 
 export interface TransformerRenderIndentGuidesOptions {
-  indent?: number
+  indent?: number | false
 }
 
 /**
@@ -15,14 +15,15 @@ export function transformerRenderIndentGuides(
   return {
     name: '@shikijs/transformers:render-indent-guides',
     code(hast) {
-      let { indent = 2 } = options
+      const indent = Number(
+        this.options.meta?.indent
+        ?? this.options.meta?.__raw?.match(/\{indent:(\d+|false)\}/)?.[1]
+        ?? options.indent
+        ?? 2,
+      )
 
-      const match = this.options.meta?.__raw?.match(/\{indent:(\d+|false)\}/)
-      if (match) {
-        if (match[1] === 'false') {
-          return hast
-        }
-        indent = Number(match[1])
+      if (Number.isNaN(indent) || indent <= 0) {
+        return hast
       }
       const indentRegex = new RegExp(` {${indent}}| {0,${indent - 1}}\t| {1,}$`, 'g')
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The `transformerRenderIndentGuides` from `@shikijs/transformers` previously only parsed the `this.options.meta?.__raw` string to get the indent value. This PR adds support for reading the pre-parsed `this.options.meta?.indent` configuration and optimizes the indent value validation logic (skips processing if the value is non-numeric(`'false'`) or ≤ 0).


### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
