### PR TITLE
Add `pwsh` as alias for PowerShell

### DIFF
--- a/packages/shiki/src/langs-bundle-full.ts
+++ b/packages/shiki/src/langs-bundle-full.ts
@@ -916,7 +916,8 @@ export const bundledLanguagesInfo: BundledLanguageInfo[] = [
     'name': 'PowerShell',
     'aliases': [
       'ps',
-      'ps1'
+      'ps1',
+      'pwsh'
     ],
     'import': (() => import('@shikijs/langs/powershell')) as DynamicImportLanguageRegistration
   },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**.
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community.
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

Add `pwsh` as alias for `powershell`.

### Linked Issues

* <https://github.com/mProjectsCode/obsidian-shiki-plugin/issues/68>

### Additional context

`pwsh` is the name of the executable ever since Dotnet Core (cross platform) was created, and PowerShell Core (cross platform) was made on top of it. Before that we had Windows PowerShell, with executable name `powershell`.

* Old Windows PowerShell: `powershell`
* New PowerShell: `pwsh`

Other code highlighters supports `pwsh` as alias for `powershell`.

* Chroma: <https://github.com/alecthomas/chroma/blob/10daf0405b1352a692381221d9634d716e65a0cc/lexers/embedded/powershell.xml#L9>
* GitHub linguist: <https://github.com/github-linguist/linguist/blob/738a27e1e2f26f061a24e94f85cd37ae9be71105/lib/linguist/languages.yml#L5923-L5939>
* Highlight.js: <https://github.com/highlightjs/highlight.js/blob/main/src%2Flanguages%2Fpowershell.js>
* Pygments: <https://github.com/pygments/pygments/blob/28ec10c5e154ee27201997feb573a0b065f74082/pygments/lexers/shell.py#L645>
* Rouge: <https://github.com/rouge-ruby/rouge/blob/1e3f8f9cabec5f7d5a8a02a75a92b37d007b03c7/lib/rouge/lexers/powershell.rb#L11>