### PR TITLE
fix(transformers): preserve empty lines with annotations

### DIFF
--- a/packages/transformers/src/shared/notation-transformer.ts
+++ b/packages/transformers/src/shared/notation-transformer.ts
@@ -76,7 +76,11 @@ export function createCommentNotationTransformer(
           comment.info[1] = ''
 
         if (isEmpty && comment.isLineCommentOnly) {
-          linesToRemove.push(comment.line)
+          const classNames = comment.line.properties.className
+          const hasOtherClasses = Array.isArray(classNames) && classNames.some(c => c !== 'line')
+
+          if (!hasOtherClasses)
+            linesToRemove.push(comment.line)
         }
         else if (isEmpty && comment.isJsxStyle) {
           comment.line.children.splice(comment.line.children.indexOf(comment.token) - 1, 3)

--- a/packages/transformers/test/fixtures/highlight/preserve-empty.js
+++ b/packages/transformers/test/fixtures/highlight/preserve-empty.js
@@ -1,0 +1,2 @@
+// [!code highlight:2]
+// [!code highlight]

--- a/packages/transformers/test/fixtures/highlight/preserve-empty.js.output.html
+++ b/packages/transformers/test/fixtures/highlight/preserve-empty.js.output.html
@@ -1,0 +1,7 @@
+<pre class="shiki github-dark has-highlighted" style="background-color:#24292e;color:#e1e4e8" tabindex="0"><code><span class="line highlighted"></span></code></pre>
+<style>
+body { margin: 0; }
+.shiki { padding: 1em; }
+.line { display: block; width: 100%; height: 1.2em; }
+.highlighted { background-color: #8885; }
+</style>


### PR DESCRIPTION
Fixes #589

### Description
Previously, the notation transformer would unconditionally remove lines that became empty after comment removal, even if those lines were targeted by annotations (e.g., `// [code app/Models/InstanceSettings.php
  highlight]`).

This PR modifies the removal logic to check if the line has any CSS classes other than the default `line`. If it does (meaning it was highlighted, focused, etc.), the line is preserved.

### Changes
- Modified `packages/transformers/src/shared/notation-transformer.ts` to check for additional classes before removing empty lines.
- Added a reproduction test case in `packages/transformers/test/fixtures/highlight/preserve-empty.js`.
- Updated snapshots.