### PR TITLE
fix: allow langAlias to work with text and special languages (#1164)

### DIFF
--- a/packages/core/src/constructors/bundle-factory.ts
+++ b/packages/core/src/constructors/bundle-factory.ts
@@ -65,6 +65,8 @@ export function createBundledHighlighter<BundledLangs extends string, BundledThe
         if (isSpecialLang(lang))
           return []
         lang = (options.langAlias?.[lang] || lang) as LanguageInput | BundledLangs | SpecialLanguage
+        if (isSpecialLang(lang))
+          return []
         const bundle = bundledLanguages[lang as BundledLangs]
         if (!bundle)
           throw new ShikiError(`Language \`${lang}\` is not included in this bundle. You may want to load it from external source.`)

--- a/packages/core/test/repro_1164.test.ts
+++ b/packages/core/test/repro_1164.test.ts
@@ -1,0 +1,19 @@
+import { createJavaScriptRegexEngine } from '@shikijs/engine-javascript'
+import { createHighlighter } from 'shiki'
+import { expect, it } from 'vitest'
+
+it('repro #1164', async () => {
+  const highlighter = await createHighlighter({
+    langs: [],
+    langAlias: {
+      gitignore: 'text',
+    },
+    themes: [],
+    engine: createJavaScriptRegexEngine(),
+  })
+
+  await highlighter.loadLanguage('gitignore' as any)
+
+  expect(highlighter.codeToHtml('foo', { lang: 'gitignore', theme: 'none' }))
+    .toMatchInlineSnapshot(`"<pre class="shiki none" style="background-color:;color:" tabindex="0"><code><span class="line"><span>foo</span></span></code></pre>"`)
+})


### PR DESCRIPTION
Description
This PR fixes an issue where using langAlias to map a language to 

text
 (or other special languages like plaintext, ansi) would cause a crash.

Previously, 

loadLanguage
 attempted to load the target language as a regular external bundle. Since special languages are handled internally and do not have external bundles, this resulted in a "Language not found" error.

I have updated 

internal-sync.ts
 and 

bundle-factory.ts
 to correctly resolve aliases and check if the target is a special language before attempting to load it.

Linked Issues
Fixes #1164

Additional context
I added a reproduction test case 

packages/core/test/repro_1164.test.ts
 which aliases 

gitignore
 to 

text
 and verifies that 

codeToHtml
 works correctly without throwing an error.