### PR TITLE
fix(core): check embeddedLanguages in registry dependency check

### DIFF
--- a/packages/core/src/textmate/registry.ts
+++ b/packages/core/src/textmate/registry.ts
@@ -135,7 +135,12 @@ export class Registry extends TextMateRegistry {
     const missingLangs = langsGraphArray.filter(([_, lang]) => !lang)
     if (missingLangs.length) {
       const dependents = langsGraphArray
-        .filter(([_, lang]) => lang && lang.embeddedLangs?.some(l => missingLangs.map(([name]) => name).includes(l)))
+        .filter(([_, lang]) => {
+          if (!lang)
+            return false
+          const embedded = lang.embeddedLanguages || lang.embeddedLangs
+          return embedded?.some(l => missingLangs.map(([name]) => name).includes(l))
+        })
         .filter(lang => !missingLangs.includes(lang))
       throw new ShikiError(`Missing languages ${missingLangs.map(([name]) => `\`${name}\``).join(', ')}, required by ${dependents.map(([name]) => `\`${name}\``).join(', ')}`)
     }

--- a/packages/core/test/registry.test.ts
+++ b/packages/core/test/registry.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { createJavaScriptRegexEngine } from '../../engine-javascript/src/index'
+import { createShikiInternal } from '../src/constructors/internal'
+
+describe('repro issue', () => {
+  it('should throw error when missing embeddedLanguages', async () => {
+    const shiki = await createShikiInternal({
+      engine: createJavaScriptRegexEngine(),
+      themes: [],
+      langs: [],
+    })
+
+    await expect(shiki.loadLanguage({
+      name: 'test-lang',
+      scopeName: 'source.test',
+      embeddedLanguages: ['missing-lang'],
+      patterns: [],
+      repository: {},
+    }))
+      .rejects
+      .toThrowError(/Missing languages `missing-lang`, required by `test-lang`/)
+  })
+})


### PR DESCRIPTION

This PR fixes an issue in packages/core/src/textmate/registry.ts where the embeddedLanguages property (the modern replacement for embeddedLangs) was ignored when checking for missing language dependencies in Registry.loadLanguages.

Previously, only embeddedLangs was checked, leading to incomplete error messages when a dependency specified in embeddedLanguages was missing.

Linked Issues
N/A

Additional context
Added a regression test in packages/core/test/registry.test.ts to verify the fix.
Verified that all core tests pass.
