### PR TITLE
feat(cli): add --format option for html output

### DIFF
--- a/docs/packages/cli.md
+++ b/docs/packages/cli.md
@@ -68,6 +68,15 @@ Language is auto-inferred from the file extension. You can override it with `--l
 npx @shikijs/cli src/index.js --lang=ts
 ```
 
+### `--format`
+
+Specify the output format. Defaults to `ansi`.
+Supported values: `ansi`, `html`.
+
+```bash
+npx @shikijs/cli README.md --format=html
+```
+
 ## Node.js API
 
 The `@shikijs/cli` package also provides a Node.js API.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -46,6 +46,7 @@ export async function run(
   cli
     .option('--theme <theme>', 'Color theme to use', { default: 'vitesse-dark' })
     .option('--lang <lang>', 'Programming language')
+    .option('--format <format>', 'Output format (ansi, html)', { default: 'ansi' })
     .help()
     .version(version)
 
@@ -55,7 +56,16 @@ export async function run(
   const codes = await Promise.all(files.map(async (path) => {
     const { content, ext } = await readSource(path)
     const lang = options.lang || ext
-    return await codeToANSI(content, lang as BundledLanguage, options.theme)
+    if (options.format === 'html') {
+      const { codeToHtml } = await import('shiki')
+      return await codeToHtml(content, {
+        lang: lang as BundledLanguage,
+        theme: options.theme,
+      })
+    }
+    else {
+      return await codeToANSI(content, lang as BundledLanguage, options.theme)
+    }
   }))
 
   for (const code of codes)

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -127,4 +127,20 @@ describe('run', () => {
 
     vi.unstubAllGlobals()
   })
+
+  it('--format html option', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('console.log("hello")'),
+    }))
+
+    const output: string[] = []
+    await run(['node', 'shiki', '--format', 'html', 'https://example.com/code.js'], msg => output.push(msg))
+
+    expect(output.length).toBe(1)
+    expect(output[0]).toContain('<pre class="shiki')
+    expect(output[0]).toContain('console')
+
+    vi.unstubAllGlobals()
+  })
 })


### PR DESCRIPTION
### Description

This PR introduces a new `--format` option to the `@shikijs/cli`, enabling users to output syntax-highlighted code as **HTML**, in addition to the existing ANSI terminal output.

**Changes:**

- Added `--format <format>` flag (supports `ansi` | `html`, default: `ansi`).
- Integrated `codeToHtml` for HTML output generation.
- Added comprehensive test case for the new option.
- Updated CLI documentation.

**Why this is valuable:**

1.  **Scripting & Automation**: Users can now easily pipe highlighted HTML into files for static sites, documentation, or reports without writing custom Node.js scripts.
    - _Example:_ `npx shiki-cli file.js --format html > snippet.html`
2.  **Debugging**: Provides a quick way for maintainers and users to inspect the exact HTML output Shiki generates for a specific code/theme combination directly from the terminal.
3.  **Feature Parity**: Aligns Shiki CLI with other standard highlighting tools (like `pygments`) that support multiple output formats.

**Implementation Details:**

- The implementation leverages the existing `codeToHtml` function from the core package, ensuring consistent output with the main library.
- The default behavior remains unchanged (ANSI output), ensuring no breaking changes for existing workflows.

**Verification:**

- Added a new test in `packages/cli/test/cli.test.ts` to verify that `--format html` correctly produces an HTML string with the expected class names.
- Ran `pnpm test packages/cli` -> All tests passed.
- Ran `pnpm build` -> Build successful.
