### PR TITLE
fix(monaco): preserve bold, italic, and strikethrough token styles in…

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "bench": "pnpm -r run bench:prepare && vitest bench",
     "prepare": "simple-git-hooks"
   },
+  "dependencies": {
+    "monaco-editor": "catalog:"
+  },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:cli",
     "@antfu/ni": "catalog:cli",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      monaco-editor:
+        specifier: ^0.54.0
+        version: 0.54.0
     devDependencies:
       '@antfu/eslint-config':
         specifier: catalog:cli
@@ -3820,6 +3824,9 @@ packages:
 
   monaco-editor-core@0.54.0:
     resolution: {integrity: sha512-0zQ0Ny1QguMdOicIyRgvgK5le2jxf6sOI6lpFlCXoYD2eQDuD+C3hvAxXDCCzzZkDaIN38BcXxCRu1gj9ZWPZA==}
+
+  monaco-editor@0.54.0:
+    resolution: {integrity: sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==}
 
   mrmime@2.0.0:
     resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
@@ -8432,6 +8439,11 @@ snapshots:
       ufo: 1.6.1
 
   monaco-editor-core@0.54.0:
+    dependencies:
+      dompurify: 3.1.7
+      marked: 14.0.0
+
+  monaco-editor@0.54.0:
     dependencies:
       dompurify: 3.1.7
       marked: 14.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,8 @@ packages:
   - playground
   - examples/*
   - docs
+catalog:
+  monaco-editor: ^0.54.0
 catalogs:
   bundling:
     '@rollup/plugin-alias': ^6.0.0


### PR DESCRIPTION

### Description

This PR fixes an issue where `shikiToMonaco` didn’t preserve Markdown text styles (**bold**, *italic*, ~~strikethrough~~) when using Shiki themes in the Monaco Editor.
Previously, Monaco only mapped tokens by color, losing style metadata.
Now, bold, italic, underline, and strikethrough styles are correctly applied across all supported themes.

### Summary of Changes

* Added `parseFontStyleToMask()` to translate Shiki `fontStyle` strings into Monaco bitmasks.
* Introduced dual mapping:
  `color → scope` (backward compatibility) and `color + style → scope` (accurate style mapping).
* Updated theme conversion to propagate `fontStyle`.
* Removed unused helpers and ensured ESLint compliance.

### Linked Issue

Fixes #1022

### Testing & Verification

Tested locally with `monaco-editor@0.54.0` and Shiki themes `github-dark` / `github-light`.
Confirmed via Monaco’s API that Markdown tokens (`markup.bold`, `markup.italic`, `markup.strikethrough`) now return correct `fontStyle` values.
Visually verified that bold, italic, and strikethrough render correctly, with no regressions in other languages.

Console logs confirmed:

```
Style applied: markup.bold bold
Style applied: markup.italic italic
Style applied: markup.strikethrough strikethrough
```

### Additional Context

Verified theme switching works correctly.
All lint, type, and build checks pass.



