### PR TITLE
Remove Deprecated `loadWasm` References from Docs

### DIFF
--- a/docs/blog/v2.md
+++ b/docs/blog/v2.md
@@ -64,20 +64,18 @@ Since the introduction of the [engine system](/guide/regex-engines) in v1.16, We
 You might need to change your import path:
 
 ```ts
-import { loadWasm } from 'shiki' // [!code --]
-import { loadWasm } from 'shiki/engine/oniguruma' // [!code ++]
+import { loadWasm } from 'shiki/engine/oniguruma'
 ```
 
 `loadWasm` field in `createHighlighterCore` is replaced with `engine` field:
 
 ```ts
 import { createHighlighter } from 'shiki'
-import { createOnigurumaEngine } from 'shiki/engine/oniguruma' // [!code ++]
+import { createOnigurumaEngine } from 'shiki/engine/oniguruma'
 
 const shiki = await createHighlighter({
   // ...
-  loadWasm: () => import('shiki/wasm'), // [!code --]
-  engine: createOnigurumaEngine(() => import('shiki/wasm')), // [!code ++]
+  engine: createOnigurumaEngine(() => import('shiki/wasm')),
 })
 ```
 

--- a/docs/blog/v3.md
+++ b/docs/blog/v3.md
@@ -27,20 +27,18 @@ Since the introduction of the [engine system](/guide/regex-engines) in v1.16, We
 You might need to change your import path:
 
 ```ts
-import { loadWasm } from 'shiki' // [!code --]
-import { loadWasm } from 'shiki/engine/oniguruma' // [!code ++]
+import { loadWasm } from 'shiki/engine/oniguruma'
 ```
 
 `loadWasm` field in `createHighlighterCore` is replaced with `engine` field:
 
 ```ts
 import { createHighlighter } from 'shiki'
-import { createOnigurumaEngine } from 'shiki/engine/oniguruma' // [!code ++]
+import { createOnigurumaEngine } from 'shiki/engine/oniguruma'
 
 const shiki = await createHighlighter({
   // ...
-  loadWasm: () => import('shiki/wasm'), // [!code --]
-  engine: createOnigurumaEngine(() => import('shiki/wasm')), // [!code ++]
+  engine: createOnigurumaEngine(() => import('shiki/wasm')),
 })
 ```
 

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -262,16 +262,18 @@ Meanwhile, it's also recommended to use the [Fine-grained Bundle](#fine-grained-
 // @noErrors
 import js from '@shikijs/langs/javascript'
 import nord from '@shikijs/themes/nord'
-import { createHighlighterCore, loadWasm } from 'shiki/core'
+import { createHighlighterCore } from 'shiki/core'
+import { createOnigurumaEngine } from 'shiki/engine/oniguruma'
 
-// import wasm as assets
-await loadWasm(import('shiki/onig.wasm'))
+// import wasm as assets (Cloudflare Workers requires importing the wasm file)
+const engine = createOnigurumaEngine(() => import('shiki/onig.wasm'))
 
 export default {
   async fetch() {
     const highlighter = await createHighlighterCore({
       themes: [nord],
       langs: [js],
+      engine,
     })
 
     return new Response(highlighter.codeToHtml('console.log(\'shiki\');', {


### PR DESCRIPTION
-------------------------------------------------------------------------------------------------------------------------
PR = #1113 SOLVED

-------------------------------------------------------------------------------------------------------------------------
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

# Fix: Remove Deprecated `loadWasm` References from Docs

## Summary
This update removes outdated `loadWasm` examples from the documentation, which were deprecated in the latest Shiki API.  
The affected files used incorrect imports and initialization patterns, especially in the **Cloudflare Workers** section.

---

## Changes Made

### **1. `v2.md`**

- **Removed deprecated imports:**
  ```js
  import { loadWasm } from 'shiki'
