### PR TITLE
fix(monaco): ensure correct color map update when switching themes

### DIFF
--- a/packages/monaco/playground/package.json
+++ b/packages/monaco/playground/package.json
@@ -6,6 +6,11 @@
   "scripts": {
     "play": "vite"
   },
+  "dependencies": {
+    "@shikijs/monaco": "workspace:*",
+    "monaco-editor-core": "catalog:integrations",
+    "shiki": "workspace:*"
+  },
   "devDependencies": {
     "typescript": "catalog:cli",
     "vite": "catalog:bundling"

--- a/packages/monaco/playground/src/main.ts
+++ b/packages/monaco/playground/src/main.ts
@@ -20,7 +20,7 @@ monaco.languages.register({ id: 'vue' })
 monaco.languages.register({ id: 'typescript' })
 monaco.languages.register({ id: 'javascript' })
 
-// Register the themes from Shiki, and provide syntax highlighting for Monaco. // [!code highlight:2]
+// Register the themes from Shiki, and provide syntax highlighting for Monaco.
 shikiToMonaco(highlighter, monaco)
 
 // Create the editor

--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -103,6 +103,14 @@ export function shikiToMonaco(
     _setTheme(themeName)
   }
 
+  const _create = monaco.editor.create
+  monaco.editor.create = (element: HTMLElement, options?: monacoNs.editor.IStandaloneEditorConstructionOptions, override?: monacoNs.editor.IEditorOverrideServices) => {
+    if (options?.theme) {
+      monaco.editor.setTheme(options.theme)
+    }
+    return _create(element, options, override)
+  }
+
   // Set the first theme as the default theme
   monaco.editor.setTheme(themeIds[0])
 
@@ -147,7 +155,8 @@ export function shikiToMonaco(
           for (let j = 0; j < tokensLength; j++) {
             const startIndex = result.tokens[2 * j]
             const metadata = result.tokens[2 * j + 1]
-            const color = normalizeColor(colorMap[EncodedTokenMetadata.getForeground(metadata)] || '')
+            const colorIdx = EncodedTokenMetadata.getForeground(metadata)
+            const color = normalizeColor(colorMap[colorIdx] || '')
             const fontStyle = EncodedTokenMetadata.getFontStyle(metadata)
 
             // Because Monaco only support one scope per token,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -638,6 +638,16 @@ importers:
         version: 0.55.1
 
   packages/monaco/playground:
+    dependencies:
+      '@shikijs/monaco':
+        specifier: workspace:*
+        version: link:..
+      monaco-editor-core:
+        specifier: catalog:integrations
+        version: 0.55.1
+      shiki:
+        specifier: workspace:*
+        version: link:../../shiki
     devDependencies:
       typescript:
         specifier: ^5.9.3


### PR DESCRIPTION
# Description

Fixes #1093

This PR fixes an issue where switching themes in [shikiToMonaco](cci:1://file:///Users/shivankgupta/Desktop/shiki/packages/monaco/src/index.ts:64:0-172:1) would not correctly update the internal color map if the new theme had a different color map length or structure. This resulted in incorrect syntax highlighting colors (e.g., dark theme colors appearing in a light theme) when multiple themes were loaded and switched.

The fix involves hijacking `monaco.editor.create` to ensure `monaco.editor.setTheme` is called when a theme is provided in the options. This ensures that [shikiToMonaco](cci:1://file:///Users/shivankgupta/Desktop/shiki/packages/monaco/src/index.ts:64:0-172:1)'s [setTheme](cci:1://file:///Users/shivankgupta/Desktop/shiki/packages/monaco/src/index.ts:85:2-103:3) hook is triggered, updating the color map and scope map before the editor renders.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified manually in the `packages/monaco/playground`.

**Reproduction Steps:**
1. Modified playground to load `material-theme-palenight` and `catppuccin-latte`.
2. Registered `regexp` language.
3. Created editor with `theme: 'catppuccin-latte'` and content `(a|b)[]***********`.

**Before Fix:**
The syntax highlighting for `(a|b)` was dark (incorrect for `catppuccin-latte`).

**After Fix:**
The syntax highlighting is correct (light/colorful) for `catppuccin-latte`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings