### PR TITLE
fix(transformers): keep notations on content comment lines

### DIFF
--- a/packages/transformers/src/shared/notation-transformer.ts
+++ b/packages/transformers/src/shared/notation-transformer.ts
@@ -51,7 +51,11 @@ export function createCommentNotationTransformer(
           continue
 
         let lineIdx = lines.indexOf(comment.line)
-        const isStandaloneNotation = comment.info[1].replace(RE_NOTATION, '').trim().length === 0
+        const isStandaloneNotation = comment.info[1]
+          .replace(RE_NOTATION, '')
+          .replace(regex, '')
+          .trim()
+          .length === 0
         if (comment.isLineCommentOnly && isStandaloneNotation && matchAlgorithm !== 'v1')
           lineIdx++
 

--- a/packages/transformers/src/shared/notation-transformer.ts
+++ b/packages/transformers/src/shared/notation-transformer.ts
@@ -3,6 +3,8 @@ import type { Element, Text } from 'hast'
 import type { ParsedComments } from './parse-comments'
 import { parseComments, v1ClearEndCommentPrefix, v3ClearEndCommentPrefix } from './parse-comments'
 
+const RE_NOTATION = /#?\s*\[!code\b(?:\\.|[^\]])*\]/gi
+
 export type MatchAlgorithm = 'v1' | 'v3'
 
 export interface MatchAlgorithmOptions {
@@ -49,7 +51,8 @@ export function createCommentNotationTransformer(
           continue
 
         let lineIdx = lines.indexOf(comment.line)
-        if (comment.isLineCommentOnly && matchAlgorithm !== 'v1')
+        const isStandaloneNotation = comment.info[1].replace(RE_NOTATION, '').trim().length === 0
+        if (comment.isLineCommentOnly && isStandaloneNotation && matchAlgorithm !== 'v1')
           lineIdx++
 
         let replaced = false

--- a/packages/transformers/test/notation-comment-line.test.ts
+++ b/packages/transformers/test/notation-comment-line.test.ts
@@ -1,0 +1,41 @@
+import { codeToHtml } from 'shiki'
+import { describe, expect, it } from 'vitest'
+import { transformerNotationDiff, transformerNotationFocus } from '../src'
+
+function getLineClasses(html: string): string[] {
+  return [...html.matchAll(/<span class="line([^"]*)">/g)]
+    .map(match => match[1].trim())
+}
+
+describe('comment-only line notations', () => {
+  it('applies notations to a comment line that has visible content', async () => {
+    const html = await codeToHtml(`# foo # [!code ++] [!code focus]\nbar`, {
+      lang: 'yaml',
+      theme: 'github-dark',
+      transformers: [transformerNotationDiff(), transformerNotationFocus()],
+    })
+
+    const lineClasses = getLineClasses(html)
+    expect(lineClasses[0]).toContain('diff add')
+    expect(lineClasses[0]).toContain('focused')
+    expect(lineClasses[1]).not.toContain('diff add')
+    expect(lineClasses[1]).not.toContain('focused')
+    expect(html).toContain('# foo')
+    expect(html).not.toContain('[!code')
+  })
+
+  it('still applies a standalone notation comment to the next line', async () => {
+    const html = await codeToHtml(`# [!code ++] [!code focus]\nbar`, {
+      lang: 'yaml',
+      theme: 'github-dark',
+      transformers: [transformerNotationDiff(), transformerNotationFocus()],
+    })
+
+    const lineClasses = getLineClasses(html)
+    expect(lineClasses).toHaveLength(1)
+    expect(lineClasses[0]).toContain('diff add')
+    expect(lineClasses[0]).toContain('focused')
+    expect(html).toContain('bar')
+    expect(html).not.toContain('[!code')
+  })
+})

--- a/packages/transformers/test/notation-comment-line.test.ts
+++ b/packages/transformers/test/notation-comment-line.test.ts
@@ -1,6 +1,6 @@
 import { codeToHtml } from 'shiki'
 import { describe, expect, it } from 'vitest'
-import { transformerNotationDiff, transformerNotationFocus } from '../src'
+import { createCommentNotationTransformer, transformerNotationDiff, transformerNotationFocus } from '../src'
 
 function getLineClasses(html: string): string[] {
   return [...html.matchAll(/<span class="line([^"]*)">/g)]
@@ -37,5 +37,29 @@ describe('comment-only line notations', () => {
     expect(lineClasses[0]).toContain('focused')
     expect(html).toContain('bar')
     expect(html).not.toContain('[!code')
+  })
+
+  it('supports standalone markers with a custom notation syntax', async () => {
+    const customTransformer = createCommentNotationTransformer(
+      'custom-focus',
+      /\s*@focus/,
+      function (_match, _line, _comment, lines, index) {
+        this.addClassToHast(lines[index], 'focused')
+        return true
+      },
+      'v3',
+    )
+
+    const html = await codeToHtml(`# @focus\nbar`, {
+      lang: 'yaml',
+      theme: 'github-dark',
+      transformers: [customTransformer],
+    })
+
+    const lineClasses = getLineClasses(html)
+    expect(lineClasses).toHaveLength(1)
+    expect(lineClasses[0]).toContain('focused')
+    expect(html).toContain('bar')
+    expect(html).not.toContain('@focus')
   })
 })


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackts.

### Description

Comment-only lines were always treated as standalone notation lines, so a line such as `# foo # [!code ++]` applied its class to the following line instead of the visible comment.

This change distinguishes a standalone notation comment from a comment that still has visible content after all notation markers are removed. Contentful comment lines now keep the notation themselves, while standalone notation comments continue to target the next line.

Regression coverage checks both behaviors with combined diff and focus markers.

### Linked Issues

fixes #1305

### Additional context

Validated with:

- `pnpm exec vitest run packages/transformers/test` (11 files, 63 tests)
- `pnpm exec eslint --no-cache packages/transformers/src/shared/notation-transformer.ts packages/transformers/test/notation-comment-line.test.ts`
- `pnpm --filter @shikijs/transformers build`
