### PR TITLE
Add 'plain' to PlainTextLanguage type

### DIFF
--- a/packages/types/src/langs.ts
+++ b/packages/types/src/langs.ts
@@ -1,7 +1,7 @@
 import type { RawGrammar } from './textmate'
 import type { MaybeArray, MaybeGetter } from './utils'
 
-export type PlainTextLanguage = 'text' | 'plaintext' | 'txt'
+export type PlainTextLanguage = 'text' | 'plaintext' | 'txt' | 'plain'
 export type AnsiLanguage = 'ansi'
 export type SpecialLanguage = PlainTextLanguage | AnsiLanguage
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Adds `'plain'` to the `PlainTextLanguage` type. It's supported as a [plaintext language option](https://github.com/shikijs/shiki/blob/f3fb8cc4a9602919b1ab1673a3bd11cd587e7bbc/packages/core/src/utils/general.ts#L27), but that's not reflected in the type.
