### PR TITLE
Fix decorations for structure: 'inline'

### DIFF
--- a/packages/core/src/highlight/code-to-hast.ts
+++ b/packages/core/src/highlight/code-to-hast.ts
@@ -229,7 +229,7 @@ export function tokensToHast(
       type: 'element',
       tagName: 'code',
       properties: {},
-      children: root.children,
+      children: root.children as Element[],
     }
     codeNode = virtualCode
 


### PR DESCRIPTION
### Description
This PR fixes an issue where decorations (like underlines and strikethroughs) do not work when using `structure: 'inline'`.  
Previously, the `transformerDecorations` transformer relies on the `code` hook, which wasn’t invoked in inline structures, causing decorations to be ignored.  

Key changes:
- Populates `lineNodes` even in inline mode so transformers that rely on line information can access it.
- Creates a virtual `<code>` element wrapping all inline children before calling the `code` transformer.
- Updates the `codeNode` reference so transformers are properly applied.
- After transformation, assigns the transformed children back to `root.children`.

This ensures that all transformer hooks (`tokens`, `span`, `line`, `code`, `root`) are properly invoked in inline mode, while preserving classic structure functionality.

### Linked Issues
- Fixes issue where decorations are not applied with `structure: 'inline'`.

### Additional context
- Tested with inline decorations; they now render correctly.
- Classic structure rendering remains unaffected.
- Reviewers may focus on the inline transformation logic and ensuring backward compatibility with classic structure.
