### PR TITLE
fix(themes): horizon-bright categorized as a dark theme

### DIFF
--- a/packages/shiki/src/themes.ts
+++ b/packages/shiki/src/themes.ts
@@ -173,7 +173,7 @@ export const bundledThemesInfo: BundledThemeInfo[] = [
   {
     "id": "horizon-bright",
     "displayName": "Horizon Bright",
-    "type": "dark",
+    "type": "light",
     "import": (() => import('@shikijs/themes/horizon-bright')) as unknown as DynamicImportThemeRegistration
   },
   {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**.
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community.
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->
I noticed in your last theme update commit (https://github.com/shikijs/shiki/commit/9b4cacac) for 3.23 that Horizon Bright was added as a dark theme. From its name it looked weird to me, so I checked on shiki.style and it indeed is a light theme, mistakenly categorized as a dark theme. This PR fixes this small typo!

### Linked Issues

~~fixes #<number>~~ none

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
It seems like this global update your performed is automated in some way, so there might be an upstream fix to propagate, I don't know
