### PR TITLE
test(twoslash): avoid top-level console.log in fixture to prevent noisy test output.

### DIFF
--- a/packages/twoslash/test/fixtures/highlights.ts
+++ b/packages/twoslash/test/fixtures/highlights.ts
@@ -7,5 +7,7 @@ const hello = "OK"
 const world = "OK"
 //  ^^^^^^
 
-console.log("OK")
-//          ^^^^^
+// console.log("OK")
+// The fixture previously printed to stdout when imported which can
+// pollute test output. Keep the example code but don't execute it at
+// import time.


### PR DESCRIPTION
This PR removes an unintended top-level console output from a test fixture that executed at import time and produced noisy stdout during test runs.

### Description


Replaces the top-level console.log("OK") in highlights.ts with a commented example and explanatory note

Keeps the fixture example visible for readers while removing the unintended side-effect of printing to stdout during imports


###Why this change is needed

Top-level console output in fixture files pollutes test logs and CI output

Makes test failures, diffs, and snapshots harder to review

This is a minimal, low-risk cleanup that improves overall test hygiene and developer experience


