### PR TITLE
feat(langs): add gn language support

### DIFF
--- a/packages/langs/grammars/gn.json
+++ b/packages/langs/grammars/gn.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "gn",
+  "scopeName": "source.gn",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#functions"
+    },
+    {
+      "include": "#constants"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "match": "#.*$",
+          "name": "comment.line.number-sign.gn"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "begin": "\"",
+          "end": "\"",
+          "name": "string.quoted.double.gn",
+          "patterns": [
+            {
+              "match": "\\\\.",
+              "name": "constant.character.escape.gn"
+            },
+            {
+              "match": "\\$[a-zA-Z0-9_]+",
+              "name": "variable.other.gn"
+            },
+            {
+              "match": "\\${[^}]*}",
+              "name": "variable.other.gn"
+            }
+          ]
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "match": "\\b(if|else|true|false)\\b",
+          "name": "keyword.control.gn"
+        }
+      ]
+    },
+    "functions": {
+      "patterns": [
+        {
+          "match": "\\b(assert|config|declare_args|defined|exec_script|foreach|get_label_info|get_path_info|get_target_outputs|getenv|import|print|process_file_template|read_file|rebase_path|set_default_toolchain|set_defaults|template|tool|toolchain|toolchain_args|write_file)\\b",
+          "name": "support.function.gn"
+        },
+        {
+          "match": "\\b(action|action_foreach|bundle_data|copy|create_bundle|executable|generated_file|group|loadable_module|rust_library|rust_proc_macro|shared_library|source_set|static_library|target)\\b",
+          "name": "entity.name.function.gn"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "match": "\\b(current_cpu|current_os|current_toolchain|default_toolchain|host_cpu|host_os|root_build_dir|root_gen_dir|root_out_dir|target_cpu|target_gen_dir|target_os|target_out_dir)\\b",
+          "name": "constant.language.gn"
+        }
+      ]
+    }
+  }
+}

--- a/packages/langs/package.json
+++ b/packages/langs/package.json
@@ -19,6 +19,7 @@
   "sideEffects": false,
   "exports": {
     ".": "./dist/index.mjs",
+    "./gn": "./dist/gn.mjs",
     "./abap": "./dist/abap.mjs",
     "./actionscript-3": "./dist/actionscript-3.mjs",
     "./ada": "./dist/ada.mjs",

--- a/packages/shiki/src/langs-bundle-full.ts
+++ b/packages/shiki/src/langs-bundle-full.ts
@@ -18,9 +18,39 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
     'import': (() => import('@shikijs/langs/ada')) as DynamicImportLanguageRegistration
   },
   {
+    'id': 'angular-expression',
+    'name': 'angular-expression',
+    'import': (() => import('@shikijs/langs/angular-expression')) as DynamicImportLanguageRegistration
+  },
+  {
     'id': 'angular-html',
     'name': 'Angular HTML',
     'import': (() => import('@shikijs/langs/angular-html')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'angular-inline-style',
+    'name': 'angular-inline-style',
+    'import': (() => import('@shikijs/langs/angular-inline-style')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'angular-inline-template',
+    'name': 'angular-inline-template',
+    'import': (() => import('@shikijs/langs/angular-inline-template')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'angular-let-declaration',
+    'name': 'angular-let-declaration',
+    'import': (() => import('@shikijs/langs/angular-let-declaration')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'angular-template',
+    'name': 'angular-template',
+    'import': (() => import('@shikijs/langs/angular-template')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'angular-template-blocks',
+    'name': 'angular-template-blocks',
+    'import': (() => import('@shikijs/langs/angular-template-blocks')) as DynamicImportLanguageRegistration
   },
   {
     'id': 'angular-ts',
@@ -208,6 +238,11 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
     'import': (() => import('@shikijs/langs/cpp')) as DynamicImportLanguageRegistration
   },
   {
+    'id': 'cpp-macro',
+    'name': 'C++',
+    'import': (() => import('@shikijs/langs/cpp-macro')) as DynamicImportLanguageRegistration
+  },
+  {
     'id': 'crystal',
     'name': 'Crystal',
     'import': (() => import('@shikijs/langs/crystal')) as DynamicImportLanguageRegistration
@@ -324,6 +359,31 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
     'import': (() => import('@shikijs/langs/erlang')) as DynamicImportLanguageRegistration
   },
   {
+    'id': 'es-tag-css',
+    'name': 'es-tag-css',
+    'import': (() => import('@shikijs/langs/es-tag-css')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'es-tag-glsl',
+    'name': 'es-tag-glsl',
+    'import': (() => import('@shikijs/langs/es-tag-glsl')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'es-tag-html',
+    'name': 'es-tag-html',
+    'import': (() => import('@shikijs/langs/es-tag-html')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'es-tag-sql',
+    'name': 'es-tag-sql',
+    'import': (() => import('@shikijs/langs/es-tag-sql')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'es-tag-xml',
+    'name': 'es-tag-xml',
+    'import': (() => import('@shikijs/langs/es-tag-xml')) as DynamicImportLanguageRegistration
+  },
+  {
     'id': 'fennel',
     'name': 'Fennel',
     'import': (() => import('@shikijs/langs/fennel')) as DynamicImportLanguageRegistration
@@ -432,6 +492,12 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
     'id': 'glsl',
     'name': 'GLSL',
     'import': (() => import('@shikijs/langs/glsl')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'gn',
+    'name': 'gn',
+    'aliases': [],
+    'import': (() => import('@shikijs/langs/gn')) as DynamicImportLanguageRegistration
   },
   {
     'id': 'gnuplot',
@@ -564,6 +630,11 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
     'id': 'jinja',
     'name': 'Jinja',
     'import': (() => import('@shikijs/langs/jinja')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'jinja-html',
+    'name': 'jinja-html',
+    'import': (() => import('@shikijs/langs/jinja-html')) as DynamicImportLanguageRegistration
   },
   {
     'id': 'jison',
@@ -701,6 +772,16 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
       'md'
     ],
     'import': (() => import('@shikijs/langs/markdown')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'markdown-nix',
+    'name': 'markdown-nix',
+    'import': (() => import('@shikijs/langs/markdown-nix')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'markdown-vue',
+    'name': 'markdown-vue',
+    'import': (() => import('@shikijs/langs/markdown-vue')) as DynamicImportLanguageRegistration
   },
   {
     'id': 'marko',
@@ -1275,9 +1356,24 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
     'import': (() => import('@shikijs/langs/vue')) as DynamicImportLanguageRegistration
   },
   {
+    'id': 'vue-directives',
+    'name': 'vue-directives',
+    'import': (() => import('@shikijs/langs/vue-directives')) as DynamicImportLanguageRegistration
+  },
+  {
     'id': 'vue-html',
     'name': 'Vue HTML',
     'import': (() => import('@shikijs/langs/vue-html')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'vue-interpolations',
+    'name': 'vue-interpolations',
+    'import': (() => import('@shikijs/langs/vue-interpolations')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'vue-sfc-style-variable-injection',
+    'name': 'vue-sfc-style-variable-injection',
+    'import': (() => import('@shikijs/langs/vue-sfc-style-variable-injection')) as DynamicImportLanguageRegistration
   },
   {
     'id': 'vue-vine',
@@ -1373,7 +1469,13 @@ export type BundledLanguage =
   | 'actionscript-3'
   | 'ada'
   | 'adoc'
+  | 'angular-expression'
   | 'angular-html'
+  | 'angular-inline-style'
+  | 'angular-inline-template'
+  | 'angular-let-declaration'
+  | 'angular-template'
+  | 'angular-template-blocks'
   | 'angular-ts'
   | 'apache'
   | 'apex'
@@ -1417,6 +1519,7 @@ export type BundledLanguage =
   | 'console'
   | 'coq'
   | 'cpp'
+  | 'cpp-macro'
   | 'cql'
   | 'crystal'
   | 'cs'
@@ -1443,6 +1546,11 @@ export type BundledLanguage =
   | 'erb'
   | 'erl'
   | 'erlang'
+  | 'es-tag-css'
+  | 'es-tag-glsl'
+  | 'es-tag-html'
+  | 'es-tag-sql'
+  | 'es-tag-xml'
   | 'f'
   | 'f#'
   | 'f03'
@@ -1473,6 +1581,7 @@ export type BundledLanguage =
   | 'glimmer-js'
   | 'glimmer-ts'
   | 'glsl'
+  | 'gn'
   | 'gnuplot'
   | 'go'
   | 'gql'
@@ -1501,6 +1610,7 @@ export type BundledLanguage =
   | 'java'
   | 'javascript'
   | 'jinja'
+  | 'jinja-html'
   | 'jison'
   | 'jl'
   | 'js'
@@ -1533,6 +1643,8 @@ export type BundledLanguage =
   | 'make'
   | 'makefile'
   | 'markdown'
+  | 'markdown-nix'
+  | 'markdown-vue'
   | 'marko'
   | 'matlab'
   | 'md'
@@ -1663,7 +1775,10 @@ export type BundledLanguage =
   | 'viml'
   | 'vimscript'
   | 'vue'
+  | 'vue-directives'
   | 'vue-html'
+  | 'vue-interpolations'
+  | 'vue-sfc-style-variable-injection'
   | 'vue-vine'
   | 'vy'
   | 'vyper'

--- a/packages/shiki/src/langs-bundle-web.ts
+++ b/packages/shiki/src/langs-bundle-web.ts
@@ -3,9 +3,39 @@ import type { DynamicImportLanguageRegistration, BundledLanguageInfo } from '@sh
 
 export const bundledLanguagesInfo: BundledLanguageInfo[] = [
   {
+    'id': 'angular-expression',
+    'name': 'angular-expression',
+    'import': (() => import('@shikijs/langs/angular-expression')) as DynamicImportLanguageRegistration
+  },
+  {
     'id': 'angular-html',
     'name': 'Angular HTML',
     'import': (() => import('@shikijs/langs/angular-html')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'angular-inline-style',
+    'name': 'angular-inline-style',
+    'import': (() => import('@shikijs/langs/angular-inline-style')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'angular-inline-template',
+    'name': 'angular-inline-template',
+    'import': (() => import('@shikijs/langs/angular-inline-template')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'angular-let-declaration',
+    'name': 'angular-let-declaration',
+    'import': (() => import('@shikijs/langs/angular-let-declaration')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'angular-template',
+    'name': 'angular-template',
+    'import': (() => import('@shikijs/langs/angular-template')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'angular-template-blocks',
+    'name': 'angular-template-blocks',
+    'import': (() => import('@shikijs/langs/angular-template-blocks')) as DynamicImportLanguageRegistration
   },
   {
     'id': 'angular-ts',
@@ -44,6 +74,11 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
     'import': (() => import('@shikijs/langs/cpp')) as DynamicImportLanguageRegistration
   },
   {
+    'id': 'cpp-macro',
+    'name': 'C++',
+    'import': (() => import('@shikijs/langs/cpp-macro')) as DynamicImportLanguageRegistration
+  },
+  {
     'id': 'css',
     'name': 'CSS',
     'import': (() => import('@shikijs/langs/css')) as DynamicImportLanguageRegistration
@@ -52,6 +87,31 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
     'id': 'csv',
     'name': 'CSV',
     'import': (() => import('@shikijs/langs/csv')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'es-tag-css',
+    'name': 'es-tag-css',
+    'import': (() => import('@shikijs/langs/es-tag-css')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'es-tag-glsl',
+    'name': 'es-tag-glsl',
+    'import': (() => import('@shikijs/langs/es-tag-glsl')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'es-tag-html',
+    'name': 'es-tag-html',
+    'import': (() => import('@shikijs/langs/es-tag-html')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'es-tag-sql',
+    'name': 'es-tag-sql',
+    'import': (() => import('@shikijs/langs/es-tag-sql')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'es-tag-xml',
+    'name': 'es-tag-xml',
+    'import': (() => import('@shikijs/langs/es-tag-xml')) as DynamicImportLanguageRegistration
   },
   {
     'id': 'glsl',
@@ -125,6 +185,11 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
     'import': (() => import('@shikijs/langs/jinja')) as DynamicImportLanguageRegistration
   },
   {
+    'id': 'jinja-html',
+    'name': 'jinja-html',
+    'import': (() => import('@shikijs/langs/jinja-html')) as DynamicImportLanguageRegistration
+  },
+  {
     'id': 'jison',
     'name': 'Jison',
     'import': (() => import('@shikijs/langs/jison')) as DynamicImportLanguageRegistration
@@ -174,6 +239,11 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
       'md'
     ],
     'import': (() => import('@shikijs/langs/markdown')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'markdown-vue',
+    'name': 'markdown-vue',
+    'import': (() => import('@shikijs/langs/markdown-vue')) as DynamicImportLanguageRegistration
   },
   {
     'id': 'marko',
@@ -297,9 +367,24 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
     'import': (() => import('@shikijs/langs/vue')) as DynamicImportLanguageRegistration
   },
   {
+    'id': 'vue-directives',
+    'name': 'vue-directives',
+    'import': (() => import('@shikijs/langs/vue-directives')) as DynamicImportLanguageRegistration
+  },
+  {
     'id': 'vue-html',
     'name': 'Vue HTML',
     'import': (() => import('@shikijs/langs/vue-html')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'vue-interpolations',
+    'name': 'vue-interpolations',
+    'import': (() => import('@shikijs/langs/vue-interpolations')) as DynamicImportLanguageRegistration
+  },
+  {
+    'id': 'vue-sfc-style-variable-injection',
+    'name': 'vue-sfc-style-variable-injection',
+    'import': (() => import('@shikijs/langs/vue-sfc-style-variable-injection')) as DynamicImportLanguageRegistration
   },
   {
     'id': 'vue-vine',
@@ -341,7 +426,13 @@ export const bundledLanguagesBase = Object.fromEntries(bundledLanguagesInfo.map(
 export const bundledLanguagesAlias = Object.fromEntries(bundledLanguagesInfo.flatMap(i => i.aliases?.map(a => [a, i.import]) || []))
 
 export type BundledLanguage =
+  | 'angular-expression'
   | 'angular-html'
+  | 'angular-inline-style'
+  | 'angular-inline-template'
+  | 'angular-let-declaration'
+  | 'angular-template'
+  | 'angular-template-blocks'
   | 'angular-ts'
   | 'astro'
   | 'bash'
@@ -352,9 +443,15 @@ export type BundledLanguage =
   | 'coffee'
   | 'coffeescript'
   | 'cpp'
+  | 'cpp-macro'
   | 'css'
   | 'csv'
   | 'cts'
+  | 'es-tag-css'
+  | 'es-tag-glsl'
+  | 'es-tag-html'
+  | 'es-tag-sql'
+  | 'es-tag-xml'
   | 'glsl'
   | 'gql'
   | 'graphql'
@@ -370,6 +467,7 @@ export type BundledLanguage =
   | 'java'
   | 'javascript'
   | 'jinja'
+  | 'jinja-html'
   | 'jison'
   | 'jl'
   | 'js'
@@ -382,6 +480,7 @@ export type BundledLanguage =
   | 'less'
   | 'lit'
   | 'markdown'
+  | 'markdown-vue'
   | 'marko'
   | 'md'
   | 'mdc'
@@ -410,7 +509,10 @@ export type BundledLanguage =
   | 'tsx'
   | 'typescript'
   | 'vue'
+  | 'vue-directives'
   | 'vue-html'
+  | 'vue-interpolations'
+  | 'vue-sfc-style-variable-injection'
   | 'vue-vine'
   | 'wasm'
   | 'wgsl'


### PR DESCRIPTION
## Description
This PR adds support for the `gn` (Generate Ninja) language.
Since the `gn` grammar is not available in `tm-grammars`, I added a basic local grammar file [packages/langs/grammars/gn.json](file:///Users/amanjeet/Desktop/GAME/shiki/packages/langs/grammars/gn.json) and updated the build scripts to support local grammars.

## Changes
- Added [packages/langs/grammars/gn.json](file:///Users/amanjeet/Desktop/GAME/shiki/packages/langs/grammars/gn.json): A basic TextMate grammar for GN.
- Updated [packages/langs/scripts/langs.ts](file:///Users/amanjeet/Desktop/GAME/shiki/packages/langs/scripts/langs.ts):
  - Modified [loadLangs](file:///Users/amanjeet/Desktop/GAME/shiki/packages/langs/scripts/langs.ts#69-131) to load local grammars from `packages/langs/grammars/*.json`.
  - Added fallback logic to use the local grammar content if it's not found in `tm-grammars`.
  - Updated [writeLanguageBundleIndex](file:///Users/amanjeet/Desktop/GAME/shiki/packages/langs/scripts/langs.ts#220-279) to use the resolved languages list instead of `tm-grammars` directly, ensuring local grammars are included in the bundle.

## Verification
- Ran `pnpm build` in `packages/langs` to ensure the language package builds successfully.
- Verified that `dist/gn.mjs` is generated.
- Tested with a sample GN code snippet to confirm syntax highlighting works for keywords, strings, comments, and functions.

## Checklist
- [x] Added `gn` grammar
- [x] Updated build scripts
- [x] Verified build and highlighting

closes: #1194 