### PR TITLE
chore: Format reproduction input as textarea

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,7 +27,7 @@ body:
       placeholder: Bug description
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: reproduction
     attributes:
       label: Reproduction


### PR DESCRIPTION

- [x] <- Keep this line and put an `x` between the brackts.

### Description

The input type previously used only allowed a single line, which is generally insufficient, as any standalone reproduction needs to at least import Shiki and call some function.

If users are intended to provide a link to a reproduction, the template should say that.

### Linked Issues

Discovered when submitting #1254.

### Additional context

\-