### PR TITLE
fix: enable decorations for structure: inline

### DIFF
--- a/packages/core/test/decorations.test.ts
+++ b/packages/core/test/decorations.test.ts
@@ -153,6 +153,64 @@ describe('decorations', () => {
     await expect(style + html)
       .toMatchFileSnapshot('./out/decorations/adjacent.html')
   })
+
+  it('works with structure inline', async () => {
+    const html = await codeToHtml('const foo = "bar"', {
+      theme: 'vitesse-light',
+      lang: 'ts',
+      structure: 'inline',
+      decorations: [
+        {
+          start: { line: 0, character: 6 },
+          end: { line: 0, character: 9 },
+          properties: { class: 'highlighted' },
+        },
+        {
+          start: { line: 0, character: 12 },
+          end: { line: 0, character: 17 },
+          properties: { class: 'highlighted-body' },
+        },
+      ],
+    })
+
+    await expect(style + html)
+      .toMatchFileSnapshot('./out/decorations/inline.html')
+  })
+
+  it('works with structure inline multiline', async () => {
+    const multilineCode = `const x = 1
+const y = 2
+const z = 3`
+
+    const html = await codeToHtml(multilineCode, {
+      theme: 'vitesse-light',
+      lang: 'ts',
+      structure: 'inline',
+      decorations: [
+        // Highlight "x" in first line
+        {
+          start: { line: 0, character: 6 },
+          end: { line: 0, character: 7 },
+          properties: { class: 'highlighted' },
+        },
+        // Highlight "y" in second line
+        {
+          start: { line: 1, character: 6 },
+          end: { line: 1, character: 7 },
+          properties: { class: 'highlighted-body' },
+        },
+        // Highlight across lines
+        {
+          start: { line: 1, character: 10 },
+          end: { line: 2, character: 6 },
+          properties: { class: 'highlighted-border' },
+        },
+      ],
+    })
+
+    await expect(style + html)
+      .toMatchFileSnapshot('./out/decorations/inline-multiline.html')
+  })
 })
 
 describe('decorations errors', () => {

--- a/packages/core/test/out/decorations/inline-multiline.html
+++ b/packages/core/test/out/decorations/inline-multiline.html
@@ -1,0 +1,13 @@
+
+<style>
+.highlighted {
+  background-color: #ff000050;
+  display: inline;
+}
+.highlighted-body {
+  background-color: #8883;
+}
+.highlighted-border {
+  border: 1px solid #ff0000;
+}
+</style><span style="color:#AB5959">const </span><span style="color:#B07D48" class="highlighted">x</span><span style="color:#999999"> =</span><span style="color:#2F798A"> 1</span><br><span style="color:#AB5959">const </span><span style="color:#B07D48" class="highlighted-body">y</span><span style="color:#999999"> =</span><span style="color:#2F798A"> </span><span style="color:#2F798A" class="highlighted-border">2</span><br><span style="color:#AB5959" class="highlighted-border">const </span><span style="color:#B07D48">z</span><span style="color:#999999"> =</span><span style="color:#2F798A"> 3</span>

--- a/packages/core/test/out/decorations/inline.html
+++ b/packages/core/test/out/decorations/inline.html
@@ -1,0 +1,13 @@
+
+<style>
+.highlighted {
+  background-color: #ff000050;
+  display: inline;
+}
+.highlighted-body {
+  background-color: #8883;
+}
+.highlighted-border {
+  border: 1px solid #ff0000;
+}
+</style><span style="color:#AB5959">const </span><span style="color:#B07D48" class="highlighted">foo</span><span style="color:#999999"> =</span><span style="color:#B5695977"> </span><span class="highlighted-body"><span style="color:#B5695977">"</span><span style="color:#B56959">bar</span><span style="color:#B5695977">"</span></span>


### PR DESCRIPTION
- Invoke code transformer hooks for inline structures
- Build synthetic code element to allow transformers like decorations to work
- Add tests for single-line and multi-line decorations with inline structure

Fixes #992

### Description

This PR fixes an issue where decorations don't work with `structure: inline` because the `transformerDecorations` transformer's `code` hook was not being invoked for inline structures.

**What changed:**
- Modified `tokensToHast` in `code-to-hast.ts` to invoke the `code` transformer hook for inline structures
- For inline mode, a synthetic `<code>` element is built from the root's children, transformers are applied, and the result is extracted back to inline format
- This allows transformers like `transformerDecorations` to work correctly with inline structures while maintaining compatibility with all existing transformers

**Implementation approach:**
1. Collect inline tokens and build a temporary line-based structure
2. Apply all `code` hook transformers (including decorations)
3. Flatten the structure back to inline format with `<br>` separators

### Linked Issues

Fixes #992

### Additional context

- Added 2 new test cases with snapshots to verify single-line and multi-line decorations work correctly with `structure: inline`
- All existing tests pass
- The fix maintains backward compatibility - no breaking changes to the API or existing behavior