### PR TITLE
fix: add typesVersions for legacy resolution support

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,13 @@
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "typesVersions": {
+    "*": {
+      "types": [
+        "./dist/types.d.mts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Description
This PR fixes a TypeScript module resolution error (TS2307: Cannot find module '@shikijs/core/types') that occurs when using shiki in projects with moduleResolution: "node" (or default) and module: "commonjs".

While exports in 
package.json
 works for modern resolution strategies (node16, nodenext, bundler), older strategies require typesVersions to correctly resolve subpath exports for types.

I added typesVersions to 
packages/core/package.json
 to explicitly map the types subpath, ensuring compatibility with a wider range of TypeScript configurations.

Linked Issues
fixes #987

Additional context
I verified this fix by creating a reproduction environment using the exact 
tsconfig.json
 provided in the issue (target es2017, module commonjs).

Before fix: tsc failed with error TS2307.
After fix: tsc compiled successfully.
