### PR TITLE
fix: support ANSI language with multiple themes

### DIFF
--- a/packages/core/src/highlight/code-to-tokens.ts
+++ b/packages/core/src/highlight/code-to-tokens.ts
@@ -42,6 +42,7 @@ export function codeToTokens(
       primitive,
       code,
       options,
+      codeToTokensBase,
     )
 
     grammarState = getLastGrammarStateFromMap(themeTokens)

--- a/packages/primitive/src/highlight/code-to-tokens-themes.ts
+++ b/packages/primitive/src/highlight/code-to-tokens-themes.ts
@@ -14,6 +14,7 @@ export function codeToTokensWithThemes(
   primitive: ShikiPrimitive,
   code: string,
   options: CodeToTokensWithThemesOptions,
+  codeToTokensBaseFn: typeof codeToTokensBase = codeToTokensBase,
 ): ThemedTokenWithVariants[][] {
   const themes = Object
     .entries(options.themes)
@@ -21,7 +22,7 @@ export function codeToTokensWithThemes(
     .map(i => ({ color: i[0], theme: i[1]! }))
 
   const themedTokens = themes.map((t) => {
-    const tokens = codeToTokensBase(primitive, code, {
+    const tokens = codeToTokensBaseFn(primitive, code, {
       ...options,
       theme: t.theme,
     })

--- a/packages/shiki/test/ansi.test.ts
+++ b/packages/shiki/test/ansi.test.ts
@@ -44,3 +44,13 @@ Done in 15.7s`, { theme: 'dark-plus', lang: 'ansi' })
 
   await expect(out).toMatchFileSnapshot('./out/ansi-dark-plus.html')
 })
+
+// https://github.com/shikijs/shiki/issues/1257
+it('renders ansi with multiple themes', async () => {
+  const out = await codeToHtml('\x1B[32mhello\x1B[0m', {
+    lang: 'ansi',
+    themes: { light: 'github-light', dark: 'github-dark' },
+  })
+
+  await expect(out).toMatchFileSnapshot('./out/ansi-multi-themes.html')
+})

--- a/packages/shiki/test/out/ansi-multi-themes.html
+++ b/packages/shiki/test/out/ansi-multi-themes.html
@@ -1,0 +1,1 @@
+<pre class="shiki shiki-themes github-light github-dark" style="background-color:#fff;--shiki-dark-bg:#24292e;color:#24292e;--shiki-dark:#e1e4e8" tabindex="0"><code><span class="line"><span style="color:#28a745;--shiki-dark:#34d058">hello</span></span></code></pre>


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackts.

### Description

Fixes `ansi` language throwing "Language `ansi` not found" when using multiple `themes`.

Let me know if this is the right fix/direction.

### Linked Issues

fixes #1257