### PR TITLE
feat(transformers): add classActiveCode option to transformerNotationWordHighlight

### DIFF
--- a/packages/transformers/src/transformers/notation-highlight-word.ts
+++ b/packages/transformers/src/transformers/notation-highlight-word.ts
@@ -12,6 +12,10 @@ export interface TransformerNotationWordHighlightOptions extends MatchAlgorithmO
    * Class added to the root element when the code has highlighted words
    */
   classActivePre?: string
+  /**
+   * Class added to the <code> element when the code has highlighted words
+   */
+  classActiveCode?: string
 }
 
 export function transformerNotationWordHighlight(
@@ -20,6 +24,7 @@ export function transformerNotationWordHighlight(
   const {
     classActiveWord = 'highlighted-word',
     classActivePre = undefined,
+    classActiveCode = undefined,
   } = options
 
   return createCommentNotationTransformer(
@@ -36,6 +41,8 @@ export function transformerNotationWordHighlight(
 
       if (classActivePre)
         this.addClassToHast(this.pre, classActivePre)
+      if (classActiveCode)
+        this.addClassToHast(this.code, classActiveCode)
       return true
     },
     options.matchAlgorithm,

--- a/packages/transformers/test/class-active-code.test.ts
+++ b/packages/transformers/test/class-active-code.test.ts
@@ -5,6 +5,7 @@ import {
   transformerNotationErrorLevel,
   transformerNotationFocus,
   transformerNotationHighlight,
+  transformerNotationWordHighlight,
 } from '../src'
 
 describe('classActiveCode option', () => {
@@ -105,5 +106,55 @@ describe('classActiveCode option', () => {
     })
 
     expect(html).not.toContain('has-diff-code')
+  })
+
+  it('transformerNotationWordHighlight adds class to code element', async () => {
+    const code = `const hello = 'world' // [!code word:hello]`
+
+    const html = await codeToHtml(code, {
+      lang: 'js',
+      theme: 'github-dark',
+      transformers: [
+        transformerNotationWordHighlight({
+          classActiveCode: 'has-word-highlight-code',
+        }),
+      ],
+    })
+
+    expect(html).toContain('<code class="has-word-highlight-code">')
+  })
+
+  it('transformerNotationWordHighlight works with classActivePre and classActiveCode', async () => {
+    const code = `const hello = 'world' // [!code word:hello]`
+
+    const html = await codeToHtml(code, {
+      lang: 'js',
+      theme: 'github-dark',
+      transformers: [
+        transformerNotationWordHighlight({
+          classActivePre: 'has-word-highlight-pre',
+          classActiveCode: 'has-word-highlight-code',
+        }),
+      ],
+    })
+
+    expect(html).toContain('has-word-highlight-pre')
+    expect(html).toContain('<code class="has-word-highlight-code">')
+  })
+
+  it('transformerNotationWordHighlight does not add class when no notation is present', async () => {
+    const code = `const hello = 'world'`
+
+    const html = await codeToHtml(code, {
+      lang: 'js',
+      theme: 'github-dark',
+      transformers: [
+        transformerNotationWordHighlight({
+          classActiveCode: 'has-word-highlight-code',
+        }),
+      ],
+    })
+
+    expect(html).not.toContain('has-word-highlight-code')
   })
 })


### PR DESCRIPTION
## Add `classActiveCode` option to `transformerNotationWordHighlight`
closes #1203 

### Problem
The `transformerNotationWordHighlight` transformer was missing the `classActiveCode` option that was recently added to other notation transformers:

- `transformerNotationDiff`
- `transformerNotationFocus`
- `transformerNotationHighlight`
- `transformerNotationErrorLevel`

This caused inconsistency and limited styling options when word highlight notations were present in code blocks.

### Solution
Added support for a new option: `classActiveCode`.

This enables applying a custom class to the `<code>` element when word highlight notation is detected.

### Usage

```ts
import { codeToHtml } from 'shiki'
import { transformerNotationWordHighlight } from '@shikijs/transformers'

const html = await codeToHtml(code, {
  lang: 'js',
  theme: 'github-dark',
  transformers: [
    transformerNotationWordHighlight({
      classActivePre: 'has-word-highlight',
      classActiveCode: 'has-word-highlight-code', // NEW
    }),
  ],
})

```

Changes

Added classActiveCode option to TransformerNotationWordHighlightOptions interface

Implemented handling inside transformerNotationWordHighlight

Added 3 new tests for this functionality

Checklist

 Code follows existing patterns

 Tests added and passing (9 total tests for classActiveCode)

 All transformer tests pass (60 tests)