### PR TITLE
docs(rehype): remove deprecated line highlight feature

### DIFF
--- a/docs/packages/rehype.md
+++ b/docs/packages/rehype.md
@@ -104,23 +104,6 @@ const file = await unified()
 
 ## Features
 
-### Line Highlight
-
-::: warning
-This is deprecated. It's disabled by default in `v0.10.0` and will be removed in the next minor. Consider use [`transformerNotationHighlight`](https://shiki.style/packages/transformers#transformernotationhighlight) instead.
-:::
-
-In addition to the features of `shiki`, this plugin also supports line highlighting. You can specify line numbers to highlight after the language name in the format `{<line-numbers>}` - a comma separated list of `<line-number>`s, wrapped in curly braces. Each line number can be a single number (e.g. `{2}` highlights line 2 and `{1,4}` highlights lines 1 and 4) or a range (e.g. `{1-7}` highlights lines 1 through 7, and `{1-3,5-6}` highlights lines 1 through 3 and 5 through 6). For example:
-
-````md
-```js {1,3-4}
-console.log('1') // highlighted
-console.log('2')
-console.log('3') // highlighted
-console.log('4') // highlighted
-```
-````
-
 ### Inline Code
 
 You can also highlight inline codes with the `inline` option.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Removes the deprecated "Line Highlight" section from the `@shikijs/rehype` documentation. This feature is disabled by default in v0.10.0 and users are encouraged to use `transformerNotationHighlight` instead.

### Linked Issues
Fixes #947

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Verified that the documentation builds correctly with `pnpm run docs:build`.