### PR TITLE
docs: fix typos in index.md and bundles.md

### DIFF
--- a/docs/guide/bundles.md
+++ b/docs/guide/bundles.md
@@ -85,5 +85,5 @@ const code = highlighter.codeToHtml('const a = 1', {
 ```
 
 ::: info
-[Shorthands](/guide/install#shorthands) are only avaliable in bundle presets. For a fine-grained bundle, you can create your own shorthands using [`createSingletonShorthands`](https://github.com/shikijs/shiki/blob/main/packages/core/src/constructors/bundle-factory.ts#L203) or port it yourself.
+[Shorthands](/guide/install#shorthands) are only available in bundle presets. For a fine-grained bundle, you can create your own shorthands using [`createSingletonShorthands`](https://github.com/shikijs/shiki/blob/main/packages/core/src/constructors/bundle-factory.ts#L203) or port it yourself.
 :::

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -37,7 +37,7 @@ Here is a little playground for you to try out how Shiki highlights your code. T
 
 You can inspect the bundle size in detail on [pkg-size.dev/shiki](https://pkg-size.dev/shiki).
 
-As of `v1.1.6`, measured at 22th, February 2024:
+As of `v1.1.6`, measured at 22nd, February 2024:
 
 | Bundle              | Size (minified) | Size (gzip) | Notes                                                            |
 | ------------------- | --------------: | ----------: | ---------------------------------------------------------------- |


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR fixes two minor typos in the Shiki documentation for better clarity and correctness:

1. docs/guide/index.md (line 40): Fixed typo — 22th → 22nd
2. docs/guide/bundles.md (line 88): Fixed typo — avaliable → available

These are small documentation improvements and do not affect any functionality or code behavior.


