### PR TITLE
feat(langs): support embeddedLanguages alias for backwards compatibility (#1044)

### DIFF
--- a/packages/core/src/textmate/registry.ts
+++ b/packages/core/src/textmate/registry.ts
@@ -166,8 +166,9 @@ export class Registry extends TextMateRegistry {
   private resolveEmbeddedLanguages(lang: LanguageRegistration): void {
     this._langMap.set(lang.name, lang)
     this._langGraph.set(lang.name, lang)
-    if (lang.embeddedLangs) {
-      for (const embeddedLang of lang.embeddedLangs)
+    const embedded = lang.embeddedLanguages ?? lang.embeddedLangs
+    if (embedded) {
+      for (const embeddedLang of embedded)
         this._langGraph.set(embeddedLang, this._langMap.get(embeddedLang)!)
     }
   }

--- a/packages/types/src/langs.ts
+++ b/packages/types/src/langs.ts
@@ -20,6 +20,7 @@ export interface LanguageRegistration extends RawGrammar {
    * languages for each parent language.
    */
   embeddedLangs?: string[]
+  embeddedLanguages?: string[] // for VS code
   /**
    * A list of languages that embed the current language.
    * Unlike `embeddedLangs`, the embedded languages will not be loaded automatically.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR adds support for the embeddedLanguages field in LanguageRegistration.

Historically the field was named embeddedLangs, while VSCode grammars use embeddedLanguages.
Shiki currently supports only embeddedLangs, which prevents grammars using the VSCode naming convention from working as expected.

### Linked Issues
Fixes #1044

### Additional context

No breaking changes introduced — if both fields are present, embeddedLanguages takes priority.
This brings Shiki in line with VSCode terminology while preserving support for older grammars.
