### PR TITLE
fix(monaco): add high-contrast theme support

### DIFF
--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -52,8 +52,19 @@ export function textmateThemeToMonacoTheme(theme: ThemeRegistrationResolved): Mo
       .map(([key, value]) => [key, `#${normalizeColor(value)}`]),
   )
 
+  // Detect high-contrast themes and set appropriate Monaco base
+  const isHighContrast = theme.name?.toLowerCase().includes('high-contrast')
+  let base: 'vs' | 'vs-dark' | 'hc-black' | 'hc-light'
+
+  if (isHighContrast) {
+    base = theme.type === 'light' ? 'hc-light' : 'hc-black'
+  }
+  else {
+    base = theme.type === 'light' ? 'vs' : 'vs-dark'
+  }
+
   return {
-    base: theme.type === 'light' ? 'vs' : 'vs-dark',
+    base,
     inherit: false,
     colors,
     rules,

--- a/packages/monaco/test/high-contrast.test.ts
+++ b/packages/monaco/test/high-contrast.test.ts
@@ -1,0 +1,75 @@
+import type { ThemeRegistrationResolved } from '@shikijs/types'
+import { describe, expect, it } from 'vitest'
+import { textmateThemeToMonacoTheme } from '../src/index'
+
+describe('high-contrast theme support', () => {
+  it('should set base to hc-black for dark high-contrast themes', () => {
+    const theme: ThemeRegistrationResolved = {
+      name: 'github-dark-high-contrast',
+      type: 'dark',
+      fg: '#ffffff',
+      bg: '#000000',
+      colors: {},
+      settings: [],
+    }
+
+    const monacoTheme = textmateThemeToMonacoTheme(theme)
+    expect(monacoTheme.base).toBe('hc-black')
+  })
+
+  it('should set base to hc-light for light high-contrast themes', () => {
+    const theme: ThemeRegistrationResolved = {
+      name: 'github-light-high-contrast',
+      type: 'light',
+      fg: '#000000',
+      bg: '#ffffff',
+      colors: {},
+      settings: [],
+    }
+
+    const monacoTheme = textmateThemeToMonacoTheme(theme)
+    expect(monacoTheme.base).toBe('hc-light')
+  })
+
+  it('should set base to vs-dark for regular dark themes', () => {
+    const theme: ThemeRegistrationResolved = {
+      name: 'github-dark',
+      type: 'dark',
+      fg: '#ffffff',
+      bg: '#000000',
+      colors: {},
+      settings: [],
+    }
+
+    const monacoTheme = textmateThemeToMonacoTheme(theme)
+    expect(monacoTheme.base).toBe('vs-dark')
+  })
+
+  it('should set base to vs for regular light themes', () => {
+    const theme: ThemeRegistrationResolved = {
+      name: 'github-light',
+      type: 'light',
+      fg: '#000000',
+      bg: '#ffffff',
+      colors: {},
+      settings: [],
+    }
+
+    const monacoTheme = textmateThemeToMonacoTheme(theme)
+    expect(monacoTheme.base).toBe('vs')
+  })
+
+  it('should handle case-insensitive high-contrast detection', () => {
+    const theme: ThemeRegistrationResolved = {
+      name: 'Custom-High-Contrast-Theme',
+      type: 'dark',
+      fg: '#ffffff',
+      bg: '#000000',
+      colors: {},
+      settings: [],
+    }
+
+    const monacoTheme = textmateThemeToMonacoTheme(theme)
+    expect(monacoTheme.base).toBe('hc-black')
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR fixes high-contrast theme support in [shikiToMonaco](cci:1://file:///Users/adarshpriydarshi/Desktop/shiki/packages/monaco/src/index.ts:72:0-165:1) by properly detecting and configuring Monaco editor's base theme for high-contrast themes.

**Problem:**
When using high-contrast themes (like `github-dark-high-contrast` or `github-light-high-contrast`) with Monaco editor, the selection foreground color was not being applied correctly. This is because Monaco requires the theme base to be set to `hc-black` or `hc-light` for high-contrast mode to work properly, but [shikiToMonaco](cci:1://file:///Users/adarshpriydarshi/Desktop/shiki/packages/monaco/src/index.ts:72:0-165:1) was only using `vs` and `vs-dark`.

**Solution:**
- Detect high-contrast themes by checking if the theme name contains 'high-contrast' (case-insensitive)
- Set Monaco base to `'hc-black'` for dark high-contrast themes
- Set Monaco base to `'hc-light'` for light high-contrast themes
- Regular themes continue to use `'vs'` (light) and `'vs-dark'` (dark) as before

**Changes:**
- Modified [textmateThemeToMonacoTheme](cci:1://file:///Users/adarshpriydarshi/Desktop/shiki/packages/monaco/src/index.ts:24:0-70:1) function in [/packages/monaco/src/index.ts](cci:7://file:///Users/adarshpriydarshi/Desktop/shiki/packages/monaco/src/index.ts:0:0-0:0)
- Added comprehensive test suite in [/packages/monaco/test/high-contrast.test.ts](cci:7://file:///Users/adarshpriydarshi/Desktop/shiki/packages/monaco/test/high-contrast.test.ts:0:0-0:0) with 5 test cases covering:
  - Dark high-contrast themes → `hc-black`
  - Light high-contrast themes → `hc-light`
  - Regular dark themes → `vs-dark`
  - Regular light themes → `vs`
  - Case-insensitive detection

### Linked Issues

Fixes #1081

### Additional context

The fix is minimal and backward-compatible. All existing themes continue to work as before, while high-contrast themes now properly enable Monaco's high-contrast mode, making the editor accessible for users who need high-contrast interfaces.

The detection method (checking for "high-contrast" in the theme name) aligns with the existing naming convention used by bundled themes like `github-dark-high-contrast` and `github-light-high-contrast`.