### PR TITLE
fix(monaco): register language aliases for Monaco editorfix(monaco): register language aliases for Monaco editor

### DIFF
--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -135,16 +135,16 @@ export function shikiToMonaco(
     if (!monacoLanguageIds.has(lang)) {
       // Resolve the alias to get the base language name
       const baseLang = highlighter.resolveLangAlias(lang)
-      
+
       // Register the alias as a Monaco language
       monaco.languages.register({ id: lang })
-      
+
       // If the base language is different and exists in Monaco, set it as an alias
       if (baseLang !== lang && monacoLanguageIds.has(baseLang)) {
         // Monaco doesn't have a direct alias API, but registering it as a separate language works
         // The tokenizer will be set for each alias individually
       }
-      
+
       monacoLanguageIds.add(lang)
     }
   }
@@ -153,7 +153,7 @@ export function shikiToMonaco(
   for (const lang of loadedLanguages) {
     // Resolve to the base language to get the correct grammar
     const baseLang = highlighter.resolveLangAlias(lang)
-    
+
     monaco.languages.setTokensProvider(lang, {
       getInitialState() {
         return new TokenizerState(INITIAL)

--- a/packages/monaco/test/repro.test.ts
+++ b/packages/monaco/test/repro.test.ts
@@ -35,6 +35,7 @@ describe('shikiToMonaco', () => {
         }
       },
       getLoadedLanguages: () => ['javascript'],
+      resolveLangAlias: (lang: string) => lang, // Return the same language (no aliases in this test)
       getLanguage: (_lang: string) => ({
         tokenizeLine2: (line: string, stack: any) => {
           return {
@@ -145,7 +146,7 @@ describe('shikiToMonaco', () => {
         const aliases = ['shellscript', 'bash', 'sh', 'zsh']
         return aliases.includes(lang) ? 'shell' : lang
       },
-      getLanguage: (lang: string) => ({
+      getLanguage: (_lang: string) => ({
         tokenizeLine2: (line: string, stack: any) => ({
           tokens: new Uint32Array([0, 0]),
           ruleStack: stack,


### PR DESCRIPTION
Fixes #1030

This PR fixes an issue where language aliases like `shellscript`, `bash`, `sh`, and `zsh` were not working when used with `monaco.editor.create()`.

The `shikiToMonaco` function now registers all loaded language aliases in Monaco's language registry before setting up tokenizers, ensuring that these aliases are recognized and highlighted correctly.Fixes #1030

Previously, shikiToMonaco only registered tokenizers for languages that existed in Monaco's language registry. This caused aliases like 'shellscript', 'bash', 'sh', 'zsh' to not work when specified in monaco.editor.create({ language: 'shellscript' }).

Changes:
- Register all language aliases in Monaco's language registry before setting up tokenizers
- Use highlighter.resolveLangAlias() to resolve aliases to base language when getting grammar
- Add test case to verify language aliases work correctly

This ensures that users can use any language alias supported by Shiki when creating Monaco editor instances.

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
