### PR TITLE
fix: resolve race condition in singleton highlighter (issue #1009)

### DIFF
--- a/packages/core/src/constructors/internal-sync.ts
+++ b/packages/core/src/constructors/internal-sync.ts
@@ -71,10 +71,10 @@ export function createShikiInternalSync(options: HighlighterCoreOptions<true>): 
   } {
     ensureNotDisposed()
     const theme = getTheme(name)
-    if (_lastTheme !== name) {
-      _registry.setTheme(theme)
-      _lastTheme = name
-    }
+    // Always set the theme to ensure the registry is in sync.
+    // The registry has its own cache so this is not too expensive.
+    _registry.setTheme(theme)
+    _lastTheme = name
     const colorMap = _registry.getColorMap()
     return {
       theme,


### PR DESCRIPTION
### Description

This PR addresses a race condition encountered when using singleton highlighters in concurrent environments.

Previously, `internal-sync.ts` included an optimization that skipped synchronizing the registry if the requested theme matched the last used theme. While efficient in single-threaded contexts, this caused issues during concurrent requests. If multiple requests hit the highlighter simultaneously, the internal state could become stale, leading to the wrong theme being applied or tokenization errors.

I have removed this optimization in `packages/core/src/constructors/internal-sync.ts`. Now, the registry explicitly synchronizes the theme for every request. This ensures that the state is always consistent, preventing stale usage regardless of concurrency.

### Linked Issues

Fixes #1009

### Additional context

This change trades a small micro-optimization for significantly better stability in server-side or high-concurrency usage (e.g., when Shiki is used in an API route handling multiple requests at once).