### PR TITLE
docdocs: fix typo in RegExp Engines guide (createShiki → createHighlighter)

### DIFF
--- a/docs/guide/regex-engines.md
+++ b/docs/guide/regex-engines.md
@@ -11,7 +11,7 @@ Shiki also offers the ability to switch the regex engine or provide a custom imp
 ```ts
 import { createHighlighter } from 'shiki'
 
-const shiki = await createShiki({
+const shiki = await createHighlighter({
   themes: ['nord'],
   langs: ['javascript'],
   engine: { /* custom engine */ }
@@ -28,7 +28,7 @@ This is the default engine that uses the compiled Oniguruma WebAssembly.
 import { createHighlighter } from 'shiki'
 import { createOnigurumaEngine } from 'shiki/engine/oniguruma'
 
-const shiki = await createShiki({
+const shiki = await createHighlighter({
   themes: ['nord'],
   langs: ['javascript'],
   engine: createOnigurumaEngine(import('shiki/wasm'))


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
This PR fixes a small typo in the RegExp Engines guide.  
The docs were using `createShiki`, which isn't a valid API in v3.  
Replaced it with `createHighlighter` in both examples for accuracy.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
Fixes shikijs/shiki#1121



### Additional context
No additional context — just a straightforward doc fix.


<!-- e.g. is there anything you'd like reviewers to focus on? -->
