### PR TITLE
feat(transformers): add 'leading' position to transformerRenderWhites…

### DIFF
--- a/docs/packages/transformers.md
+++ b/docs/packages/transformers.md
@@ -326,6 +326,10 @@ console.warn('Warning') // [!code warning]
 
 Render whitespaces (tabs and spaces) as individual spans, with classes `tab` and `space`.
 
+Options:
+
+- `position`: `'all' | 'boundary' | 'trailing' | 'leading'`. Default `'all'`.
+
 With some additional CSS rules, you can make it look like this:
 
 <div class="language-js vp-adaptive-theme"><button title="Copy Code" class="copy"></button><span class="lang">js</span><pre v-pre class="shiki shiki-themes vitesse-light vitesse-dark" style="--shiki-light:#393a34;--shiki-dark:#dbd7caee;--shiki-light-bg:#ffffff;--shiki-dark-bg:#121212;" tabindex="0"><code><span class="line"><span style="--shiki-light:#AB5959;--shiki-dark:#CB7676;">function</span><span class="space"> </span><span style="--shiki-light:#59873A;--shiki-dark:#80A665;">block</span><span style="--shiki-light:#999999;--shiki-dark:#666666;">(</span><span class="space"> </span><span style="--shiki-light:#999999;--shiki-dark:#666666;">)</span><span class="space"> </span><span style="--shiki-light:#999999;--shiki-dark:#666666;">{</span></span>

--- a/packages/transformers/src/shared/utils.ts
+++ b/packages/transformers/src/shared/utils.ts
@@ -37,14 +37,14 @@ export function separateContinuousSpaces(inputs: string[]): string[] {
 
 export function splitSpaces(
   parts: string[],
-  type: 'all' | 'boundary' | 'trailing',
+  type: 'all' | 'boundary' | 'trailing' | 'leading',
   renderContinuousSpaces = true,
 ): string[] {
   if (type === 'all')
     return parts
   let leftCount = 0
   let rightCount = 0
-  if (type === 'boundary') {
+  if (type === 'boundary' || type === 'leading') {
     for (let i = 0; i < parts.length; i++) {
       if (isSpace(parts[i]))
         leftCount++

--- a/packages/transformers/src/transformers/render-whitespace.ts
+++ b/packages/transformers/src/transformers/render-whitespace.ts
@@ -20,7 +20,7 @@ export interface TransformerRenderWhitespaceOptions {
    * Position of rendered whitespace
    * @default all position
    */
-  position?: 'all' | 'boundary' | 'trailing'
+  position?: 'all' | 'boundary' | 'trailing' | 'leading'
 }
 
 /**
@@ -57,6 +57,8 @@ export function transformerRenderWhitespace(
             return token
           if (position === 'trailing' && index !== last)
             return token
+          if (position === 'leading' && index !== 0)
+            return token
 
           const node = token.children[0]
           if (node.type !== 'text' || !node.value)
@@ -68,7 +70,7 @@ export function transformerRenderWhitespace(
             (position === 'boundary' && index === last && last !== 0)
               ? 'trailing'
               : position,
-            position !== 'trailing',
+            position !== 'trailing' && position !== 'leading',
           )
           if (parts.length <= 1)
             return token

--- a/packages/transformers/test/fixtures.test.ts
+++ b/packages/transformers/test/fixtures.test.ts
@@ -184,6 +184,16 @@ suite(
 )
 
 suite(
+  'whitespace:leading',
+  import.meta.glob('./fixtures/whitespace/*.*', { query: '?raw', import: 'default', eager: true }),
+  [
+    transformerRenderWhitespace({ position: 'leading' }),
+  ],
+  code => `${code}${CSS_RENDER_WHITESPACE}`,
+  '.leading',
+)
+
+suite(
   'all',
   import.meta.glob('./fixtures/all/*.*', { query: '?raw', import: 'default', eager: true }),
   [

--- a/packages/transformers/test/fixtures/whitespace/a.js.leading.output.html
+++ b/packages/transformers/test/fixtures/whitespace/a.js.leading.output.html
@@ -1,0 +1,13 @@
+<pre class="shiki github-dark" style="background-color:#24292e;color:#e1e4e8" tabindex="0"><code><span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> block</span><span style="color:#E1E4E8">( ) {</span></span>
+<span class="line"><span class="space"> </span><span class="space"> </span><span style="color:#B392F0">space</span><span style="color:#E1E4E8">( )</span></span>
+<span class="line"><span class="tab">	</span><span class="tab">	</span><span style="color:#B392F0">table</span><span style="color:#E1E4E8">( ) </span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span></code></pre>
+<style>
+* { tab-size: 4; }
+body { margin: 0; }
+.shiki { padding: 1em; }
+.tab, .space { position: relative; }
+.tab::before { content: "\21E5"; position: absolute; opacity: 0.3; }
+.space::before { content: "\B7"; position: absolute; opacity: 0.3; }
+</style>

--- a/packages/transformers/test/fixtures/whitespace/b.js.leading.output.html
+++ b/packages/transformers/test/fixtures/whitespace/b.js.leading.output.html
@@ -1,0 +1,14 @@
+<pre class="shiki github-dark" style="background-color:#24292e;color:#e1e4e8" tabindex="0"><code><span class="line"><span style="color:#F97583">function</span><span style="color:#B392F0"> hello</span><span style="color:#E1E4E8">(</span><span style="color:#FFAB70">indentSize</span><span style="color:#E1E4E8">, </span><span style="color:#FFAB70">type</span><span style="color:#E1E4E8">) {</span></span>
+<span class="line"><span class="space"> </span><span class="space"> </span><span style="color:#F97583">if</span><span style="color:#E1E4E8"> (indentSize </span><span style="color:#F97583">===</span><span style="color:#79B8FF"> 4</span><span style="color:#F97583"> &#x26;&#x26;</span><span style="color:#E1E4E8"> type </span><span style="color:#F97583">!==</span><span style="color:#9ECBFF"> 'tab'</span><span style="color:#E1E4E8">) { </span></span>
+<span class="line"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="tab">	</span><span style="color:#E1E4E8">console.</span><span style="color:#B392F0">log</span><span style="color:#E1E4E8">(</span><span style="color:#9ECBFF">'Each next indentation will increase on 4 spaces'</span><span style="color:#E1E4E8">);   </span></span>
+<span class="line"><span class="space"> </span><span class="space"> </span><span style="color:#E1E4E8">}</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span></code></pre>
+<style>
+* { tab-size: 4; }
+body { margin: 0; }
+.shiki { padding: 1em; }
+.tab, .space { position: relative; }
+.tab::before { content: "\21E5"; position: absolute; opacity: 0.3; }
+.space::before { content: "\B7"; position: absolute; opacity: 0.3; }
+</style>

--- a/packages/transformers/test/fixtures/whitespace/c.js.leading.output.html
+++ b/packages/transformers/test/fixtures/whitespace/c.js.leading.output.html
@@ -1,0 +1,14 @@
+<pre class="shiki github-dark" style="background-color:#24292e;color:#e1e4e8" tabindex="0"><code><span class="line"><span style="color:#79B8FF">module</span><span style="color:#E1E4E8">.</span><span style="color:#79B8FF">exports</span><span style="color:#F97583"> =</span><span style="color:#E1E4E8"> {</span></span>
+<span class="line"><span class="space"> </span><span class="space"> </span><span style="color:#E1E4E8">plugins:  [   </span><span style="color:#6A737D">// more than two spaces	and tab</span></span>
+<span class="line"><span class="space"> </span><span class="space"> </span><span class="space"> </span><span class="space"> </span><span style="color:#9ECBFF">'foo'</span></span>
+<span class="line"><span class="space"> </span><span class="space"> </span><span style="color:#E1E4E8">]</span></span>
+<span class="line"><span style="color:#E1E4E8">}</span></span>
+<span class="line"></span></code></pre>
+<style>
+* { tab-size: 4; }
+body { margin: 0; }
+.shiki { padding: 1em; }
+.tab, .space { position: relative; }
+.tab::before { content: "\21E5"; position: absolute; opacity: 0.3; }
+.space::before { content: "\B7"; position: absolute; opacity: 0.3; }
+</style>


### PR DESCRIPTION
- [x] -
### Description

This PR adds a new `position: 'leading'` option to the `transformerRenderWhitespace` transformer.

**What:**
It extends the existing `position` options (`'all' | 'boundary' | 'trailing'`) to include `'leading'`. When selected, the transformer will only convert leading whitespace (indentation) into distinct span elements (`.space` or `.tab`).

**Why:**
This is useful for scenarios where users want to style indentation separately—for example, to implement "**indentation guides**" or verify indentation depth visually—without implementing a custom transformer or affecting the rendering of spaces between words in the rest of the code.

**Changes:**
- Updated `splitSpaces` utility in `packages/transformers/src/shared/utils.ts` to support the `leading` mode.
- Updated `transformerRenderWhitespace` to handle the new option.
- Added a new test suite `whitespace:leading` in `packages/transformers/test/fixtures.test.ts` (reusing existing fixtures) and generated corresponding snapshots.
- Updated documentation in `docs/packages/transformers.md`.

### Additional context

Existing test fixtures (`a.js`, `b.js`, `c.js`) were used to verify the new mode, ensuring consistency with how other whitespace modes (`all`, `boundary`, `trailing`) are tested.
