### PR TITLE
docs: add transformers section to markdown-it

### DIFF
--- a/docs/packages/markdown-it.md
+++ b/docs/packages/markdown-it.md
@@ -46,14 +46,15 @@ md.use(await Shiki({
   }
 }))
 ```
+
 ## Transformers
 
 You can pass [transformers](/guide/transformers) to the plugin options to customize the highlighted code.
 
 ```ts twoslash
 import Shiki from '@shikijs/markdown-it'
-import MarkdownIt from 'markdown-it'
 import { transformerNotationDiff } from '@shikijs/transformers'
+import MarkdownIt from 'markdown-it'
 
 const md = MarkdownIt()
 


### PR DESCRIPTION
docs: add transformers section to markdown-it

Adds a paragraph and example on how to use transformers with the `@shikijs/markdown-it` plugin.

Closes #722