### PR TITLE
feat(rehype): add `onFallback` callback option

### DIFF
--- a/packages/rehype/src/core.ts
+++ b/packages/rehype/src/core.ts
@@ -25,6 +25,7 @@ function rehypeShikiFromHighlighter(
     defaultLanguage,
     fallbackLanguage,
     onError,
+    onFallback,
     stripEndNewline = true,
     inline = false,
     lazy = false,
@@ -123,6 +124,7 @@ function rehypeShikiFromHighlighter(
         lang = parsed.lang
       }
       else if (fallbackLanguage) {
+        onFallback?.({ requestedLanguage: parsed.lang, fallbackLanguage })
         lang = fallbackLanguage
       }
 
@@ -154,6 +156,7 @@ function rehypeShikiFromHighlighter(
               .then(() => processNode(lang))
               .catch((error) => {
                 if (fallbackLanguage) {
+                  onFallback?.({ requestedLanguage: lang, fallbackLanguage })
                   processNode(fallbackLanguage)
                 }
                 else if (onError) {
@@ -166,11 +169,16 @@ function rehypeShikiFromHighlighter(
           )
         }
         catch (error) {
-          if (fallbackLanguage)
+          if (fallbackLanguage) {
+            onFallback?.({ requestedLanguage: lang, fallbackLanguage })
             return processNode(fallbackLanguage)
-          else if (onError)
+          }
+          else if (onError) {
             onError(error)
-          else throw error
+          }
+          else {
+            throw error
+          }
         }
       }
       else {

--- a/packages/rehype/src/types.ts
+++ b/packages/rehype/src/types.ts
@@ -81,6 +81,14 @@ export interface RehypeShikiExtraOptions {
    * If not provided, the error will be thrown
    */
   onError?: (error: unknown) => void
+
+  /**
+   * Called when falling back to `fallbackLanguage`
+   */
+  onFallback?: (context: {
+    requestedLanguage: string
+    fallbackLanguage: string
+  }) => void
 }
 
 export type RehypeShikiCoreOptions


### PR DESCRIPTION
- [x]  <- Keep this line and put an `x` between the brackts.

### Description

When using `fallbackLanguage` there's no way to know when a fallback actually happens, making it hard to detect typos in language identifiers or missing grammars.

Adds an `onFallback` callback to rehype options:

```ts
onFallback?: (context: { requestedLanguage: string; fallbackLanguage: string }) => void
```
So it can be used liked this:

```ts
rehypeShikiFromHighlighter(highlighter, {
  fallbackLanguage: "text",
  onFallback({ requestedLanguage, fallbackLanguage }) {
    console.warn(`Language "${requestedLanguage}" not found. Falling back to "${fallbackLanguage}"`);
  },
});
```



