### PR TITLE
docs(twoslash): fix typo in JSDoc comment ("genreated" → "generated")

### DIFF
--- a/packages/twoslash/src/renderer-rich.ts
+++ b/packages/twoslash/src/renderer-rich.ts
@@ -90,7 +90,7 @@ export interface RendererRichOptions {
   queryRendering?: 'popup' | 'line'
 
   /**
-   * Extensions for the genreated HAST tree.
+   * Extensions for the generated HAST tree.
    */
   hast?: {
     /**


### PR DESCRIPTION
## Summary
This PR fixes a minor typo in a JSDoc comment within the Twoslash renderer.
The word "genreated" has been corrected to "generated".

## Changes Made
- Updated file: `packages/twoslash/src/renderer-rich.ts`
- Line 93 updated:
  - "genreated" → "generated"
- Documentation-only change

## Verification
- Verified that no other occurrences of the typo exist in the repository.
- No functional or runtime behavior is affected.
- No tests or configuration updates required.

## Not Changed (Intentional)
- Backward compatibility class `twoslash-query-presisted` left unchanged.
- Existing TODO comments remain untouched.

## Impact
- **Risk:** Minimal
- **Breaking Changes:** None
- **Tests Required:** No
- Improves documentation clarity and code quality.

## Additional Notes
This follows the project's conventional commit guidelines and passes linting and testing without issues.
