### PR TITLE
fix(cli): handle top-level runtime errors gracefully

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -72,4 +72,7 @@ export async function run(
     log(code)
 }
 
-run()
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})


### PR DESCRIPTION
Description
Currently, if the CLI encounters an error during execution (for example, if a provided file path does not exist or a URL fetch fails), it terminates with an unhandled promise rejection. This results in a confusing stack trace and a poor user experience.

This PR improves the error handling by adding a top-level .catch() handler to the run() function in packages/cli/src/cli.ts. Now, if an error occurs:

The error message is logged cleanly to console.error.

The process exits with status code 1 to indicate failure.

Linked Issues
N/A

Additional context
Verification: I tested this locally by running the CLI against a non-existent file.

Before: The process would crash with an UnhandledPromiseRejectionWarning or a raw stack trace.

After: The CLI outputs a clean error message
