### PR TITLE
feat: add `type` field for `ThemedToken`

### DIFF
--- a/packages/core/test/__snapshots__/tokens.test.ts.snap
+++ b/packages/core/test/__snapshots__/tokens.test.ts.snap
@@ -773,6 +773,69 @@ exports[`includeExplanation > scopeName 1`] = `
 ]
 `;
 
+exports[`includeExplanation > tokenType 1`] = `
+[
+  [
+    {
+      "color": "#BD976A",
+      "content": "console",
+      "fontStyle": 0,
+      "offset": 0,
+      "type": 0,
+    },
+    {
+      "color": "#666666",
+      "content": ".",
+      "fontStyle": 0,
+      "offset": 7,
+      "type": 0,
+    },
+    {
+      "color": "#80A665",
+      "content": "log",
+      "fontStyle": 0,
+      "offset": 8,
+      "type": 0,
+    },
+    {
+      "color": "#666666",
+      "content": "(",
+      "fontStyle": 0,
+      "offset": 11,
+      "type": 0,
+    },
+    {
+      "color": "#C98A7D77",
+      "content": """,
+      "fontStyle": 0,
+      "offset": 12,
+      "type": 2,
+    },
+    {
+      "color": "#C98A7D",
+      "content": "hello",
+      "fontStyle": 0,
+      "offset": 13,
+      "type": 2,
+    },
+    {
+      "color": "#C98A7D77",
+      "content": """,
+      "fontStyle": 0,
+      "offset": 18,
+      "type": 2,
+    },
+    {
+      "color": "#666666",
+      "content": ")",
+      "fontStyle": 0,
+      "offset": 19,
+      "type": 0,
+    },
+  ],
+]
+`;
+
 exports[`includeExplanation > true 1`] = `
 [
   [

--- a/packages/core/test/tokens.test.ts
+++ b/packages/core/test/tokens.test.ts
@@ -17,10 +17,12 @@ it('includeExplanation', async () => {
   const caseFalse = await codeToTokensBase(engine, code, { lang: 'js', theme: 'vitesse-dark', includeExplanation: false })
   const caseTrue = await codeToTokensBase(engine, code, { lang: 'js', theme: 'vitesse-dark', includeExplanation: true })
   const caseScopeName = await codeToTokensBase(engine, code, { lang: 'js', theme: 'vitesse-dark', includeExplanation: 'scopeName' })
+  const caseTokenType = await codeToTokensBase(engine, code, { lang: 'js', theme: 'vitesse-dark', includeExplanation: 'tokenType' })
 
   expect(caseFalse).toMatchSnapshot('false')
   expect(caseTrue).toMatchSnapshot('true')
   expect(caseScopeName).toMatchSnapshot('scopeName')
+  expect(caseTokenType).toMatchSnapshot('tokenType')
 })
 
 describe('defaultColor light-dark()', () => {

--- a/packages/primitive/src/highlight/code-to-tokens-base.ts
+++ b/packages/primitive/src/highlight/code-to-tokens-base.ts
@@ -39,7 +39,7 @@ export function codeToTokensBase(
   const lang = primitive.resolveLangAlias(options.lang || 'text')
 
   if (isPlainLang(lang) || isNoneTheme(themeName))
-    return splitLines(code).map(line => [{ type: 0, content: line[0], offset: line[1] }])
+    return splitLines(code).map(line => [{ content: line[0], offset: line[1] }])
 
   const { theme, colorMap } = primitive.setTheme(themeName)
 
@@ -134,6 +134,7 @@ function _tokenizeWithTheme(
   const {
     tokenizeMaxLineLength = 0,
     tokenizeTimeLimit = 500,
+    includeExplanation = false,
   } = options
 
   const lines = splitLines(code)
@@ -169,7 +170,6 @@ function _tokenizeWithTheme(
     if (tokenizeMaxLineLength > 0 && line.length >= tokenizeMaxLineLength) {
       actual = []
       final.push([{
-        type: 0,
         content: line,
         offset: lineOffset,
         color: '',
@@ -182,7 +182,7 @@ function _tokenizeWithTheme(
     let tokensWithScopes
     let tokensWithScopesIndex
 
-    if (options.includeExplanation) {
+    if (includeExplanation && includeExplanation !== 'tokenType') {
       resultWithScopes = grammar.tokenizeLine(line, stateStack, tokenizeTimeLimit)
       tokensWithScopes = resultWithScopes.tokens
       tokensWithScopesIndex = 0
@@ -203,20 +203,21 @@ function _tokenizeWithTheme(
         colorReplacements,
       )
       const fontStyle: FontStyle = EncodedTokenMetadata.getFontStyle(metadata)
-      const type: number = EncodedTokenMetadata.getTokenType(metadata)
 
       const token: ThemedToken = {
-        type,
         content: line.substring(startIndex, nextStartIndex),
         offset: lineOffset + startIndex,
         color,
         fontStyle,
       }
 
-      if (options.includeExplanation) {
+      if (includeExplanation === 'tokenType') {
+        token.type = EncodedTokenMetadata.getTokenType(metadata)
+      }
+      else if (includeExplanation) {
         const themeSettingsSelectors: ThemeSettingsSelectors[] = []
 
-        if (options.includeExplanation !== 'scopeName') {
+        if (includeExplanation !== 'scopeName') {
           for (const setting of theme.settings) {
             let selectors: string[]
             switch (typeof setting.scope) {
@@ -249,7 +250,7 @@ function _tokenizeWithTheme(
           offset += tokenWithScopesText.length
           token.explanation.push({
             content: tokenWithScopesText,
-            scopes: options.includeExplanation === 'scopeName'
+            scopes: includeExplanation === 'scopeName'
               ? explainThemeScopesNameOnly(
                   tokenWithScopes.scopes,
                 )

--- a/packages/primitive/src/highlight/code-to-tokens-base.ts
+++ b/packages/primitive/src/highlight/code-to-tokens-base.ts
@@ -39,7 +39,7 @@ export function codeToTokensBase(
   const lang = primitive.resolveLangAlias(options.lang || 'text')
 
   if (isPlainLang(lang) || isNoneTheme(themeName))
-    return splitLines(code).map(line => [{ content: line[0], offset: line[1] }])
+    return splitLines(code).map(line => [{ type: 0, content: line[0], offset: line[1] }])
 
   const { theme, colorMap } = primitive.setTheme(themeName)
 
@@ -169,6 +169,7 @@ function _tokenizeWithTheme(
     if (tokenizeMaxLineLength > 0 && line.length >= tokenizeMaxLineLength) {
       actual = []
       final.push([{
+        type: 0,
         content: line,
         offset: lineOffset,
         color: '',
@@ -202,8 +203,10 @@ function _tokenizeWithTheme(
         colorReplacements,
       )
       const fontStyle: FontStyle = EncodedTokenMetadata.getFontStyle(metadata)
+      const type: number = EncodedTokenMetadata.getTokenType(metadata)
 
       const token: ThemedToken = {
+        type,
         content: line.substring(startIndex, nextStartIndex),
         offset: lineOffset + startIndex,
         color,

--- a/packages/types/src/tokens.ts
+++ b/packages/types/src/tokens.ts
@@ -116,6 +116,14 @@ export interface ThemedToken extends TokenStyles, TokenBase {}
 
 export interface TokenBase {
   /**
+   * The type of the token
+   * 0 - other
+   * 1 - comment
+   * 2 - string
+   * 3 - regex
+   */
+  type: number
+  /**
    * The content of the token
    */
   content: string

--- a/packages/types/src/tokens.ts
+++ b/packages/types/src/tokens.ts
@@ -116,14 +116,6 @@ export interface ThemedToken extends TokenStyles, TokenBase {}
 
 export interface TokenBase {
   /**
-   * The type of the token
-   * 0 - other
-   * 1 - comment
-   * 2 - string
-   * 3 - regex
-   */
-  type: number
-  /**
    * The content of the token
    */
   content: string
@@ -131,6 +123,14 @@ export interface TokenBase {
    * The start offset of the token, relative to the input code. 0-indexed.
    */
   offset: number
+  /**
+   * The type of the token
+   * 0 - other
+   * 1 - comment
+   * 2 - string
+   * 3 - regex
+   */
+  type?: number
   /**
    * Explanation of
    *
@@ -181,7 +181,7 @@ export interface TokenizeWithThemeOptions {
    *
    * @default false
    */
-  includeExplanation?: boolean | 'scopeName'
+  includeExplanation?: boolean | 'scopeName' | 'tokenType'
 
   /**
    * A map of color names to new color values.


### PR DESCRIPTION
`includeExplanation` now accepts `'tokenType'`, that returns tokens with a `type` property. it's fast by using the `EncodedTokenMetadata.getTokenType` method (just some bit computes)

```diff
export interface TokenBase {
  /**
   * The content of the token
   */
  content: string
  /**
   * The start offset of the token, relative to the input code. 0-indexed.
   */
  offset: number
  /**
   * The type of the token
   * 0 - other
   * 1 - comment
   * 2 - string
   * 3 - regex
   */
+  type?: number
  /**
   * Explanation of
   *
   * - token text's matching scopes
   * - reason that token text is given a color (one matching scope matches a rule (scope -> color) in the theme)
   */
  explanation?: ThemedTokenExplanation[]
}
```