### PR TITLE
perf(engine-js): reuse each regex's last search while tokenizing a line

### DIFF
--- a/docs/references/engine-js-compat.md
+++ b/docs/references/engine-js-compat.md
@@ -2,9 +2,9 @@
 
 Compatibility reference of all built-in grammars with the [JavaScript RegExp engine](/guide/regex-engines#javascript-regexp-engine).
 
-> Generated on Friday, July 31, 2026
+> Generated on Friday, September 11, 2026
 >
-> Version `4.3.1`
+> Version `4.4.3`
 >
 > Runtime: Node.js v24.16.0
 
@@ -239,7 +239,7 @@ In some edge cases, it's not guaranteed that the highlighting will be 100% the s
 | twig               | ✅ OK           |              2445 |               - |      |
 | typescript         | ✅ OK           |               362 |               - |      |
 | typespec           | ✅ OK           |                73 |               - |      |
-| typst              | ✅ OK           |                78 |               - |      |
+| typst              | ✅ OK           |              5699 |               - |      |
 | v                  | ✅ OK           |                77 |               - |      |
 | vala               | ✅ OK           |                20 |               - |      |
 | vb                 | ✅ OK           |                34 |               - |      |

--- a/packages/engine-javascript/src/engine-compile.ts
+++ b/packages/engine-javascript/src/engine-compile.ts
@@ -3,6 +3,7 @@ import type { ToRegExpOptions } from 'oniguruma-to-es'
 import type { JavaScriptRegexScannerOptions } from './scanner'
 import { toRegExp } from 'oniguruma-to-es'
 import { JavaScriptScanner } from './scanner'
+import { createJavaScriptEngineString } from './string'
 
 export interface JavaScriptRegexEngineOptions extends JavaScriptRegexScannerOptions {
   /**
@@ -73,10 +74,6 @@ export function createJavaScriptRegexEngine(options: JavaScriptRegexEngineOption
     createScanner(patterns) {
       return new JavaScriptScanner(patterns, _options)
     },
-    createString(s: string) {
-      return {
-        content: s,
-      }
-    },
+    createString: createJavaScriptEngineString,
   }
 }

--- a/packages/engine-javascript/src/engine-raw.ts
+++ b/packages/engine-javascript/src/engine-raw.ts
@@ -1,6 +1,7 @@
 import type { RegexEngine } from '@shikijs/types'
 import type { JavaScriptRegexScannerOptions } from './scanner'
 import { JavaScriptScanner } from './scanner'
+import { createJavaScriptEngineString } from './string'
 
 /**
  * Raw JavaScript regex engine that only supports precompiled grammars.
@@ -21,10 +22,6 @@ export function createJavaScriptRawEngine(): RegexEngine {
     createScanner(patterns) {
       return new JavaScriptScanner(patterns, options)
     },
-    createString(s: string) {
-      return {
-        content: s,
-      }
-    },
+    createString: createJavaScriptEngineString,
   }
 }

--- a/packages/engine-javascript/src/scanner.ts
+++ b/packages/engine-javascript/src/scanner.ts
@@ -3,6 +3,7 @@ import type {
   RegexEngineString,
 } from '@shikijs/types'
 import type { IOnigMatch } from '@shikijs/vscode-textmate'
+import type { JavaScriptEngineString } from './string'
 
 const MAX = 4294967295
 
@@ -27,8 +28,47 @@ export interface JavaScriptRegexScannerOptions {
   regexConstructor?: (pattern: string) => RegExp
 }
 
+interface LastSearch {
+  strId: number
+  searchedFrom: number
+  matchIndex: number // -1 for no match
+  indices: RegExpIndicesArray | null
+}
+
+// Sticky regexps and `EmulatedRegExp`s with a search strategy (how `oniguruma-to-es` emulates `\G`)
+// depend on the exact start position, so their searches can't be reused
+function isSearchCacheable(regexp: RegExp): boolean {
+  return !regexp.sticky && !(regexp as { rawOptions?: { strategy?: string | null } }).rawOptions?.strategy
+}
+
+function toResult(index: number, indices: RegExpIndicesArray): IOnigMatch {
+  return {
+    index,
+    captureIndices: indices.map((indice) => {
+      if (indice == null) {
+        return {
+          start: MAX,
+          end: MAX,
+          length: 0,
+        }
+      }
+      return {
+        start: indice[0],
+        end: indice[1],
+        length: indice[1] - indice[0],
+      }
+    }),
+  }
+}
+
 export class JavaScriptScanner implements PatternScanner {
   regexps: (RegExp | null)[]
+
+  /**
+   * Last search of each regexp on the current string, reused the way `vscode-oniguruma` does.
+   * `null` for regexps whose searches can't be reused.
+   */
+  private lastSearches: (LastSearch | null)[]
 
   constructor(
     public patterns: (string | RegExp)[],
@@ -71,51 +111,66 @@ export class JavaScriptScanner implements PatternScanner {
         throw e
       }
     })
+
+    this.lastSearches = this.regexps.map(regexp => regexp && isSearchCacheable(regexp)
+      ? { strId: 0, searchedFrom: 0, matchIndex: -1, indices: null }
+      : null,
+    )
   }
 
   findNextMatchSync(string: string | RegexEngineString, startPosition: number, _options: number): IOnigMatch | null {
     const str = typeof string === 'string'
       ? string
       : string.content
-    const pending: [index: number, match: RegExpExecArray, offset: number][] = []
+    // No id (plain string or a string from another engine): never reuse
+    const strId = typeof string === 'string'
+      ? 0
+      : (string as Partial<JavaScriptEngineString>).id || 0
 
-    function toResult(index: number, match: RegExpExecArray, offset = 0): IOnigMatch {
-      return {
-        index,
-        captureIndices: match.indices!.map((indice) => {
-          if (indice == null) {
-            return {
-              start: MAX,
-              end: MAX,
-              length: 0,
-            }
-          }
-          return {
-            start: indice[0] + offset,
-            end: indice[1] + offset,
-            length: indice[1] - indice[0],
-          }
-        }),
-      }
-    }
+    let bestIndex = -1
+    let bestMatchIndex = 0
+    let bestIndices: RegExpIndicesArray | null = null
 
     for (let i = 0; i < this.regexps.length; i++) {
       const regexp = this.regexps[i]
       if (!regexp)
         continue
       try {
-        regexp.lastIndex = startPosition
-        const match = regexp.exec(str)
+        const last = strId ? this.lastSearches[i] : null
+        let matchIndex: number
+        let indices: RegExpIndicesArray | null
 
-        if (!match)
+        // Still valid if it found nothing, or a match at or after the start position
+        if (last && last.strId === strId && last.searchedFrom <= startPosition && (last.matchIndex === -1 || last.matchIndex >= startPosition)) {
+          matchIndex = last.matchIndex
+          indices = last.indices
+        }
+        else {
+          regexp.lastIndex = startPosition
+          const match = regexp.exec(str)
+          matchIndex = match ? match.index : -1
+          indices = match ? match.indices! : null
+          if (last) {
+            last.strId = strId
+            last.searchedFrom = startPosition
+            last.matchIndex = matchIndex
+            last.indices = indices
+          }
+        }
+
+        if (matchIndex === -1)
           continue
 
         // If the match is at the start position, return it immediately
-        if (match.index === startPosition) {
-          return toResult(i, match, 0)
+        if (matchIndex === startPosition) {
+          return toResult(i, indices!)
         }
-        // Otherwise, store it for later
-        pending.push([i, match, 0])
+        // Otherwise, keep the closest one
+        if (bestIndex === -1 || matchIndex < bestMatchIndex) {
+          bestIndex = i
+          bestMatchIndex = matchIndex
+          bestIndices = indices
+        }
       }
       catch (e) {
         if (this.options.forgiving)
@@ -124,16 +179,8 @@ export class JavaScriptScanner implements PatternScanner {
       }
     }
 
-    // Find the closest match to the start position
-    if (pending.length) {
-      const minIndex = Math.min(...pending.map(m => m[1].index))
-      for (const [i, match, offset] of pending) {
-        if (match.index === minIndex) {
-          return toResult(i, match, offset)
-        }
-      }
-    }
-
-    return null
+    return bestIndex === -1
+      ? null
+      : toResult(bestIndex, bestIndices!)
   }
 }

--- a/packages/engine-javascript/src/string.ts
+++ b/packages/engine-javascript/src/string.ts
@@ -1,0 +1,17 @@
+import type { RegexEngineString } from '@shikijs/types'
+
+/**
+ * String with an `id`, so scanners can reuse searches on it (like `OnigString`).
+ */
+export interface JavaScriptEngineString extends RegexEngineString {
+  readonly id: number
+}
+
+let lastStringId = 0
+
+export function createJavaScriptEngineString(content: string): JavaScriptEngineString {
+  return {
+    content,
+    id: ++lastStringId,
+  }
+}

--- a/packages/engine-javascript/test/search-cache.test.ts
+++ b/packages/engine-javascript/test/search-cache.test.ts
@@ -1,0 +1,205 @@
+import type { LanguageRegistration, RegexEngine, RegexEngineString, ShikiPrimitive, ThemedToken } from '@shikijs/types'
+import { codeToTokensBase, createShikiPrimitive } from '@shikijs/primitive'
+import { describe, expect, it, vi } from 'vitest'
+import { createJavaScriptRegexEngine, JavaScriptScanner } from '../src'
+
+// Same regexps, but strings without an id, so searches are never reused
+function createUncachedEngine(options?: Parameters<typeof createJavaScriptRegexEngine>[0]): RegexEngine {
+  return {
+    ...createJavaScriptRegexEngine(options),
+    createString: (s: string) => ({ content: s }),
+  }
+}
+
+function countExecCalls(run: () => void): number {
+  const exec = vi.spyOn(RegExp.prototype, 'exec')
+  try {
+    run()
+    return exec.mock.calls.length
+  }
+  finally {
+    exec.mockRestore()
+  }
+}
+
+function fill(length: number, piece: (i: number) => string): string {
+  let s = ''
+  for (let i = 0; s.length < length; i++)
+    s += piece(i)
+  return s.slice(0, length)
+}
+
+// Long lines that are slow without reuse, plus snippets heavy in `\G` anchors and `while` rules
+const LINE_LENGTH = 300
+const lines: Record<string, string> = {
+  punctuation: fill(LINE_LENGTH, () => ';'),
+  dottedChain: fill(LINE_LENGTH, () => 'a.'),
+  generics: fill(LINE_LENGTH, () => 'a<'),
+  closeParens: fill(LINE_LENGTH, () => ')'),
+  spaces: fill(LINE_LENGTH, () => ' '),
+  escapedStars: fill(LINE_LENGTH, () => '\\*'),
+  yamlAliases: fill(LINE_LENGTH, () => '*a '),
+  argumentList: `const result = compute(${fill(LINE_LENGTH, i => `arg${i}, `)}`,
+  objectLiteral: `const cfg = { ${fill(LINE_LENGTH, i => i % 2 ? `key${i}: "value${i}", ` : `key${i}: ${i * 3}, `)}`,
+  minified: fill(LINE_LENGTH, () => 'function a(b,c){return b&&c||d?e:f}var g=h(1,2),i=[j,k];if(l){m.n(o)}else{p=q+"r"}'),
+  json: `[${fill(LINE_LENGTH, i => `{"id":${i},"name":"item${i}","tags":["a","b"],"nested":{"x":1.5,"y":null,"ok":true}},`)}`,
+  markdownInline: fill(LINE_LENGTH, i => `The **config${i}** option uses \`value_${i}\` and links to [the docs](https://example.com/${i}), see _notes_. `),
+  logLine: fill(LINE_LENGTH, i => `2026-09-04T12:34:${10 + (i % 50)}.789Z INFO [worker-${i}] request id=abc${i} status=200 path=/api/v1/items/${i} `),
+  jsx: `<div className="row">${fill(LINE_LENGTH, i => `<span key={${i}} className="cell" onClick={() => select(${i})}>{label${i}}</span>`)}`,
+  shell: `docker run --rm ${fill(LINE_LENGTH, i => `-e VAR_${i}=value${i} -v /host/${i}:/container/${i} `)}`,
+  pythonCall: `result = build(${fill(LINE_LENGTH, i => (i % 3 === 0 ? `p_${i}="s${i}", ` : i % 3 === 1 ? `p_${i}=True, ` : `p_${i}=${i}.5, `))}`,
+  html: fill(LINE_LENGTH, i => `<div class="item item-${i}" data-id="${i}"><a href="/p/${i}">Item ${i}</a></div>`),
+}
+
+const snippets: Record<string, string[]> = {
+  markdown: [
+    '> > - a *b* `c`\n>   1. b\n> > > deep\n  - > quoted in list\n    > - list in quote in list\n1. x\n   2. y\n      > z **w**\n\n> # heading in quote\n> ---\n> ```ts\n> const a = 1;\n> ```\n- [ ] task\n- * nested star\n  * deeper\n    + > quote\n',
+    '>>#',
+    '>>***',
+  ],
+  shellscript: [
+    'cat <<EOF\nline $VAR $(cmd) $X\nEOF\ncat <<-"X"\n\traw $no\n\tX\nX\necho done | grep -E "a|b" > /dev/null 2>&1 && f() { local x="$1"; }\ncase "$1" in\n  a|b) echo ab ;;\n  *) [[ $x =~ ^[0-9]+$ ]] && echo n ;;\nesac\n',
+  ],
+  typescript: [
+    `const re = /a(b)[c-d]*\\/(?<n>x)/giu; const s = \`a \${b + \`c\`} d\`;
+type T<K extends keyof U = "a" | "b"> = { [P in K]?: U[P] extends (infer R)[] ? R : never };
+@dec class A<T> extends B implements C { #p = 1; static async *g() { yield* h(); } }
+`,
+  ],
+  tsx: [
+    'export function Row({ items }: { items: Item[] }) {\n  const [open, setOpen] = useState<boolean>(false);\n  return (<ul className={cx("row", { open })}>{items.map((it) => <li key={it.id} onClick={() => setOpen(!open)}>{it.label ?? "-"}</li>)}</ul>);\n}\n',
+  ],
+  python: [
+    '@dataclass\nclass P:\n    x: int = 0\n    def f(self, *a, **k) -> "P":\n        match a:\n            case [1, *rest]: return P(x=len(rest))\n        s = f"{self.x!r:>8} {k.get("y", 0):.2f}"\n        """doc\n        string"""\n        return self  # c\n',
+  ],
+  yaml: [
+    '%YAML 1.2\n---\na: &a { b: [1, 2], c: *a }\n? complex\n: key\nd: |\n  block\n  scalar\ne: >-\n  folded\n- ! &e tag\n~\n! &a x\n',
+    ' ! &e',
+    '~\n! &a',
+  ],
+  html: [
+    `<!DOCTYPE html>
+<html lang="en">
+<head><style>a > b { color: red; }</style></head>
+<body onload="init()">
+<script type="module">import { x } from "./x.js"; x\`<p>\${1}</p>\`</script>
+</body>
+</html>
+`,
+  ],
+  vue: [
+    '<script setup lang="ts">\nimport { ref } from "vue"\nconst n = ref<number>(0)\n</script>\n\n<template>\n  <button :class="{ on: n > 0 }" @click="n++">{{ n }}</button>\n</template>\n\n<style scoped>\nbutton { color: v-bind(color); }\n</style>\n',
+  ],
+}
+
+const langs: Record<string, () => Promise<{ default: LanguageRegistration[] }>> = {
+  typescript: () => import('@shikijs/langs/typescript'),
+  tsx: () => import('@shikijs/langs/tsx'),
+  markdown: () => import('@shikijs/langs/markdown'),
+  yaml: () => import('@shikijs/langs/yaml'),
+  python: () => import('@shikijs/langs/python'),
+  shellscript: () => import('@shikijs/langs/shellscript'),
+  html: () => import('@shikijs/langs/html'),
+  vue: () => import('@shikijs/langs/vue'),
+}
+
+describe('search cache', async () => {
+  const theme = await import('@shikijs/themes/vitesse-dark').then(m => m.default)
+  const grammars = (await Promise.all(Object.values(langs).map(load => load().then(m => m.default)))).flat()
+
+  function highlighter(engine: RegexEngine): ShikiPrimitive {
+    return createShikiPrimitive({ engine, langs: grammars, themes: [theme], warnings: false })
+  }
+
+  // Shared pattern cache, so both use the same RegExp objects
+  const cache = new Map<string, RegExp | Error>()
+  const cached = highlighter(createJavaScriptRegexEngine({ cache }))
+  const uncached = highlighter(createUncachedEngine({ cache }))
+
+  function tokenize(shiki: ShikiPrimitive, code: string, lang: string, includeExplanation = true): ThemedToken[][] {
+    return codeToTokensBase(shiki, code, { lang, theme: theme.name!, includeExplanation, tokenizeTimeLimit: 0 })
+  }
+
+  it.each(Object.keys(langs))('gives the same tokens as searching every time (%s)', (lang) => {
+    for (const [name, code] of [...Object.entries(lines), ...(snippets[lang] ?? []).map((s, i) => [`snippet ${i}`, s])]) {
+      const actual = tokenize(cached, code, lang)
+      const expected = tokenize(uncached, code, lang)
+      if (JSON.stringify(actual) !== JSON.stringify(expected))
+        expect(actual, name).toEqual(expected)
+    }
+  })
+
+  it('searches a long line far fewer times', () => {
+    const line = fill(1000, i => `item${i}, `)
+    const run = (shiki: ShikiPrimitive) => () => tokenize(shiki, line, 'typescript', false)
+    // Warm up so regex compilation isn't counted
+    run(cached)()
+    run(uncached)()
+
+    expect(countExecCalls(run(cached))).toBeLessThan(countExecCalls(run(uncached)) / 10)
+  })
+})
+
+describe('scanner search reuse', () => {
+  const engine = createJavaScriptRegexEngine()
+
+  function createScanner(regexps: RegExp[]) {
+    const scanner = new JavaScriptScanner(regexps, {
+      regexConstructor: () => {
+        throw new Error('unused')
+      },
+    })
+    const execs = regexps.map(re => vi.spyOn(re, 'exec'))
+    return { scanner, execs: () => execs.map(e => e.mock.calls.length) }
+  }
+
+  it('reuses a search until the position passes its match', () => {
+    const { scanner, execs } = createScanner([/b/dg, /x/dg])
+    const str = engine.createString('aaab aaab')
+
+    expect(scanner.findNextMatchSync(str, 0, 0)).toMatchObject({ index: 0, captureIndices: [{ start: 3, end: 4, length: 1 }] })
+    expect(scanner.findNextMatchSync(str, 2, 0)).toMatchObject({ index: 0, captureIndices: [{ start: 3 }] })
+    expect(scanner.findNextMatchSync(str, 3, 0)).toMatchObject({ index: 0, captureIndices: [{ start: 3 }] })
+    expect(execs()).toEqual([1, 1])
+
+    expect(scanner.findNextMatchSync(str, 4, 0)).toMatchObject({ index: 0, captureIndices: [{ start: 8 }] })
+    expect(execs()).toEqual([2, 1])
+
+    expect(scanner.findNextMatchSync(str, 9, 0)).toBe(null)
+    expect(execs()).toEqual([3, 1])
+  })
+
+  it('does not reuse a search from a later position, on another string, or on a plain string', () => {
+    const { scanner, execs } = createScanner([/b/dg])
+    const str = engine.createString('ab ab')
+
+    scanner.findNextMatchSync(str, 3, 0)
+    expect(scanner.findNextMatchSync(str, 0, 0)).toMatchObject({ captureIndices: [{ start: 1 }] })
+    expect(execs()).toEqual([2])
+
+    expect(scanner.findNextMatchSync(engine.createString('ab ab'), 0, 0)).toMatchObject({ captureIndices: [{ start: 1 }] })
+    expect(execs()).toEqual([3])
+
+    scanner.findNextMatchSync('ab ab', 0, 0)
+    scanner.findNextMatchSync('ab ab', 0, 0)
+    scanner.findNextMatchSync({ content: 'ab ab' } as RegexEngineString, 0, 0)
+    expect(execs()).toEqual([6])
+  })
+
+  it('always searches sticky regexps and regexps with a search strategy', () => {
+    const withStrategy = Object.assign(/(?<=a)b/dg, { rawOptions: { strategy: 'clip_search' } })
+    const { scanner, execs } = createScanner([/x/dgy, withStrategy, /c/dg])
+    const str = engine.createString('abcab')
+    expect(scanner.findNextMatchSync(str, 0, 0)).toMatchObject({ index: 1, captureIndices: [{ start: 1 }] })
+    expect(scanner.findNextMatchSync(str, 1, 0)).toMatchObject({ index: 1, captureIndices: [{ start: 1 }] })
+    expect(scanner.findNextMatchSync(str, 2, 0)).toMatchObject({ index: 2, captureIndices: [{ start: 2 }] })
+    expect(execs()).toEqual([3, 3, 1])
+  })
+
+  it('prefers the earliest match, then the earliest pattern', () => {
+    const { scanner } = createScanner([/c/dg, /b/dg, /[bc]/dg])
+    const str = engine.createString('abc')
+    expect(scanner.findNextMatchSync(str, 0, 0)).toMatchObject({ index: 1 })
+    expect(scanner.findNextMatchSync(str, 2, 0)).toMatchObject({ index: 0 })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,6 +588,8 @@ importers:
         specifier: catalog:cli
         version: 4.120.0
 
+  bench/bundle-test: {}
+
   docs:
     devDependencies:
       '@braintree/sanitize-url':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ packages:
   - playground
   - examples/*
   - docs
+  - bench/*
 
 overrides:
   rollup: ^4.62.4


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackts.

### Description

Highlighting a long line takes quadratic time. This PR copies the pattern of reusing each regex's last search on a line (used in `vscode-oniguruma`) to the JS engine. The change written with AI assistance.


Local benchmarks (single lines of 960 characters), best of 3.
| input | before (ms) | after (ms) | speedup |
| --- | ---: | ---: | ---: |
| TS argument list | 38.8 | 1.0 | 39× |
| TS `a.a.a.…` chain | 658.2 | 8.7 | 76× |
| minified JS | 39.3 | 2.6 | 15× |
| Markdown `\*` repeated | 412.8 | 2.8 | 147× |
| `packages/core/src/highlight/code-to-hast.ts` | 23.1 | 15.5 | 1.5× |


### Linked Issues

None

### Additional context

`isSearchCacheable`: `\G` is not safe to cache so its skipped. A custom `regexConstructor` that depends on the start position in some other way must set the sticky flag so it is also skipped.
