### PR TITLE
docs(types): fix broken @see link for dual themes to shiki.style/guid…

### DIFF
--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -80,7 +80,7 @@ export interface CodeOptionsMultipleThemes<Themes extends string = string> {
    * <span style="color:#111;--shiki-dark:#fff;">code</span>
    * ```
    *
-   * @see https://github.com/shikijs/shiki#lightdark-dual-themes
+   * @see https://shiki.style/guide/dual-themes
    */
   themes: Partial<Record<string, ThemeRegistrationAny | StringLiteralUnion<Themes>>>
 


### PR DESCRIPTION
…e/dual-themes

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Fix broken documentation link in the themes property docstring for dual theme support.

File: packages/types/src/options.ts
Section: CodeOptionsMultipleThemes doc comment for themes
Change: Update @see URL to the correct Dual Themes guide.
Before:

https://github.com/shikijs/shiki#lightdark-dual-themes (broken)


After:

https://shiki.style/guide/dual-themes (correct)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

fixes #1034

### Additional context
No runtime or type behavior changes — documentation comment only.
This change aligns doc references with the latest shiki.style guide for dual theme usage.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
