### PR TITLE
fix(vitepress-twoslash): scroll blocking on mobile viewports

### DIFF
--- a/packages/vitepress-twoslash/src/client.ts
+++ b/packages/vitepress-twoslash/src/client.ts
@@ -64,6 +64,7 @@ const TwoslashFloatingVue = {
     }
 
     app.use(FloatingVue, {
+      strategy: 'fixed',
       ...options,
       themes: {
         ...options.themes,

--- a/packages/vitepress-twoslash/src/style.css
+++ b/packages/vitepress-twoslash/src/style.css
@@ -16,10 +16,6 @@
   z-index: calc(var(--vp-z-index-local-nav) - 1);
 }
 
-.v-popper--theme-twoslash.v-popper__popper {
-  content-visibility: auto;
-}
-
 .v-popper--theme-twoslash .v-popper__inner {
   background: var(--twoslash-popup-bg);
   color: var(--twoslash-popup-color);


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**.
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community.
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

Revert PR #1235

In the latest `vitepress` with `twoslash` web, the arrow is hidden due to `content-visibility: auto`, which creates `paint containment` that behaves like `overflow: hidden`. The scroll problem also exsit.

So i use `position: fixed` to ensure popper relative to viewport, don't affect scrollarea.

<img width="833" height="248" alt="image" src="https://github.com/user-attachments/assets/9cccfec5-e76f-4c28-92ec-0ff3ba02e8cb" />

Reproduce:
- https://stackblitz.com/edit/vitejs-vite-64zpcwhr?file=docs%2F.vitepress%2Ftheme%2Findex.ts
  1. Open new tab and devtool in mobile mode, u can see the arrow missing and scroll problem is exsit.
  2. Uncomment `docs/.vitepress/theme/index.ts:11`, the scroll problem is solved.
- I also clone https://github.com/dahlia/optique.git, set `strategy: 'fixed'`, it seems to work.
  
Refers:
- https://stackoverflow.com/a/75769415
- https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Containment/Using#basic_example

### Linked Issues

PR #1235

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I also tried modify the dist code of `floating-vue` to add throttle to scroll event, it's also works. but the repo is seem not maintain.
