### PR TITLE
test(transformers): add reproduction case for issue #1074

### DIFF
--- a/packages/transformers/test/repro-1074.test.ts
+++ b/packages/transformers/test/repro-1074.test.ts
@@ -1,0 +1,20 @@
+import { codeToHtml } from 'shiki'
+import { expect, it } from 'vitest'
+import { transformerNotationDiff } from '../src'
+
+it('repro #1074: supports diff notation in string literals', async () => {
+  const code = `
+const a = "remove me // [!code --]"
+const b = "keep me"
+  `.trim()
+
+  const html = await codeToHtml(code, {
+    lang: 'js',
+    theme: 'nord',
+    transformers: [
+      transformerNotationDiff(),
+    ],
+  })
+
+  expect(html).toContain('diff remove')
+})


### PR DESCRIPTION
### Description

This PR adds a reproduction test case for a reported issue where transformer notations (like ⁠ // [!code --] ⁠) are not processed correctly when they appear inside string literals.

I have added a new test file ⁠ packages/transformers/test/repro-1074.test.ts ⁠ that attempts to highlight a diff notation within a string. This will help maintainers identify and fix the underlying parsing logic.

### Linked Issues

N/A

### Additional context

This is a test-only contribution to assist in debugging Issue #1074.
