### PR TITLE
perf(transformers): optimize transformerCompactLineOptions lookup to O(1)perf(transformers): optimize transformerCompactLineOptions lookup to …

### DIFF
--- a/packages/transformers/src/transformers/compact-line-options.ts
+++ b/packages/transformers/src/transformers/compact-line-options.ts
@@ -14,10 +14,16 @@ export interface TransformerCompactLineOption {
 export function transformerCompactLineOptions(
   lineOptions: TransformerCompactLineOption[] = [],
 ): ShikiTransformer {
+  // Pre-compute line options into a Map for O(1) lookup
+  const lineOptionsMap = new Map<number, TransformerCompactLineOption>()
+  for (const option of lineOptions) {
+    lineOptionsMap.set(option.line, option)
+  }
+
   return {
     name: '@shikijs/transformers:compact-line-options',
     line(node, line) {
-      const lineOption = lineOptions.find(o => o.line === line)
+      const lineOption = lineOptionsMap.get(line)
       if (lineOption?.classes)
         this.addClassToHast(node, lineOption.classes)
       return node


### PR DESCRIPTION
## Description
This PR optimizes the `transformerCompactLineOptions` transformer by replacing the O(M) `Array.find()` lookup with an O(1) `Map.get()` lookup.

## Changes
- Pre-compute line options into a `Map<number, TransformerCompactLineOption>` during transformer initialization
- Replace `lineOptions.find(o => o.line === line)` with `lineOptionsMap.get(line)` for O(1) lookup
- Reduces time complexity from O(N * M) to O(N + M) where N is lines of code and M is number of line options

## Performance Impact
For large files (500+ lines) with many line options (50+), this provides significant performance improvements while maintaining the same API and backward compatibility.

## Testing
- All existing tests pass (31/31)
- No API changes required
- Maintains backward compatibility

Fixes #1209…O(1)

Replace Array.find() with Map-based lookup for better performance. This reduces time complexity from O(N * M) to O(N + M) where:
- N is the number of lines in the code
- M is the number of line options

For large files (500+ lines) with many line options, this provides significant performance improvements while maintaining the same API.

Fixes #1209

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/shikijs/shiki/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
