### PR TITLE
fix(cli): fall back to 'text' when file/URL has no extension and no -…

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -102,7 +102,7 @@ export async function run(
 
   const codes = await Promise.all(files.map(async (path) => {
     const { content, ext } = await readSource(path)
-    const lang = (options.lang || ext).toLowerCase()
+    const lang = (options.lang || ext || 'text').toLowerCase()
     if (options.format === 'html') {
       const { codeToHtml } = await import('shiki')
       return await codeToHtml(content, {


### PR DESCRIPTION
…-lang

When processing local files or remote URLs, the language was resolved as:

  const lang = (options.lang || ext).toLowerCase()

If both `options.lang` and `ext` are empty (e.g. `Makefile`, `Dockerfile`, or a URL like https://host/Dockerfile), `lang` becomes an empty string `''` which is passed directly to shiki and causes an error.

The stdin code path already handles this correctly:

  const lang = options.lang || 'text'

This commit aligns the file/URL path with the same fallback:

  const lang = (options.lang || ext || 'text').toLowerCase()

Two regression tests are added covering:
- A local file with no extension (Makefile)
- A remote URL whose path has no file extension (Dockerfile)

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**.
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community.
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [ ] <- Keep this line and put an `x` between the brackts.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->

### Linked Issues

fixes #<number>

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
