### PR TITLE
fix(transformers): support comment-prefixed [code . highlight] marker…

### DIFF
--- a/packages/transformers/src/transformers/notation-map.ts
+++ b/packages/transformers/src/transformers/notation-map.ts
@@ -25,7 +25,7 @@ export function transformerNotationMap(
 
   return createCommentNotationTransformer(
     name,
-    new RegExp(`\\s*\\[!code (${Object.keys(classMap).map(escapeRegExp).join('|')})(:\\d+)?\\]`),
+    new RegExp(`#?\\s*\\[!code (${Object.keys(classMap).map(escapeRegExp).join('|')})(:\\d+)?\\]`, 'gi'),
     function ([_, match, range = ':1'], _line, _comment, lines, index) {
       const lineNum = Number.parseInt(range.slice(1), 10)
 


### PR DESCRIPTION
fix(transformers): support comment-prefixed [!code highlight] markers (fixes #1006)

### Description

This PR fixes **#1006 — "line highlighting: v3 matching algorithm will not match bare comments"**.

In Shiki v3, comment-prefixed highlight markers such as:
```python
# Important line # [!code highlight]

---


