### PR TITLE
fix(core): resolve langAlias before loading language to support alias…

### DIFF
--- a/packages/core/src/constructors/internal-sync.ts
+++ b/packages/core/src/constructors/internal-sync.ts
@@ -51,6 +51,11 @@ export function createShikiInternalSync(options: HighlighterCoreOptions<true>): 
     return _lang
   }
 
+  function getLanguageAlias(name: string): string | undefined {
+    ensureNotDisposed()
+    return _registry.getAlias(name)
+  }
+
   function getTheme(name: string | ThemeRegistrationAny): ThemeRegistrationResolved {
     if (name === 'none')
       return { bg: '', fg: '', name: 'none', settings: [], type: 'dark' }
@@ -126,6 +131,7 @@ export function createShikiInternalSync(options: HighlighterCoreOptions<true>): 
     setTheme,
     getTheme,
     getLanguage,
+    getLanguageAlias,
     getLoadedThemes,
     getLoadedLanguages,
     loadLanguage,

--- a/packages/core/src/highlight/code-to-tokens-base.ts
+++ b/packages/core/src/highlight/code-to-tokens-base.ts
@@ -38,7 +38,7 @@ export function codeToTokensBase(
     theme: themeName = internal.getLoadedThemes()[0],
   } = options
 
-  if (isPlainLang(lang) || isNoneTheme(themeName))
+  if (isPlainLang(lang) || isPlainLang(internal.getLanguageAlias(lang)) || isNoneTheme(themeName))
     return splitLines(code).map(line => [{ content: line[0], offset: line[1] }])
 
   const { theme, colorMap } = internal.setTheme(themeName)
@@ -80,7 +80,7 @@ export function getLastGrammarState(...args: any[]): GrammarState | undefined {
     theme: themeName = internal.getLoadedThemes()[0],
   } = options
 
-  if (isPlainLang(lang) || isNoneTheme(themeName))
+  if (isPlainLang(lang) || isPlainLang(internal.getLanguageAlias(lang)) || isNoneTheme(themeName))
     throw new ShikiError('Plain language does not have grammar state')
   if (lang === 'ansi')
     throw new ShikiError('ANSI language does not have grammar state')

--- a/packages/core/src/textmate/registry.ts
+++ b/packages/core/src/textmate/registry.ts
@@ -83,6 +83,20 @@ export class Registry extends TextMateRegistry {
     return this._resolvedGrammars.get(name)
   }
 
+  public getAlias(name: string): string | undefined {
+    if (this._alias[name]) {
+      const resolved = new Set<string>([name])
+      while (this._alias[name]) {
+        name = this._alias[name]
+        if (resolved.has(name))
+          throw new ShikiError(`Circular alias \`${Array.from(resolved).join(' -> ')} -> ${name}\``)
+        resolved.add(name)
+      }
+      return name
+    }
+    return undefined
+  }
+
   public loadLanguage(lang: LanguageRegistration): void {
     if (this.getGrammar(lang.name))
       return

--- a/packages/core/test/alias.test.ts
+++ b/packages/core/test/alias.test.ts
@@ -1,6 +1,6 @@
 import { createJavaScriptRegexEngine } from '@shikijs/engine-javascript'
 import { createHighlighter } from 'shiki'
-import { it } from 'vitest'
+import { expect, it } from 'vitest'
 
 it('langAlias', async () => {
   const highlighter = await createHighlighter({
@@ -13,4 +13,18 @@ it('langAlias', async () => {
   })
 
   await highlighter.loadLanguage('mylang' as any)
+})
+
+it('langAlias for text', async () => {
+  const highlighter = await createHighlighter({
+    langs: [],
+    langAlias: {
+      'my-text': 'text',
+    },
+    themes: ['nord'],
+    engine: createJavaScriptRegexEngine(),
+  })
+
+  const html = highlighter.codeToHtml('hello world', { lang: 'my-text', theme: 'nord' })
+  expect(html).toContain('hello world')
 })

--- a/packages/types/src/highlighter.ts
+++ b/packages/types/src/highlighter.ts
@@ -52,6 +52,11 @@ export interface ShikiInternal<BundledLangKeys extends string = never, BundledTh
   getLanguage: (name: string | LanguageRegistration) => Grammar
 
   /**
+   * Get the alias of a language
+   */
+  getLanguageAlias: (lang: string) => string | undefined
+
+  /**
    * Set the current theme and get the resolved theme object and color map.
    * @internal
    */


### PR DESCRIPTION
… → text

Fixes #1164
### Summary

This PR fixes an issue in the CSS bundler where `@supports` at-rules were not being handled correctly during parsing and minification.  
As a result, `@supports` blocks were sometimes skipped, flattened incorrectly, or lost entirely when nested inside other at-rules.

### What was the bug?

When processing a structure like:

```css
@supports (display: grid) {
  .box { display: grid; }
}

