### PR TITLE
fix(transformers): handle YAML comment prefixes correctly for v3

### DIFF
--- a/packages/transformers/src/shared/notation-transformer.ts
+++ b/packages/transformers/src/shared/notation-transformer.ts
@@ -1,7 +1,7 @@
 import type { ShikiTransformer, ShikiTransformerContext } from '@shikijs/core'
 import type { Element, Text } from 'hast'
 import type { ParsedComments } from './parse-comments'
-import { parseComments, v1ClearEndCommentPrefix } from './parse-comments'
+import { parseComments, v1ClearEndCommentPrefix, v3ClearEndCommentPrefix } from './parse-comments'
 
 export type MatchAlgorithm = 'v1' | 'v3'
 
@@ -67,6 +67,8 @@ export function createCommentNotationTransformer(
 
         if (matchAlgorithm === 'v1')
           comment.info[1] = v1ClearEndCommentPrefix(comment.info[1])
+        else if (matchAlgorithm === 'v3')
+          comment.info[1] = v3ClearEndCommentPrefix(comment.info[1])
 
         const isEmpty = comment.info[1].trim().length === 0
         // ignore comment node

--- a/packages/transformers/test/fixtures/diff/1007.yaml
+++ b/packages/transformers/test/fixtures/diff/1007.yaml
@@ -1,0 +1,6 @@
+# this leaves dangling `#`
+# In the original issue, `[!code focus]` was an array element!
+foo
+# bar
+# [!code ++]
+[!code focus]

--- a/packages/transformers/test/fixtures/diff/1007.yaml.output.html
+++ b/packages/transformers/test/fixtures/diff/1007.yaml.output.html
@@ -1,0 +1,12 @@
+<pre class="shiki github-dark has-diff" style="background-color:#24292e;color:#e1e4e8" tabindex="0"><code><span class="line"><span style="color:#6A737D"># this leaves dangling `#`</span></span><span class="line"><span style="color:#6A737D"># In the original issue, `[!code focus]` was an array element!</span></span><span class="line"><span style="color:#9ECBFF">foo</span></span><span class="line"><span style="color:#6A737D"># bar</span></span><span class="line diff add"><span style="color:#E1E4E8">[</span><span style="color:#F97583">!code</span><span style="color:#9ECBFF"> focus</span><span style="color:#E1E4E8">]</span></span><span class="line"></span></code></pre>
+<style>
+body { margin: 0; }
+.shiki { padding: 1.5em; }
+.line { display: block; width: 100%; height: 1.2em; }
+.diff { margin: 0 -24px; padding: 0 24px; }
+.diff.add { background-color: #0505; }
+.diff.remove { background-color: #8005; }
+.diff:before { position: absolute; left: 5px; }
+.diff.add:before { content: "+"; color: green;}
+.diff.remove:before { content: "-"; color: red; }
+</style>


### PR DESCRIPTION
**Problem**
In the `v3` match algorithm for `@shikijs/transformers`, using transformer notations such as `[!code ++]` within YAML files left behind a dangling comment character `# `. This happened because the core parser appropriately matched the line, but neglected to clear the comment prefix explicitly as it did for `v1`.

**Solution**
Introduced `v3ClearEndCommentPrefix(comment.info[1])` to `notation-transformer.ts` to seamlessly erase the matching prefix once the `v3` algorithm matches a code notation like `[!code focus]` or `[!code ++]`. This allows Shiki to then properly identify the resulting empty string and remove the entire dangling line comment.

**Testing**
Created a new diff test fixture `1007.yaml` inside `packages/transformers/test/fixtures/diff/` mapping to the user's report, and confirmed that snapshots update correctly to strip out `# ` without regressions across other files.

**Linked Issue**
Fixes: #1007
