### PR TITLE
chore: normalize package bugs metadata

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/cli"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "shiki",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/codegen"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "codegen"

--- a/packages/colorized-brackets/package.json
+++ b/packages/colorized-brackets/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/colorized-brackets"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "@shikijs/colorized-brackets"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/core"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki"
   ],

--- a/packages/engine-javascript/package.json
+++ b/packages/engine-javascript/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/engine-javascript"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "shiki-engine"

--- a/packages/engine-oniguruma/package.json
+++ b/packages/engine-oniguruma/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/engine-oniguruma"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "shiki-engine",

--- a/packages/langs-precompiled/package.json
+++ b/packages/langs-precompiled/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/langs"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "textmate-grammars"

--- a/packages/langs/package.json
+++ b/packages/langs/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/langs"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "textmate-grammars"

--- a/packages/magic-move/package.json
+++ b/packages/magic-move/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/magic-move"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "@shikijs/magic-move",

--- a/packages/markdown-exit/package.json
+++ b/packages/markdown-exit/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/markdown-exit"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "markdown-exit"

--- a/packages/markdown-it/package.json
+++ b/packages/markdown-it/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/markdown-it"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "markdown-it"

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/monaco"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "monaco-editor"

--- a/packages/primitive/package.json
+++ b/packages/primitive/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/primitive"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki"
   ],

--- a/packages/rehype/package.json
+++ b/packages/rehype/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/rehype"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "rehype"

--- a/packages/shiki/package.json
+++ b/packages/shiki/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/shiki"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki"
   ],

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/stream"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "@shikijs/stream",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/themes"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "textmate-themes"

--- a/packages/transformers/package.json
+++ b/packages/transformers/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/transformers"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "@shikijs/transformers"

--- a/packages/twoslash/package.json
+++ b/packages/twoslash/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/twoslash"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "twoslash"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/types"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki"
   ],

--- a/packages/vitepress-twoslash/package.json
+++ b/packages/vitepress-twoslash/package.json
@@ -11,7 +11,9 @@
     "url": "git+https://github.com/shikijs/shiki.git",
     "directory": "packages/vitepress-twoslash"
   },
-  "bugs": "https://github.com/shikijs/shiki/issues",
+  "bugs": {
+    "url": "https://github.com/shikijs/shiki/issues"
+  },
   "keywords": [
     "shiki",
     "twoslash",


### PR DESCRIPTION
## Summary

- Normalize published package `bugs` metadata from a string to the standard object shape with `bugs.url` across Shiki packages.
- Keep the same issue tracker URL, package versions, runtime code, dependencies, exports, and repository metadata unchanged.

## Validation

- Parsed every changed `packages/*/package.json` as JSON.
- Verified each changed manifest now has `bugs.url === "https://github.com/shikijs/shiki/issues"`.

This is metadata-only; no payment details or private data are included.