### PR TITLE
fix: correct grammar and remove typo in vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
     "source.organizeImports": "never"
   },
 
-  // Silent the stylistic rules in you IDE, but still auto fix them
+  // Silence the stylistic rules in your IDE, but still auto fix them
   "eslint.rules.customizations": [
     { "rule": "@stylistic/*", "severity": "off" },
     { "rule": "*-indent", "severity": "off" },
@@ -36,7 +36,6 @@
   ],
   "references.preferredLocation": "peek",
   "cSpell.words": [
-    "Extenerlaize",
     "shikijs"
   ]
 }


### PR DESCRIPTION
**Summary**

fix grammar in .vscode/settings.json comment: “Silent … you IDE” → “Silence … your IDE” clean up cSpell.words by removing the unused typo entry “Extenerlaize”

**Testing**
n/a (config change only)