### PR TITLE
chore: Fix typo explanation for removed CSS class

### DIFF
--- a/docs/blog/v4.md
+++ b/docs/blog/v4.md
@@ -49,4 +49,4 @@ app.use(TwoslashFloatingVue, {
 
 #### CSS Class `twoslash-query-presisted` Removed
 
-The misspelled CSS class `twoslash-query-presisted` (note the typo — missing the second `s`) has been removed. Use the correct `twoslash-query-persisted` instead.
+The misspelled CSS class `twoslash-query-presisted` (a typo, with "**pre**sisted" instead of "**per**sisted") has been removed. Use the correct `twoslash-query-persisted` instead.


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackts.

### Description

Clarified the typo in the CSS class name explanation.

### Linked Issues

N/A

### Additional context

