### PR TITLE
fixed typo of createShiki --> createHighlighter as mentioned in issue…

### DIFF
--- a/docs/guide/regex-engines.md
+++ b/docs/guide/regex-engines.md
@@ -11,7 +11,7 @@ Shiki also offers the ability to switch the regex engine or provide a custom imp
 ```ts
 import { createHighlighter } from 'shiki'
 
-const shiki = await createShiki({
+const shiki = await createHighlighter({
   themes: ['nord'],
   langs: ['javascript'],
   engine: { /* custom engine */ }
@@ -28,7 +28,7 @@ This is the default engine that uses the compiled Oniguruma WebAssembly.
 import { createHighlighter } from 'shiki'
 import { createOnigurumaEngine } from 'shiki/engine/oniguruma'
 
-const shiki = await createShiki({
+const shiki = await createHighlighter({
   themes: ['nord'],
   langs: ['javascript'],
   engine: createOnigurumaEngine(import('shiki/wasm'))


### PR DESCRIPTION
## Title
docs: fix incorrect function name in RegExp Engines guide

## Description
This PR fixes a typo in the documentation for the “RegExp Engines” guide. The code examples previously used createShiki, which does not exist in the Shiki v3 API. All instances have been updated to use the correct function name, createHighlighter.

Closes #1121.