### PR TITLE
feat(cli): add stdin support and list commands

### DIFF
--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -143,4 +143,22 @@ describe('run', () => {
 
     vi.unstubAllGlobals()
   })
+
+  it('--list-themes', async () => {
+    const output: string[] = []
+    await run(['node', 'shiki', '--list-themes'], msg => output.push(msg))
+
+    expect(output.length).toBeGreaterThan(0)
+    expect(output).toContain('vitesse-dark')
+    expect(output).toContain('nord')
+  })
+
+  it('--list-langs', async () => {
+    const output: string[] = []
+    await run(['node', 'shiki', '--list-langs'], msg => output.push(msg))
+
+    expect(output.length).toBeGreaterThan(0)
+    expect(output).toContain('javascript')
+    expect(output).toContain('python')
+  })
 })


### PR DESCRIPTION
- [x] -
### Description

This PR enhances the Shiki CLI with better usability features.

**Features:**
- **Stdin Support**: Now reads from stdin if no file arguments are provided (e.g., `echo "console.log(1)" | shiki -l js`).
- **List Commands**: Added `--list-themes` and `--list-langs` to list available bundled themes and languages.

**Changes:**
- Updated [packages/cli/src/cli.ts](cci:7://file:///Users/divyapahuja/Desktop/shiki/packages/cli/src/cli.ts:0:0-0:0).
- Added tests in [packages/cli/test/cli.test.ts](cci:7://file:///Users/divyapahuja/Desktop/shiki/packages/cli/test/cli.test.ts:0:0-0:0).

**Example:**
```bash
shiki --list-themes
shiki --list-langs
cat src/index.ts | shiki --lang ts