### PR TITLE
fix(core): correct offset calculation in mergeWhitespaceTokens

### DIFF
--- a/packages/core/src/highlight/code-to-hast.ts
+++ b/packages/core/src/highlight/code-to-hast.ts
@@ -287,7 +287,7 @@ function mergeWhitespaceTokens(tokens: ThemedToken[][]): ThemedToken[][] {
   return tokens.map((line) => {
     const newLine: ThemedToken[] = []
     let carryOnContent = ''
-    let firstOffset = 0
+    let firstOffset: number | undefined
     line.forEach((token, idx) => {
       const isDecorated = token.fontStyle && (
         (token.fontStyle & FontStyle.Underline)
@@ -295,7 +295,7 @@ function mergeWhitespaceTokens(tokens: ThemedToken[][]): ThemedToken[][] {
       )
       const couldMerge = !isDecorated
       if (couldMerge && token.content.match(/^\s+$/) && line[idx + 1]) {
-        if (!firstOffset)
+        if (firstOffset === undefined)
           firstOffset = token.offset
         carryOnContent += token.content
       }
@@ -304,7 +304,7 @@ function mergeWhitespaceTokens(tokens: ThemedToken[][]): ThemedToken[][] {
           if (couldMerge) {
             newLine.push({
               ...token,
-              offset: firstOffset,
+              offset: firstOffset!,
               content: carryOnContent + token.content,
             })
           }
@@ -312,12 +312,12 @@ function mergeWhitespaceTokens(tokens: ThemedToken[][]): ThemedToken[][] {
             newLine.push(
               {
                 content: carryOnContent,
-                offset: firstOffset,
+                offset: firstOffset!,
               },
               token,
             )
           }
-          firstOffset = 0
+          firstOffset = undefined
           carryOnContent = ''
         }
         else {


### PR DESCRIPTION
This PR fixes a bug in 
mergeWhitespaceTokens
 where the offset of the merged token was incorrect if the sequence started at offset 0.

The issue was that firstOffset was initialized to 0, and the check if (!firstOffset) treated 0 as falsy. This caused the offset to be incorrectly overwritten by subsequent token offsets in the sequence.

I have updated the logic to initialize firstOffset to undefined and check explicitly for undefined, ensuring the correct start offset is preserved.

Linked Issues
N/A

Additional context
I verified the fix by creating a reproduction test case that isolated 
mergeWhitespaceTokens
 and confirmed the offset is now correct. I also ran the full core test suite to ensure no regressions.