### PR TITLE
feat(transformers): add newline rendering support to render-whitespace

### DIFF
--- a/packages/transformers/src/transformers/render-whitespace.ts
+++ b/packages/transformers/src/transformers/render-whitespace.ts
@@ -17,6 +17,13 @@ export interface TransformerRenderWhitespaceOptions {
   classSpace?: string
 
   /**
+   * Class for newline
+   *
+   * @default undefined
+   */
+  classNewline?: string
+
+  /**
    * Position of rendered whitespace
    * @default all position
    */
@@ -44,9 +51,20 @@ export function transformerRenderWhitespace(
     root(root) {
       const pre = root.children[0] as Element
       const code = pre.tagName === 'pre' ? pre.children[0] as Element : { children: [root] }
-      code.children.forEach((line) => {
+      code.children.forEach((line, idx) => {
         if (line.type !== 'element' && line.type !== 'root')
           return
+
+        const lastLine = idx === code.children.length - 1
+        if (options.classNewline && !lastLine) {
+          line.children.push({
+            type: 'element',
+            tagName: 'span',
+            properties: { class: options.classNewline },
+            children: [{ type: 'text', value: '\n' }],
+          })
+        }
+
         const elements = line.children.filter(token => token.type === 'element')
         const last = elements.length - 1
         line.children = line.children.flatMap((token) => {

--- a/packages/transformers/test/render-whitespace-newline.test.ts
+++ b/packages/transformers/test/render-whitespace-newline.test.ts
@@ -1,0 +1,67 @@
+import type { Element, Root } from 'hast'
+import { describe, expect, it } from 'vitest'
+import { transformerRenderWhitespace } from '../src/transformers/render-whitespace'
+
+describe('render-whitespace-newline unit', () => {
+  it('should inject newline spans', () => {
+    const transformer = transformerRenderWhitespace({
+      classNewline: 'newline',
+    })
+
+    // Mock HAST tree for:
+    // <pre><code>line1\nline2</code></pre>
+    // But shiki splits lines, so it looks more like:
+    // <pre><code>
+    //   <span class="line">line1</span>
+    //   <span class="line">line2</span>
+    // </code></pre>
+
+    const line1: Element = {
+      type: 'element',
+      tagName: 'span',
+      properties: { class: 'line' },
+      children: [{ type: 'text', value: 'line1' }],
+    }
+
+    const line2: Element = {
+      type: 'element',
+      tagName: 'span',
+      properties: { class: 'line' },
+      children: [{ type: 'text', value: 'line2' }],
+    }
+
+    const code: Element = {
+      type: 'element',
+      tagName: 'code',
+      properties: {},
+      children: [line1, line2],
+    }
+
+    const pre: Element = {
+      type: 'element',
+      tagName: 'pre',
+      properties: {},
+      children: [code],
+    }
+
+    const root: Root = {
+      type: 'root',
+      children: [pre],
+    }
+
+    // @ts-expect-error - mock context
+    transformer.root.call({ addClassToHast: () => {} }, root)
+
+    // Check line1 children
+    expect(line1.children).toHaveLength(2)
+    expect(line1.children[1]).toEqual({
+      type: 'element',
+      tagName: 'span',
+      properties: { class: 'newline' },
+      children: [{ type: 'text', value: '\n' }],
+    })
+
+    // Check line2 children (should NOT have newline as it is the last line)
+    expect(line2.children).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Description

This PR adds support for rendering newline characters in the transformer-render-whitespace package.

Previously, the transformer supported rendering spaces and tabs with custom classes, but newline characters remained invisible. This update introduces a new option, classNewline, in TransformerRenderWhitespaceOptions.
When this option is provided, the transformer now injects a <span> element—containing a newline character and styled with the specified class—at the end of each line (except the last one).

This enables users to visually represent line endings (for example, with CSS like ::before { content: '↵'; }), which is particularly valuable for rich-text editors, code viewers, or any interface where displaying all whitespace characters is important.

Changes

Updated packages/transformers/src/transformers/render-whitespace.ts:

Added the classNewline option to TransformerRenderWhitespaceOptions.

Implemented logic to generate and inject newline tokens in the resulting HAST tree.

Added unit test:

packages/transformers/test/render-whitespace-newline.test.ts verifies that newline spans are correctly rendered.

Verification

Created and ran a dedicated unit test to confirm that the newline <span> is properly inserted into the HAST output.

Test output:

RUN  v3.2.4 /packages/transformers
 Test Files  1 passed (1)
      Tests  1 passed (1)