### PR TITLE
fix(stream): compile Solid renderer with babel-preset-solid

### DIFF
--- a/packages/stream/build.config.ts
+++ b/packages/stream/build.config.ts
@@ -1,4 +1,6 @@
+import type { Plugin } from 'rollup'
 import fs from 'node:fs/promises'
+import babel from '@rollup/plugin-babel'
 import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
@@ -21,8 +23,23 @@ export default defineBuildConfig({
     inlineDependencies: [
       '@antfu/utils',
     ],
+    // Leave the Solid entry to babel-preset-solid. unbuild's esbuild uses the
+    // classic React JSX runtime, which ignores `/* @jsxImportSource solid-js */`.
+    esbuild: {
+      exclude: [/node_modules/, /src\/solid\//],
+    },
   },
   hooks: {
+    'rollup:options': (_config, options) => {
+      options.plugins ||= []
+      const plugins = options.plugins as Plugin[]
+      plugins.unshift(babel({
+        babelHelpers: 'bundled',
+        include: ['src/solid/**'],
+        presets: ['@babel/preset-typescript', 'solid'],
+        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+      }))
+    },
     'mkdist:done': async () => {
       await fs.writeFile('dist/svelte.mjs', 'export * from "./svelte/index.mjs"\n', 'utf-8')
       await fs.writeFile('dist/svelte.d.ts', 'export * from "./svelte/index.mjs"\n', 'utf-8')

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -87,8 +87,11 @@
   },
   "devDependencies": {
     "@antfu/utils": "catalog:inlined",
+    "@babel/preset-typescript": "catalog:bundling",
+    "@rollup/plugin-babel": "catalog:bundling",
     "@sveltejs/vite-plugin-svelte": "catalog:bundling",
     "@types/react": "catalog:types",
+    "babel-preset-solid": "catalog:bundling",
     "happy-dom": "catalog:testing",
     "react": "catalog:integrations",
     "solid-js": "catalog:integrations",

--- a/packages/stream/test/solid-dist.test.ts
+++ b/packages/stream/test/solid-dist.test.ts
@@ -1,0 +1,16 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const distFile = join(import.meta.dirname, '../dist/solid.mjs')
+
+describe('published solid stream renderer', () => {
+  it('does not compile JSX as React.createElement', async () => {
+    const code = await readFile(distFile, 'utf8')
+    expect(code).not.toContain('React.createElement')
+    expect(code).not.toMatch(/\bReact\./)
+    expect(code).not.toMatch(/from\s+['"]react['"]/)
+    // Solid's compiler emits template helpers from solid-js/web, not a React JSX runtime.
+    expect(code).toMatch(/from\s+['"]solid-js\/web['"]/)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1010,12 +1010,21 @@ importers:
       '@antfu/utils':
         specifier: catalog:inlined
         version: 9.3.0
+      '@babel/preset-typescript':
+        specifier: catalog:bundling
+        version: 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@rollup/plugin-babel':
+        specifier: catalog:bundling
+        version: 7.1.0(@babel/core@7.29.7(supports-color@10.2.2))(@types/babel__core@7.20.5)(rollup@4.62.4)(supports-color@10.2.2)
       '@sveltejs/vite-plugin-svelte':
         specifier: catalog:bundling
         version: 7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.11)(yaml@2.9.0))
       '@types/react':
         specifier: catalog:types
         version: 19.2.18
+      babel-preset-solid:
+        specifier: catalog:bundling
+        version: 1.9.12(@babel/core@7.29.7(supports-color@10.2.2))(solid-js@1.9.14)
       happy-dom:
         specifier: catalog:testing
         version: 20.11.2


### PR DESCRIPTION
Compile the Solid stream entry with babel-preset-solid so dist/solid.mjs does not emit React.createElement. Fixes #1285.