### PR TITLE
update general test for import statement

### DIFF
--- a/packages/shiki/test/general.test.ts
+++ b/packages/shiki/test/general.test.ts
@@ -8,8 +8,8 @@ describe('should', () => {
       langs: ['javascript'],
     })
 
-    expect(shiki.codeToHtml('console.log', { lang: 'js', theme: 'vitesse-light' }))
-      .toMatchInlineSnapshot(`"<pre class="shiki vitesse-light" style="background-color:#ffffff;color:#393a34" tabindex="0"><code><span class="line"><span style="color:#B07D48">console</span><span style="color:#999999">.</span><span style="color:#B07D48">log</span></span></code></pre>"`)
+    expect(shiki.codeToHtml('import { Xlsx } from "@qui/icons/application/outline";', { lang: 'js', theme: 'vitesse-light' }))
+      .toMatchInlineSnapshot(`"<pre class="shiki vitesse-light" style="background-color:#ffffff;color:#393a34" tabindex="0"><code><span class="line"><span style="color:#1E754F">import</span><span style="color:#B07D48"> { Xlsx } </span><span style="color:#1E754F">from</span><span style="color:#B5695977"> "</span><span style="color:#B56959">@qui/icons/application/outline</span><span style="color:#B5695977">"</span><span style="color:#999999">;</span></span></code></pre>"`)
   })
 
   it('dynamic load theme and lang', async () => {


### PR DESCRIPTION
#1125 PR Description
update general test for import statement


Description
This PR updates the test case in packages/shiki/test/general.test.ts to test syntax highlighting for a more complex ES6 import statement, improving test coverage for JavaScript language support.

Changes
Modified the test code from 'console.log' to 'import { Xlsx } from "@qui/icons/application/outline";'
Updated the corresponding snapshot to reflect the new output.