### PR TITLE
Preserve HAST element data and properties

### DIFF
--- a/packages/core/src/highlight/code-to-hast.ts
+++ b/packages/core/src/highlight/code-to-hast.ts
@@ -128,6 +128,7 @@ export function tokensToHast(
     tagName: 'pre',
     properties,
     children: [],
+    data: options.data as any,
   }
 
   let codeNode: Element = {

--- a/packages/core/test/hast.test.ts
+++ b/packages/core/test/hast.test.ts
@@ -166,4 +166,23 @@ describe('merge same style', () => {
 
     expect(html).toMatchInlineSnapshot(`"<pre class="shiki min-light" style="background-color:#ffffff;color:#24292eff" tabindex="0"><code><span class="line"><span style="color:#D32F2F" class="highlighted-word">name</span><span style="color:#D32F2F">:</span><span style="color:#22863A"> CI</span></span></code></pre>"`)
   })
+
+  it('supports data', async () => {
+    using shiki = await createHighlighter({
+      themes: ['vitesse-light'],
+      langs: ['javascript'],
+    })
+
+    const hast = shiki.codeToHast('console.log', {
+      lang: 'js',
+      theme: 'vitesse-light',
+      data: {
+        meta: 'foo="bar"',
+      },
+    })
+
+    expect((hast.children[0] as any).data).toEqual({
+      meta: 'foo="bar"',
+    })
+  })
 })

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -145,6 +145,11 @@ export interface CodeToHastOptionsCommon<Languages extends string = string>
   Pick<TokenizeWithThemeOptions, 'colorReplacements' | 'tokenizeMaxLineLength' | 'tokenizeTimeLimit' | 'grammarState' | 'grammarContextCode' | 'includeExplanation'> {
 
   /**
+   * Data to be added to the root `<pre>` element.
+   */
+  data?: Record<string, unknown>
+
+  /**
    * The grammar name for the code.
    */
   lang: StringLiteralUnion<Languages | SpecialLanguage>


### PR DESCRIPTION
# PR Description

## Title
feat(core): preserve HAST data and properties in codeToHast

## Description
This PR adds support for preserving HAST `data` and properties when using `codeToHast`.

Currently, when `codeToHast` generates the HAST tree, it creates a new `pre` element and does not allow passing custom `data` or properties to it (other than `meta` which is handled specifically). This change adds a `data` property to `CodeToHastOptions` which is then assigned to the `data` property of the root `pre` element in the generated HAST.

This is useful for integrations (like `rehype-shiki` or `remark-rehype`) that want to preserve metadata from the original code block (e.g. `fileName`, positional info) in the generated HAST, allowing other plugins to consume it.

## Changes
- `packages/types/src/options.ts`: Added `data` property to `CodeToHastOptionsCommon`.
- `packages/core/src/highlight/code-to-hast.ts`: Updated `tokensToHast` to assign `options.data` to `preNode.data`.

## Related Issue
Fixes #629  (Preserve HAST element data and properties)

## Checklist
- [x] Tests added/updated
- [x] Documentation updated (N/A - internal API change, but self-documenting in types)
- [x] Linting passed
