### PR TITLE
feat(twoslash): add context parameter to filter option

### DIFF
--- a/packages/twoslash/src/core.ts
+++ b/packages/twoslash/src/core.ts
@@ -111,7 +111,7 @@ export function createTransformerFactory(
         if (lang in langAlias)
           lang = langAlias[this.options.lang]
 
-        if (filter(lang, code, this.options)) {
+        if (filter(lang, code, this.options, this)) {
           try {
             const codeWithIncludes = includes.applyInclude(code)
 

--- a/packages/twoslash/src/types.ts
+++ b/packages/twoslash/src/types.ts
@@ -1,4 +1,4 @@
-import type { CodeToHastOptions, ShikiTransformerContext, ShikiTransformerContextMeta } from '@shikijs/types'
+import type { CodeToHastOptions, ShikiTransformerContext, ShikiTransformerContextCommon, ShikiTransformerContextMeta } from '@shikijs/types'
 import type { Element, ElementContent, Text } from 'hast'
 import type {
   NodeCompletion,
@@ -76,7 +76,7 @@ export interface TransformerTwoslashOptions {
    * Custom filter function to apply this transformer to
    * When specified, `langs`, `explicitTrigger`, and `disableTriggers` will be ignored
    */
-  filter?: (lang: string, code: string, options: CodeToHastOptions) => boolean
+  filter?: (lang: string, code: string, options: CodeToHastOptions, context?: ShikiTransformerContextCommon) => boolean
   /**
    * Custom instance of twoslasher function
    */


### PR DESCRIPTION
## Description
Adds an optional `context` parameter to the `filter` option in `@shikijs/twoslash`, allowing users to access code block metadata and transformer context when filtering code blocks.

## Motivation
Closes #628

When integrating TypeDoc with `@shikijs/vitepress-twoslash`, some errors occur because TypeDoc renders `@default` tags to code blocks that may not strictly follow TypeScript syntax. For example:

```typescript
class User {
  /**
   * User identity in urls.
   * @default this.name
   */
  handle: string
}