### PR TITLE
fix: add eslint-disable comment for console.warn in internal-sync

### DIFF
--- a/packages/core/src/constructors/internal-sync.ts
+++ b/packages/core/src/constructors/internal-sync.ts
@@ -27,8 +27,10 @@ let instancesCount = 0
  */
 export function createShikiInternalSync(options: HighlighterCoreOptions<true>): ShikiInternal {
   instancesCount += 1
-  if (options.warnings !== false && instancesCount >= 10 && instancesCount % 10 === 0)
+  if (options.warnings !== false && instancesCount >= 10 && instancesCount % 10 === 0) {
+    // eslint-disable-next-line no-console
     console.warn(`[Shiki] ${instancesCount} instances have been created. Shiki is supposed to be used as a singleton, consider refactoring your code to cache your highlighter instance; Or call \`highlighter.dispose()\` to release unused instances.`)
+  }
 
   let isDisposed = false
 


### PR DESCRIPTION
## Description

This PR adds the missing `eslint-disable-next-line no-console` comment for the `console.warn` call in `internal-sync.ts` to maintain consistency with the rest of the codebase.

## Changes

- Added `// eslint-disable-next-line no-console` comment before `console.warn` call
- Wrapped the `console.warn` in braces for better code style consistency

## Why this change?

The `console.warn` call on line 31 was missing an eslint-disable comment, which is inconsistent with other console usage in the codebase (e.g., `packages/core/src/warn.ts` line 34). This ensures all console statements follow the same linting pattern.

## Testing

- ✅ Linter shows no errors
- ✅ Follows existing codebase patterns
- ✅ No functional changes