### PR TITLE
fix(vitepress-twoslash): better handling of offscreen twoslash poppers

### DIFF
--- a/packages/vitepress-twoslash/src/client.ts
+++ b/packages/vitepress-twoslash/src/client.ts
@@ -1,5 +1,6 @@
 import type { App } from 'vue'
 import FloatingVue, { recomputeAllPoppers } from 'floating-vue'
+import { isShown, patchFloatingVueMethods } from './patch-floating-vue'
 
 const isMobile = typeof navigator !== 'undefined' && /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
 
@@ -13,6 +14,8 @@ export type FloatingVueConfig = Parameters<(typeof FloatingVue)['install']>[1]
 const TwoslashFloatingVue = {
   install: (app: App, options: FloatingVueConfig = {}) => {
     if (typeof window !== 'undefined') {
+      let isDragging = false
+
       // Recompute poppers when clicking on a tab
       window.addEventListener('click', (e) => {
         const path = e.composedPath()
@@ -24,42 +27,34 @@ const TwoslashFloatingVue = {
       // not show or hide while we're dragging (selecting text) so they don't
       // interfere with the selection.
       if (!isMobile) {
-        let isDragging = false
         window.addEventListener('mousedown', () => {
           isDragging = true
         }, { passive: true })
         window.addEventListener('mouseup', () => {
           isDragging = false
         }, { passive: true })
-
-        const _component = app.component
-        app.component = function (this: typeof app, ...rest: any[]) {
-          // @ts-expect-error type mismatch for `rest`
-          const comp = _component.apply(this, rest)
-          if (rest.length >= 2 && rest[0] === 'VMenu') {
-            try {
-              const PopperVue = rest[1].components.Popper
-              const PopperTs = PopperVue.extends
-
-              const _show = PopperTs.methods.show
-              PopperTs.methods.show = function (...args: any[]) {
-                if (!isDragging)
-                  return _show.apply(this, args)
-              }
-
-              const _hide = PopperTs.methods.hide
-              PopperTs.methods.hide = function (...args: any[]) {
-                if (!isDragging)
-                  return _hide.apply(this, args)
-              }
-            }
-            catch (e) {
-              console.error('Failed to patch FloatingVue', e)
-            }
-          }
-          return comp
-        }
       }
+
+      // Patch floating-vue
+      patchFloatingVueMethods(app, ({
+        async $_computePosition(popper, baseImpl, args) {
+          if (isShown(popper.$_referenceNode)) {
+            await baseImpl.apply(popper, args)
+            popper.$_popperNode.style.display = 'initial'
+          }
+          else {
+            popper.$_popperNode.style.display = 'none'
+          }
+        },
+        show: function show(popper, baseImpl, args) {
+          if (!isDragging)
+            baseImpl.apply(popper, args)
+        },
+        hide(popper, baseImpl, args) {
+          if (!isDragging)
+            baseImpl.apply(popper, args)
+        },
+      }))
     }
 
     app.use(FloatingVue, {

--- a/packages/vitepress-twoslash/src/patch-floating-vue.ts
+++ b/packages/vitepress-twoslash/src/patch-floating-vue.ts
@@ -1,0 +1,59 @@
+import type { Popper } from 'floating-vue'
+import type { App } from 'vue'
+
+type FloatingVueMethods = Exclude<ReturnType<(typeof Popper)>['methods'], undefined>
+type FloatingVueMethodsOverrides = { [Key in keyof FloatingVueMethods]?: FloatingVueMethodOverrideFn<Key> }
+type FloatingVueMethodOverrideFn<T extends keyof FloatingVueMethods> = (
+  ctx: ReturnType<typeof Popper>,
+  baseImplementation: (args?: Parameters<FloatingVueMethods[T]>) => ReturnType<FloatingVueMethods[T]>,
+  args: any,
+) => void
+
+export function patchFloatingVueMethods(app: App, methodOverrides: FloatingVueMethodsOverrides): void {
+  const _component = app.component
+  app.component = function (this: ReturnType<typeof Popper>, ...rest: any[]) {
+    // @ts-expect-error type mismatch for `rest`
+    const comp = _component.apply(this, rest)
+
+    if (rest.length >= 2 && rest[0] === 'VMenu') {
+      try {
+        const PopperVue = rest[1].components.Popper
+        const PopperTs = PopperVue.extends
+
+        for (const method of Object.keys(methodOverrides)) {
+          const _originalMethod = PopperTs.methods[method] ?? (() => {})
+          const methodFn = methodOverrides[method as keyof typeof methodOverrides]
+          PopperTs.methods[method] = async function (...args: any[]) {
+            if (methodFn) {
+              methodFn(this, _originalMethod, args)
+            }
+            else {
+              _originalMethod(args)
+            }
+          }
+        }
+      }
+      catch (e) {
+        console.error('Failed to patch FloatingVue', e)
+      }
+    }
+    return comp
+  }
+}
+
+export function isShown(el: Element | undefined): boolean {
+  if (!el)
+    return false
+
+  let current: Element | null = el
+  while (current) {
+    const style = getComputedStyle(current)
+    if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
+      return false
+    }
+    current = current.parentElement
+  }
+
+  const rect = el.getBoundingClientRect()
+  return rect.width > 0 && rect.height > 0
+}


### PR DESCRIPTION
### Description

`vitepress-twoslash` makes the assumption that we're both:
1. using VitePress' default theme [(poppers z-index rely on the `--vp-z-index-local-nav` custom property)](https://github.com/shikijs/shiki/blob/5068b26bdf48a5848a31326b1e63527c0bce0fe1/packages/vitepress-twoslash/src/style.css#L16).
2. using Twoslash within a VitePress page which uses default theme's `VPLocalNav` component.

In other words, using twoslash **ALWAYS** renders the poppers in the top-left corner . In most VitePress-powered websites, relying on the `--vp-z-index-local-nav` custom property would indeed _luckily_ hide offscreen poppers because `VPLocalNav` is higher in the stacking context (poppers are simply hidden in the background). 

But the whole thing breaks whenever the layout doesn't follow those assumptions, e.g. either:
1. by using a whole custom theme that never defines that  `--vp-z-index-local-nav` custom property
2. by trying to use vitepress-twoslash on the docs' home page which doesn't use `VPLocalNav`
3. by simply customizing CSS and refining z-indices/stacking contexts

[Here's a straightforward repro of the issue, even when using the default theme](https://stackblitz.com/edit/stackblitz-starters-sax2pvan?file=.vitepress%2Ftheme%2FLayout.vue)

<img width="1132" height="1057" alt="image" src="https://github.com/user-attachments/assets/3f4c72f4-3395-45e8-8ad4-f6e12e624018" />


### My two cents


1. Code-blocks from inactive code-groups (or even better hidden blocks) should _not_ be displayed. They may be rendered for performance purposes, but showing them obviously is an undesirable behaviour _(cf the above screen)_.

2. The current approach is both smart and naive. It's not versatile enough since it relies on a specific behaviour of a specific theme. THose are prerequisites that, as I mentioned,  _not everyone_ meet. 

3. Because there's no official API between floating-vue, VitePress and Twoslash, the easiest way of addressing this issue is to hook into floating-ui's `recomputePosition` method to either hide or show a popper depending on whether its part of displayed/hidden block. 

4. Good news is that floating-ui's `recomputePosition`  is reachable through `floating-vue`, which means custom logic could be added by overriding floating-ui's `recomputePosition method`. Even better news is that `vitepress-twoslash` already patches floating-vue to address some other issues.


### What this PR does

1. [chore] It creates a `Poppper` wrapper that makes it easieer to customize `floating-vue`.
2. [feat] Whenever a floating-vue's recomputePosition is called,, it determines whether is should be hidden or not (by checking if the reference node is actually displayed)