### PR TITLE
feat(docs): add 'export as image' button to playground

### DIFF
--- a/docs/.vitepress/components/ShikiMiniPlayground.vue
+++ b/docs/.vitepress/components/ShikiMiniPlayground.vue
@@ -9,6 +9,7 @@ const currentTheme = computed(() => play.allThemes.find(i => i.name === play.the
 
 const textAreaRef = ref<HTMLDivElement>()
 const highlightContainerRef = ref<HTMLSpanElement>()
+const isExporting = ref(false)
 
 function syncScroll() {
   if (!highlightContainerRef.value || !textAreaRef.value)
@@ -24,6 +25,100 @@ function onInput() {
   nextTick().then(() => {
     syncScroll()
   })
+}
+
+async function exportAsImage() {
+  if (!highlightContainerRef.value || isExporting.value)
+    return
+
+  isExporting.value = true
+
+  try {
+    const preEl = highlightContainerRef.value.querySelector('pre.shiki') as HTMLPreElement
+    if (!preEl)
+      return
+
+    const padding = 32
+    const rect = preEl.getBoundingClientRect()
+    const width = Math.ceil(rect.width) + padding * 2
+    const height = Math.ceil(rect.height) + padding * 2
+
+    // Collect all computed styles from the page so the SVG foreignObject renders correctly
+    const styleSheets: string[] = []
+    for (const sheet of Array.from(document.styleSheets)) {
+      try {
+        const rules = Array.from(sheet.cssRules || [])
+        styleSheets.push(rules.map(r => r.cssText).join('\n'))
+      }
+      catch {
+        // Cross-origin stylesheet — skip
+      }
+    }
+
+    // Clone the node so we can apply overrides without affecting the live DOM
+    const clone = preEl.cloneNode(true) as HTMLPreElement
+    clone.style.margin = '0'
+    clone.style.borderRadius = '0'
+    clone.style.boxShadow = 'none'
+    clone.style.overflow = 'visible'
+    clone.style.width = `${rect.width}px`
+    clone.style.padding = `${padding}px`
+
+    const outerDiv = document.createElement('div')
+    outerDiv.style.cssText = `
+      width: ${width}px;
+      height: ${height}px;
+      display: flex;
+      align-items: flex-start;
+      justify-content: flex-start;
+    `
+    outerDiv.appendChild(clone)
+
+    const svgContent = `
+      <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+        <style>${styleSheets.join('\n')}</style>
+        <foreignObject x="0" y="0" width="${width}" height="${height}">
+          <html xmlns="http://www.w3.org/1999/xhtml">
+            <head><style>* { box-sizing: border-box; }</style></head>
+            <body style="margin:0;padding:0;">${outerDiv.outerHTML}</body>
+          </html>
+        </foreignObject>
+      </svg>
+    `
+
+    const blob = new Blob([svgContent], { type: 'image/svg+xml;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+
+    const img = new Image()
+    img.width = width
+    img.height = height
+
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve()
+      img.onerror = reject
+      img.src = url
+    })
+
+    const canvas = document.createElement('canvas')
+    const dpr = window.devicePixelRatio || 1
+    canvas.width = width * dpr
+    canvas.height = height * dpr
+
+    const ctx = canvas.getContext('2d')!
+    ctx.scale(dpr, dpr)
+    ctx.drawImage(img, 0, 0)
+
+    URL.revokeObjectURL(url)
+
+    const pngUrl = canvas.toDataURL('image/png')
+    const a = document.createElement('a')
+    a.href = pngUrl
+    a.download = `shiki-${play.lang}-${play.theme}.png`
+    a.click()
+  }
+  finally {
+    isExporting.value = false
+  }
 }
 </script>
 
@@ -70,6 +165,9 @@ function onInput() {
       </a>
       <button title="Randomize" hover="bg-gray/10" p1 rounded @click="play.randomize">
         <div i-carbon:shuffle op50 />
+      </button>
+      <button title="Export as image" hover="bg-gray/10" p1 rounded :disabled="isExporting" @click="exportAsImage">
+        <div :class="isExporting ? 'i-svg-spinners-3-dots-fade' : 'i-carbon:camera'" op50 />
       </button>
     </div>
     <div relative min-h-100 float-left min-w-full>


### PR DESCRIPTION
 Description

Adds an "Export as image" button to the mini playground header (next to the Randomize button).
Clicking it captures the highlighted <pre class="shiki">`block and downloads it as a PNG file.

The implementation uses only native browser APIs (no new npm dependencies):
- Clones the rendered <pre.shiki>element and inlines page CSS rules
- Wraps it in an SVG <foreignObject> for accurate rendering
- Draws the SVG onto a Canvas at device pixel ratio for crisp/retina output
- Triggers a shiki-{lang}-{theme}.png download via an anchor tag

Linked Issues

fixes #1281


