### PR TITLE
test: resolve vitest alias for wasm-inlined

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,11 @@ export default defineConfig({
     wasmPlugin(),
     tsconfigPaths(),
   ],
+  resolve: {
+    alias: {
+      '@shikijs/engine-oniguruma/wasm-inlined': new URL('./packages/engine-oniguruma/src/wasm-inlined.ts', import.meta.url).pathname,
+    },
+  },
   test: {
     testTimeout: 30_000,
     reporters: 'dot',


### PR DESCRIPTION
This PR fixes the Vitest alias resolution for `wasm-inlined`.

Changes:
- Added missing alias in `vitest.config.ts` so that `wasm-inlined` resolves correctly.

Verification:
- `pnpm test`
  - Test Files: 59 passed
  - Tests: 767 passed

Fixes #1137 
